### PR TITLE
Basic bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,18 @@ keywords = ["xml", "reader", "parser", "write"]
 license = "MIT"
 
 [dependencies]
-log="0.3"
+log = "0.3"
+
+[dev-dependencies]
+xml-rs = "0.3.0"
+
+[lib]
+bench = false
+
+[profile.bench]
+opt-level = 3
+debug = true
+rpath = false
+lto = false
+debug-assertions = false
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -92,15 +92,20 @@ assert_eq!(result, expected.as_bytes());
 
 ## Performance
 
-On my first tests (200mb+ xmls) it performs much better (minimum 10x)
- than [xml-rs](https://github.com/netvl/xml-rs).
+Here is a simple comparison with [xml-rs](https://github.com/netvl/xml-rs) for very basic operations.
+
+```
+running 2 tests
+test bench_quick_xml ... bench:     703,323 ns/iter (+/- 11,915)
+test bench_xml_rs    ... bench:  14,104,316 ns/iter (+/- 444,845)
+```
 
 ## Todo
 
 - [ ] [namespaces](https://github.com/tafia/quick-xml/issues/14)
 - [ ] non-utf8: most methods return `&u[u8]` => probably not too relevant for the moment
 - [x] [parse xml declaration](https://github.com/tafia/quick-xml/pull/10)
-- [ ] [benchmarks](https://github.com/tafia/quick-xml/issues/13)
+- [x] [benchmarks](https://github.com/tafia/quick-xml/issues/13)
 - [ ] [escape characters](https://github.com/tafia/quick-xml/issues/12)
 - [ ] more checks
 - [ ] ... ?

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,7 @@ use quick_xml::{XmlReader, Event};
 use xml::reader::{EventReader, XmlEvent};
 
 #[bench]
-fn bench_quick(b: &mut Bencher) {
+fn bench_quick_xml(b: &mut Bencher) {
     let src: &[u8] = include_bytes!("../tests/sample_rss.xml");
     b.iter(|| {
         let r = XmlReader::from_reader(src);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,39 @@
+#![feature(test)]
+
+extern crate xml;
+extern crate quick_xml;
+extern crate test;
+
+use test::{Bencher};
+use quick_xml::{XmlReader, Event};
+use xml::reader::{EventReader, XmlEvent};
+
+#[bench]
+fn bench_quick(b: &mut Bencher) {
+    let src: &[u8] = include_bytes!("../tests/sample_rss.xml");
+    b.iter(|| {
+        let r = XmlReader::from_reader(src);
+        let mut count = test::black_box(0);
+        for e in r {
+            if let Ok(Event::Start(_)) = e {
+                count += 1;
+            }
+        }
+        assert!(count == 1550);
+    });
+}
+
+#[bench]
+fn bench_xml_rs(b: &mut Bencher) {
+    let src: &[u8] = include_bytes!("../tests/sample_rss.xml");
+    b.iter(|| {
+        let r = EventReader::new(src);
+        let mut count = test::black_box(0);
+        for e in r {
+            if let Ok(XmlEvent::StartElement { .. }) = e {
+                count += 1;
+            }
+        }
+        assert!(count == 1550);
+    });
+}


### PR DESCRIPTION
Basic benchmark parsing sample_rss.xml file.

Compares quick-xml and xml-rs, counting how many Start event are found.

```
running 2 tests
test bench_quick_xml ... bench:     703,323 ns/iter (+/- 11,915)
test bench_xml_rs    ... bench:  14,104,316 ns/iter (+/- 444,845)
```