### PR TITLE
Better position

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Carto.toml
 [dependencies]
 quick-xml = "0.1"
 ```
-
 ``` rust
 extern crate quick_xml;
 ```
@@ -59,7 +58,7 @@ for r in reader {
             }
         },
         Ok(Event::Text(e)) => txt.push(e.into_string()),
-        Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
+        Err((e, pos)) => panic!("{:?} at position {}", e, pos),
         _ => (),
     }
 }
@@ -93,7 +92,7 @@ for r in reader {
             assert!(writer.write(End(Element::new("my_elem"))).is_ok());
         },
         Ok(e) => assert!(writer.write(e).is_ok()),
-        Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
+        Err((e, pos)) => panic!("{:?} at position {}", e, pos),
     }
 }
 
@@ -107,9 +106,9 @@ assert_eq!(result, expected.as_bytes());
 Here is a simple comparison with [xml-rs](https://github.com/netvl/xml-rs) for very basic operations.
 
 ```
-test bench_quick_xml            ... bench:     692,552 ns/iter (+/- 8,580)
-test bench_quick_xml_namespaced ... bench:     975,165 ns/iter (+/- 8,571)
-test bench_xml_rs               ... bench:  14,032,716 ns/iter (+/- 830,202
+test bench_quick_xml            ... bench:     549,643 ns/iter (+/- 11,789)
+test bench_quick_xml_namespaced ... bench:     830,328 ns/iter (+/- 17,818)
+test bench_xml_rs               ... bench:  14,102,427 ns/iter (+/- 231,446)
 ```
 
 ## Todo

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,7 +1,7 @@
 //! Xml Attributes module
 //!
 //! Provides an iterator over attributes key/value pairs
-use error::{Error, Result};
+use error::{Error, ResultPos};
 
 /// Iterator over attributes key/value pairs
 pub struct Attributes<'a> {
@@ -25,7 +25,7 @@ impl<'a> Attributes<'a> {
 }
 
 impl<'a> Iterator for Attributes<'a> {
-    type Item = Result<(&'a [u8], &'a [u8])>;
+    type Item = ResultPos<(&'a [u8], &'a [u8])>;
     fn next(&mut self) -> Option<Self::Item> {
         
         if self.was_error { return None; }
@@ -74,7 +74,7 @@ impl<'a> Iterator for Attributes<'a> {
                 Some((i, b'=')) => {
                     if has_equal {
                         self.was_error = true;
-                        return Some(Err(Error::Malformed("Got 2 '=' tokens".to_owned())));
+                        return Some(Err((Error::Malformed("Got 2 '=' tokens".to_owned()), p + i)));
                     }
                     has_equal = true;
                     if end_key.is_none() {
@@ -84,7 +84,7 @@ impl<'a> Iterator for Attributes<'a> {
                 Some((i, q @ b'"')) | Some((i, q @ b'\'')) => {
                     if !has_equal {
                         self.was_error = true;
-                        return Some(Err(Error::Malformed("Unexpected quote before '='".to_owned())));
+                        return Some(Err((Error::Malformed("Unexpected quote before '='".to_owned()), p + i)));
                     }
                     if start_val.is_none() {
                         start_val = Some(i + 1);

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,13 @@ pub enum Error {
 
 /// Result type
 pub type Result<T> = ::std::result::Result<T, Error>;
-/// Result type with current buffer position
+/// Result type with position
+///
+/// Position represents byte index relative to 
+///
+/// - xml file when iterating xml `Event`s
+/// - element node when iterating on `Attribute`s. You can find xml 
+/// relative position using `XmlReader::buffer_position`
 pub type ResultPos<T> = ::std::result::Result<T, (Error, usize)>;
 
 impl fmt::Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,19 +498,19 @@ pub struct XmlDecl {
 impl XmlDecl {
 
     /// Gets xml version, including quotes (' or ")
-    pub fn version(&self) -> Result<&[u8]> {
+    pub fn version(&self) -> ResultPos<&[u8]> {
         match self.element.attributes().next() {
             Some(Err(e)) => Err(e),
             Some(Ok((b"version", v))) => Ok(v),
-            Some(Ok((k, _))) => Err(Error::Malformed(format!(
-                        "XmlDecl must start with 'version' attribute, found {:?}", k.as_str()))),
-            None => Err(Error::Malformed(
-                    "XmlDecl must start with 'version' attribute, found none".to_owned())),
+            Some(Ok((k, _))) => Err((Error::Malformed(format!(
+                        "XmlDecl must start with 'version' attribute, found {:?}", k.as_str())), 0)),
+            None => Err((Error::Malformed(
+                    "XmlDecl must start with 'version' attribute, found none".to_owned()), 0)),
         }
     }
 
     /// Gets xml encoding, including quotes (' or ")
-    pub fn encoding(&self) -> Option<Result<&[u8]>> {
+    pub fn encoding(&self) -> Option<ResultPos<&[u8]>> {
         for a in self.element.attributes() {
             match a {
                 Err(e) => return Some(Err(e)),
@@ -522,7 +522,7 @@ impl XmlDecl {
     }
 
     /// Gets xml standalone, including quotes (' or ")
-    pub fn standalone(&self) -> Option<Result<&[u8]>> {
+    pub fn standalone(&self) -> Option<ResultPos<&[u8]>> {
         for a in self.element.attributes() {
             match a {
                 Err(e) => return Some(Err(e)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! Depending on your needs, you can use:
 //!
 //! - `XmlReader`: for best performance
-//! - `XmlnsReader`: if you need to resolve namespaces (around 20% slower than XmlReader)
+//! - `XmlnsReader`: if you need to resolve namespaces (around 50% slower than XmlReader)
 //!
 //! ## Writer
 //!
@@ -77,7 +77,7 @@ impl AsStr for [u8] {
 ///             }
 ///         },
 ///         Ok(Event::Text(e)) => txt.push(e.into_string()),
-///         Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
+///         Err((e, pos)) => panic!("{:?} at position {}", e, pos),
 ///         _ => (),
 ///     }
 /// }
@@ -651,7 +651,7 @@ fn read_until<R: BufRead>(r: &mut R, byte: u8, buf: &mut Vec<u8>) -> Result<usiz
 ///             assert!(writer.write(End(Element::new("my_elem"))).is_ok());
 ///         },
 ///         Ok(e) => assert!(writer.write(e).is_ok()),
-///         Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
+///         Err((e, pos)) => panic!("{:?} at position {}", e, pos),
 ///     }
 /// }
 ///

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -120,18 +120,20 @@ impl<R: BufRead> Iterator for XmlnsReader<R> {
             }
             Some(Ok(Event::End(e))) => {
                 // decrement levels and remove namespaces with 0 level
-                let mut to_remove = false;
                 {
                     let name = e.name();
                     for n in self.namespaces.iter_mut() {
                         if name == &*n.element_name {
                             n.level -= 1;
-                            to_remove |= n.level == 0;
                         }
                     }
                 }
-                if to_remove {
-                    self.namespaces.retain(|n| n.level > 0);
+                match self.namespaces.iter().rev().position(|n| n.level > 0) {
+                    Some(0) | None => (),
+                    Some(p) => {
+                        let len = self.namespaces.len() - p;
+                        self.namespaces.truncate(len)
+                    },
                 }
                 let namespace = {
                     let name = e.name();

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -55,7 +55,7 @@ impl Namespace {
 ///             }
 ///         },
 ///         Ok((_, Event::Text(e))) => txt.push(e.into_string()),
-///         Err((e, pos)) => panic!("{:?} at buffer position {}", e, pos),
+///         Err((e, pos)) => panic!("{:?} at position {}", e, pos),
 ///         _ => (),
 ///     }
 /// }

--- a/src/test.rs
+++ b/src/test.rs
@@ -196,8 +196,19 @@ fn test_buf_position() {
         .trim_text(true).with_check(true);
 
     match r.next() {
-        Some(Err((_, 4))) => assert!(true),
-        Some(Err((_, n))) => assert!(false, "expecting buf_pos = 4, found {}", n),
+        Some(Err((_, 2))) => assert!(true), // error at char 2: no opening tag
+        Some(Err((e, n))) => assert!(false, "expecting buf_pos = 2, found {}, err: {:?}", n, e),
+        e => assert!(false, "expecting error, found {:?}", e),
+    }
+
+    r = XmlReader::from_str("<a><!--b>")
+        .trim_text(true).with_check(true);
+
+    next_eq!(r, Start, b"a");
+
+    match r.next() {
+        Some(Err((_, 5))) => assert!(true), // error at char 5: no closing --> tag found
+        Some(Err((e, n))) => assert!(false, "expecting buf_pos = 2, found {}, err: {:?}", n, e),
         e => assert!(false, "expecting error, found {:?}", e),
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 use super::{AsStr, Element, XmlReader, XmlWriter};
 use super::Event::*;
-use super::error::Result;
+use super::error::ResultPos;
 use std::str::from_utf8;
 use std::io::Cursor;
 
@@ -174,7 +174,7 @@ fn test_write_attrs() {
         let event = event.unwrap();
         let event = match event {
             Start(elem) => {
-                let mut attrs = elem.attributes().collect::<Result<Vec<_>>>().unwrap();
+                let mut attrs = elem.attributes().collect::<ResultPos<Vec<_>>>().unwrap();
                 attrs.extend_from_slice(&[(b"a", b"b"), (b"c", b"d")]);
                 let mut elem = Element::new("copy").with_attributes(attrs);
                 elem.push_attribute("x", "y");


### PR DESCRIPTION
- return exact index when getting an error.
- returns `ResultPos` for `Attributes` iterator

speedup:
```
before
test bench_quick_xml            ... bench:     692,552 ns/iter (+/- 8,580)
test bench_quick_xml_namespaced ... bench:     975,165 ns/iter (+/- 8,571)

after
test bench_quick_xml            ... bench:     549,643 ns/iter (+/- 11,789)
test bench_quick_xml_namespaced ... bench:     830,328 ns/iter (+/- 17,818)
```