### PR TITLE
Add Namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ let xml = r#"<tag1 att1 = "test">
                 </tag2>
             </tag1>"#;
 let reader = XmlReader::from_str(xml).trim_text(true);
+// if you want to use namespaces, you just need to convert the `XmlReader`
+// to an `XmlnsReader`:
+// let reader_ns = reader.namespaced();
 let mut count = 0;
 let mut txt = Vec::new();
 for r in reader {
@@ -41,7 +44,15 @@ for r in reader {
         Ok(Event::Start(ref e)) => {
             match e.name() {
                 b"tag1" => println!("attributes values: {:?}", 
-                                 e.attributes().map(|a| a.unwrap().1).collect::<Vec<_>>()),
+                                 e.attributes().map(|a| a.unwrap().1)
+                                 // if you want to resolve attribute namespaces you need to use
+                                 // the `resolve` method of XmlnsReader
+                                 //
+                                 // e.attributes().map(|a| a.map(|(k, _)| reader_ns.resolve(k))) ...
+                                 //
+                                 // note: as the `for` loop moves the reader, you may need to use a
+                                 // `while let Some(r) = reader.next()` instead
+                                 .collect::<Vec<_>>()),
                 b"tag2" => count += 1,
                 _ => (),
             }
@@ -95,14 +106,14 @@ assert_eq!(result, expected.as_bytes());
 Here is a simple comparison with [xml-rs](https://github.com/netvl/xml-rs) for very basic operations.
 
 ```
-running 2 tests
-test bench_quick_xml ... bench:     703,323 ns/iter (+/- 11,915)
-test bench_xml_rs    ... bench:  14,104,316 ns/iter (+/- 444,845)
+test bench_quick_xml            ... bench:     692,552 ns/iter (+/- 8,580)
+test bench_quick_xml_namespaced ... bench:     975,165 ns/iter (+/- 8,571)
+test bench_xml_rs               ... bench:  14,032,716 ns/iter (+/- 830,202
 ```
 
 ## Todo
 
-- [ ] [namespaces](https://github.com/tafia/quick-xml/issues/14)
+- [x] [namespaces](https://github.com/tafia/quick-xml/issues/14)
 - [ ] non-utf8: most methods return `&u[u8]` => probably not too relevant for the moment
 - [x] [parse xml declaration](https://github.com/tafia/quick-xml/pull/10)
 - [x] [benchmarks](https://github.com/tafia/quick-xml/issues/13)

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -37,3 +37,19 @@ fn bench_xml_rs(b: &mut Bencher) {
         assert!(count == 1550);
     });
 }
+
+#[bench]
+fn bench_quick_xml_namespaced(b: &mut Bencher) {
+    let src: &[u8] = include_bytes!("../tests/sample_rss.xml");
+    b.iter(|| {
+        let r = XmlReader::from_reader(src).namespaced();
+        let mut count = test::black_box(0);
+        for e in r {
+            if let Ok((_, Event::Start(_))) = e {
+                count += 1;
+            }
+        }
+        assert!(count == 1550);
+    });
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ use std::str::from_utf8;
 
 use error::{Error, Result, ResultPos};
 use attributes::Attributes;
-use namespace::Namespaced;
+use namespace::XmlnsReader;
 
 enum TagState {
     Opened,
@@ -147,9 +147,9 @@ impl<B: BufRead> XmlReader<B> {
         }
     }
 
-    /// Converts into a `Namespaced` iterator
-    pub fn namespaced(self) -> Namespaced<B> {
-        Namespaced::new(self)
+    /// Converts into a `XmlnsReader` iterator
+    pub fn namespaced(self) -> XmlnsReader<B> {
+        XmlnsReader::new(self)
     }
 
     /// Change trim_text default behaviour (false per default)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,72 +1,15 @@
 //! Quick XmlReader reader which performs **very** well.
 //!
-//! # Example
+//! ## Reader
 //!
-//! ```
-//! use quick_xml::{XmlReader, Event};
-//! 
-//! let xml = r#"<tag1 att1 = "test">
-//!                 <tag2><!--Test comment-->Test</tag2>
-//!                 <tag2>
-//!                     Test 2
-//!                 </tag2>
-//!             </tag1>"#;
-//! let reader = XmlReader::from_str(xml).trim_text(true);
-//! let mut count = 0;
-//! let mut txt = Vec::new();
-//! for r in reader {
-//!     match r {
-//!         Ok(Event::Start(ref e)) => {
-//!             match e.name() {
-//!                 b"tag1" => println!("attributes values: {:?}", 
-//!                                  e.attributes().map(|a| a.unwrap().1).collect::<Vec<_>>()),
-//!                 b"tag2" => count += 1,
-//!                 _ => (),
-//!             }
-//!         },
-//!         Ok(Event::Text(e)) => txt.push(e.into_string()),
-//!         Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
-//!         _ => (),
-//!     }
-//! }
-//! ```
+//! Depending on your needs, you can use:
 //!
-//! # Example of transforming XML
+//! - `XmlReader`: for best performance
+//! - `XmlnsReader`: if you need to resolve namespaces (around 20% slower than XmlReader)
 //!
-//! ```
-//! use quick_xml::{AsStr, Element, Event, XmlReader, XmlWriter};
-//! use quick_xml::Event::*;
-//! use std::io::Cursor;
-//! use std::iter;
-//! 
-//! let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;
-//! let reader = XmlReader::from_str(xml).trim_text(true);
-//! let mut writer = XmlWriter::new(Cursor::new(Vec::new()));
-//! for r in reader {
-//!     match r {
-//!         Ok(Event::Start(ref e)) if e.name() == b"this_tag" => {
-//!             // collect existing attributes
-//!             let mut attrs = e.attributes().map(|attr| attr.unwrap()).collect::<Vec<_>>();
+//! ## Writer
 //!
-//!             // copy existing attributes, adds a new my-key="some value" attribute
-//!             let mut elem = Element::new("my_elem").with_attributes(attrs);
-//!             elem.push_attribute(b"my-key", "some value");
-//!
-//!             // writes the event to the writer
-//!             assert!(writer.write(Start(elem)).is_ok());
-//!         },
-//!         Ok(Event::End(ref e)) if e.name() == b"this_tag" => {
-//!             assert!(writer.write(End(Element::new("my_elem"))).is_ok());
-//!         },
-//!         Ok(e) => assert!(writer.write(e).is_ok()),
-//!         Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
-//!     }
-//! }
-//!
-//! let result = writer.into_inner().into_inner();
-//! let expected = r#"<my_elem k1="v1" k2="v2" my-key="some value"><child>text</child></my_elem>"#;
-//! assert_eq!(result, expected.as_bytes());
-//! ```
+//! `XmlWriter`: to write xmls. Can be nested with readers if you want to transform xmls
 
 #![deny(missing_docs)]
 
@@ -109,9 +52,36 @@ impl AsStr for [u8] {
     }
 }
 
-/// Xml reader
+/// A Xml reader
 ///
-/// Consumes a `BufRead` and streams xml Event
+/// Consumes a `BufRead` and streams xml `Event`s
+///
+/// ```
+/// use quick_xml::{XmlReader, Event};
+/// 
+/// let xml = r#"<tag1 att1 = "test">
+///                 <tag2><!--Test comment-->Test</tag2>
+///                 <tag2>Test 2</tag2>
+///             </tag1>"#;
+/// let reader = XmlReader::from_str(xml).trim_text(true);
+/// let mut count = 0;
+/// let mut txt = Vec::new();
+/// for r in reader {
+///     match r {
+///         Ok(Event::Start(ref e)) => {
+///             match e.name() {
+///                 b"tag1" => println!("attributes values: {:?}", 
+///                                  e.attributes().map(|a| a.unwrap().1).collect::<Vec<_>>()),
+///                 b"tag2" => count += 1,
+///                 _ => (),
+///             }
+///         },
+///         Ok(Event::Text(e)) => txt.push(e.into_string()),
+///         Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
+///         _ => (),
+///     }
+/// }
+/// ```
 pub struct XmlReader<B: BufRead> {
     /// reader
     reader: B,
@@ -648,6 +618,41 @@ fn read_until<R: BufRead>(r: &mut R, byte: u8, buf: &mut Vec<u8>) -> Result<usiz
 /// Xml writer
 ///
 /// Consumes a `Write` and writes xml Events
+///
+/// ```
+/// use quick_xml::{AsStr, Element, Event, XmlReader, XmlWriter};
+/// use quick_xml::Event::*;
+/// use std::io::Cursor;
+/// use std::iter;
+/// 
+/// let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;
+/// let reader = XmlReader::from_str(xml).trim_text(true);
+/// let mut writer = XmlWriter::new(Cursor::new(Vec::new()));
+/// for r in reader {
+///     match r {
+///         Ok(Event::Start(ref e)) if e.name() == b"this_tag" => {
+///             // collect existing attributes
+///             let mut attrs = e.attributes().map(|attr| attr.unwrap()).collect::<Vec<_>>();
+///
+///             // copy existing attributes, adds a new my-key="some value" attribute
+///             let mut elem = Element::new("my_elem").with_attributes(attrs);
+///             elem.push_attribute(b"my-key", "some value");
+///
+///             // writes the event to the writer
+///             assert!(writer.write(Start(elem)).is_ok());
+///         },
+///         Ok(Event::End(ref e)) if e.name() == b"this_tag" => {
+///             assert!(writer.write(End(Element::new("my_elem"))).is_ok());
+///         },
+///         Ok(e) => assert!(writer.write(e).is_ok()),
+///         Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
+///     }
+/// }
+///
+/// let result = writer.into_inner().into_inner();
+/// let expected = r#"<my_elem k1="v1" k2="v2" my-key="some value"><child>text</child></my_elem>"#;
+/// assert_eq!(result, expected.as_bytes());
+/// ```
 pub struct XmlWriter<W: Write> {
     /// underlying writer
     writer: W

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ extern crate log;
 
 pub mod error;
 pub mod attributes;
+pub mod namespace;
 
 #[cfg(test)]
 mod test;
@@ -88,6 +89,7 @@ use std::str::from_utf8;
 
 use error::{Error, Result, ResultPos};
 use attributes::Attributes;
+use namespace::Namespaced;
 
 enum TagState {
     Opened,
@@ -143,6 +145,11 @@ impl<B: BufRead> XmlReader<B> {
             with_check: true,
             buf_position: 0,
         }
+    }
+
+    /// Converts into a `Namespaced` iterator
+    pub fn namespaced(self) -> Namespaced<B> {
+        Namespaced::new(self)
     }
 
     /// Change trim_text default behaviour (false per default)

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,0 +1,111 @@
+//! Module for managing Namespaced iterator
+
+use {XmlReader, Event};
+use error::ResultPos;
+use std::io::BufRead;
+
+struct Namespace {
+    prefix: Vec<u8>,
+    value: Vec<u8>,
+    element_name: Vec<u8>,
+    level: u8,
+}
+
+impl Namespace {
+    fn is_match(&self, name: &[u8]) -> bool {
+        let len = self.prefix.len();
+        name.len() > len && 
+        name[len] == b':' &&
+        &name[..len] == &*self.prefix
+    }
+}
+
+/// Namespaced iterator which wraps XmlReader iterator and
+/// adds namespace resolutions
+pub struct Namespaced<R: BufRead> {
+    reader: XmlReader<R>,
+    namespaces: Vec<Namespace>,
+}
+
+impl<R: BufRead> Namespaced<R> {
+
+    /// Converts a `XmlReader` into a `Namespaced` iterator
+    pub fn new(reader: XmlReader<R>) -> Namespaced<R> {
+        Namespaced {
+            reader: reader,
+            namespaces: Vec::new(),
+        }
+    }
+
+    /// Resolves a qualified name into (namespace value, local name)
+    pub fn resolve<'a, 'b>(&'a self, qname: &'b[u8]) -> (Option<&'a[u8]>, &'b[u8]) {
+        match self.namespaces.iter().rev().find(|ref n| n.is_match(qname)) {
+            Some(n) => (Some(&n.value), &qname[(n.prefix.len() + 1)..]),
+            None => (None, qname),
+        }
+    }
+}
+
+impl<R: BufRead> Iterator for Namespaced<R> {
+    type Item = ResultPos<(Option<Vec<u8>>, Event)>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.reader.next() {
+            Some(Ok(Event::Start(e))) => {
+                let namespace = {
+                    let name = e.name();
+                    // increment existing namespace level if this same element
+                    for n in self.namespaces.iter_mut() {
+                        if name == &*n.element_name {
+                            n.level += 1;
+                        }
+                    }
+                    // clone namespace value, if any
+                    // iterate in reverse order to find the most recent one
+                    self.namespaces.iter().rev()
+                        .find(|ref n| n.is_match(name))
+                        .map(|ref n| n.value.clone())
+                };
+                // adds new namespaces for attributes starting with 'xmlns:'
+                for a in e.attributes() {
+                    if let Ok((k, v)) = a {
+                        if k.len() > 6 && &k[..6] == b"xmlns:" {
+                            self.namespaces.push(Namespace {
+                                prefix: k[6..].to_vec(), 
+                                value: v.to_vec(),
+                                element_name: e.name().to_vec(),
+                                level: 1,
+                            });
+                        }
+                    }
+                }
+                Some(Ok((namespace, Event::Start(e))))
+            }
+            Some(Ok(Event::End(e))) => {
+                // decrement levels and remove namespaces with 0 level
+                let mut to_remove = false;
+                {
+                    let name = e.name();
+                    for n in self.namespaces.iter_mut() {
+                        if name == &*n.element_name {
+                            n.level -= 1;
+                            to_remove |= n.level == 0;
+                        }
+                    }
+                }
+                if to_remove {
+                    self.namespaces.retain(|n| n.level > 0);
+                }
+                let namespace = {
+                    let name = e.name();
+                    self.namespaces.iter().rev()
+                        .find(|ref n| n.is_match(name))
+                        .map(|ref n| n.value.clone())
+                };
+                Some(Ok((namespace, Event::End(e))))
+            },
+            Some(Ok(e)) => Some(Ok((None, e))),
+            Some(Err(e)) => Some(Err(e)),
+            None => None,
+        }
+    }
+}

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,4 +1,4 @@
-//! Module for managing Namespaced iterator
+//! Module for managing XmlnsReader iterator
 
 use {XmlReader, Event};
 use error::ResultPos;
@@ -20,18 +20,18 @@ impl Namespace {
     }
 }
 
-/// Namespaced iterator which wraps XmlReader iterator and
+/// XmlnsReader iterator which wraps XmlReader iterator and
 /// adds namespace resolutions
-pub struct Namespaced<R: BufRead> {
+pub struct XmlnsReader<R: BufRead> {
     reader: XmlReader<R>,
     namespaces: Vec<Namespace>,
 }
 
-impl<R: BufRead> Namespaced<R> {
+impl<R: BufRead> XmlnsReader<R> {
 
-    /// Converts a `XmlReader` into a `Namespaced` iterator
-    pub fn new(reader: XmlReader<R>) -> Namespaced<R> {
-        Namespaced {
+    /// Converts a `XmlReader` into a `XmlnsReader` iterator
+    pub fn new(reader: XmlReader<R>) -> XmlnsReader<R> {
+        XmlnsReader {
             reader: reader,
             namespaces: Vec::new(),
         }
@@ -46,7 +46,7 @@ impl<R: BufRead> Namespaced<R> {
     }
 }
 
-impl<R: BufRead> Iterator for Namespaced<R> {
+impl<R: BufRead> Iterator for XmlnsReader<R> {
     type Item = ResultPos<(Option<Vec<u8>>, Event)>;
     fn next(&mut self) -> Option<Self::Item> {
         match self.reader.next() {


### PR DESCRIPTION
Adds a `Namespaced` struct which wraps `XmlReader` and resolves namespaces.

benches:
```
running 3 tests
test bench_quick_xml            ... bench:     692,552 ns/iter (+/- 8,580)
test bench_quick_xml_namespaced ... bench:     975,165 ns/iter (+/- 8,571)
test bench_xml_rs               ... bench:  14,032,716 ns/iter (+/- 830,202
```

closes #14 
