### PR TITLE
improve Element API with new, push_attribute, extend_from_attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.project


### PR DESCRIPTION
Implemented #3, now using IntoIterator so we don't need to call .into_iter() on collections, and permitted chained calls (the two additional methods return &mut Element)