### PR TITLE
Added XmlWriter and Element::create API

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,7 @@
-use super::{XmlReader, Element};
+use super::{Element, XmlReader, XmlWriter};
 use super::Event::*;
 use std::str::from_utf8;
+use std::io::Cursor;
 
 macro_rules! next_eq {
     ($r: expr, $($t:path, $bytes:expr),*) => {
@@ -125,3 +126,15 @@ fn test_nested() {
             );
 }
 
+#[test]
+fn test_writer() {
+    let str = r#"<?xml version="1.0" encoding="utf-8"?><manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.github.sample" android:versionName="Lollipop" android:versionCode="5.1"><application android:label="SampleApplication"></application></manifest>"#;
+    let reader = XmlReader::from_str(&str).trim_text(true);
+    let mut writer = XmlWriter::new(Cursor::new(Vec::new()));
+    for event in reader {
+        assert!(writer.write(event.unwrap()).is_ok());
+    }
+
+	let result = writer.into_inner().into_inner();
+    assert_eq!(result, str.as_bytes());
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -13,11 +13,11 @@ macro_rules! next_eq {
                 },
                 Some(Ok(e)) => {
                     assert!(false, "expecting {:?}, found {:?}", 
-                            $t(Element::new($bytes.to_vec(), 0, $bytes.len(), $bytes.len())), e);
+                            $t(Element::from_buffer($bytes.to_vec(), 0, $bytes.len(), $bytes.len())), e);
                 },
                 p => {
                     assert!(false, "expecting {:?}, found {:?}", 
-                            $t(Element::new($bytes.to_vec(), 0, $bytes.len(), $bytes.len())), p);
+                            $t(Element::from_buffer($bytes.to_vec(), 0, $bytes.len(), $bytes.len())), p);
                 }
             }
         )*
@@ -135,7 +135,7 @@ fn test_writer() {
         assert!(writer.write(event.unwrap()).is_ok());
     }
 
-	let result = writer.into_inner().into_inner();
+    let result = writer.into_inner().into_inner();
     assert_eq!(result, str.as_bytes());
 }
 
@@ -154,7 +154,7 @@ fn test_write_attrs() {
                     (from_utf8(k).unwrap(), v)
                 }).collect::<Vec<_>>();
                 attrs.push(("another", "one"));
-                let elem = Element::create("elem", attrs.into_iter());
+                let elem = Element::new("elem", attrs.into_iter());
                 Start(elem)
             },
             _ => event
@@ -162,6 +162,6 @@ fn test_write_attrs() {
         assert!(writer.write(event).is_ok());
     }
 
-	let result = writer.into_inner().into_inner();
+    let result = writer.into_inner().into_inner();
     assert_eq!(result, expected.as_bytes());
 }


### PR DESCRIPTION
This PR adds the possibility to transform (add/change elements) and write XML. Two changes:

  1. add a XmlWriter structure, which just wraps a Write at the moment but could (should?) be extended in the future to support pretty-printing or automatic shortening of empty tags.
  2. add a "create" method to Element, to create an element with a name/content, and possibly attributes (should only be used for start elements, but at the moment this is not enforced). For elements with no attributes, use the iter::empty() function.

I added one test for the writer, and one test for the writer + element create. Also, note that I made the XmlWriter use a Write trait rather than BufWrite because it doesn't need its additional methods at the moment, but of course for best performance one should use a writer implementing BufWrite.