### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick-xml"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "High performance xml reader and writer"
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/tafia/quick-xml.svg?branch=master)](https://travis-ci.org/appsignal/quick-xml)
 [![Crate](http://meritbadge.herokuapp.com/quick-xml)](https://crates.io/crates/quick-xml)
+[![Clippy Linting Result](https://clippy.bashy.io/github/tafia/quick-xml/master/badge.svg)](https://clippy.bashy.io/github/tafia/quick-xml/master/log)
 
 High performance xml pull reader/writer.
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ test bench_rusty_xml            ... bench:   5,543,993 ns/iter (+/- 326,792)
 - [ ] more checks
 - [ ] ... ?
 
+## Known issues:
+
+- [ ] attribute values with `>` character will likely result in parsing error
+
 ## Contribute
 
 Any PR is welcomed!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-//! Quick XmlReader reader which performs **very** well.
+//! High performance xml reader/writer.
 //!
 //! ## Reader
 //!
 //! Depending on your needs, you can use:
 //!
 //! - `XmlReader`: for best performance
-//! - `XmlnsReader`: if you need to resolve namespaces (around 50% slower than XmlReader)
+//! - `XmlnsReader`: if you need to resolve namespaces (around 50% slower than `XmlReader`)
 //!
 //! ## Writer
 //!
@@ -48,7 +48,7 @@ pub trait AsStr {
     fn as_str(&self) -> Result<&str>;
 }
 
-/// Implements AsStr for a byte slice
+/// Implements `AsStr` for a byte slice
 impl AsStr for [u8] {
     fn as_str(&self) -> Result<&str> {
         from_utf8(self).map_err(Error::Utf8)
@@ -443,7 +443,7 @@ impl<B: BufRead> Iterator for XmlReader<B> {
 /// - no attribute parsing: use lazy `Attributes` iterator only when needed
 /// - no namespace awareness as it requires parsing all `Start` element attributes
 /// - no utf8 conversion: prefer searching statically known bytes patterns when possible 
-/// (`e.name() == b"myname"`), then use the `.as_str()` or `.into_string()` methods
+/// (`e.name() == b"myname"`), then use the `as_str` or `into_string` methods
 pub struct Element {
     /// content of the element, before any utf8 conversion
     buf: Vec<u8>,
@@ -562,7 +562,7 @@ impl fmt::Debug for Element {
     }
 }
 
-/// Wrapper around Element to parse XmlDecl
+/// Wrapper around `Element` to parse `XmlDecl`
 ///
 /// Postpone element parsing only when needed
 #[derive(Debug)]
@@ -655,10 +655,10 @@ fn is_whitespace(b: u8) -> bool {
     }
 }
 
-/// read_until slighly modified from rust std library
+/// `read_until` slighly modified from rust std library
 ///
 /// only change is that we do not write the matching character
-#[inline(always)]
+#[inline]
 fn read_until<R: BufRead>(r: &mut R, byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
     let mut read = 0;
     let mut done = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ enum TagState {
 
 /// A trait to support on-demand conversion from UTF-8
 pub trait AsStr {
-    /// Converts this to an &str
+    /// Converts this to an `&str`
     fn as_str(&self) -> Result<&str>;
 }
 
@@ -66,7 +66,7 @@ impl AsStr for [u8] {
 ///                 <tag2><!--Test comment-->Test</tag2>
 ///                 <tag2>Test 2</tag2>
 ///             </tag1>"#;
-/// let reader = XmlReader::from_str(xml).trim_text(true);
+/// let reader = XmlReader::from(xml).trim_text(true);
 /// let mut count = 0;
 /// let mut txt = Vec::new();
 /// for r in reader {
@@ -104,6 +104,12 @@ pub struct XmlReader<B: BufRead> {
     check_comments: bool,
     /// current buffer position, useful for debuging errors
     buf_position: usize,
+}
+
+impl<'a> ::std::convert::From<&'a str> for XmlReader<&'a[u8]> {
+    fn from(reader: &'a str) -> XmlReader<&'a [u8]> {
+        XmlReader::from_reader(reader.as_bytes())
+    }
 }
 
 impl<B: BufRead> XmlReader<B> {
@@ -394,13 +400,6 @@ impl XmlReader<BufReader<File>> {
     }
 }
 
-impl<'a> XmlReader<&'a [u8]> {
-    /// Creates a xml reader for an in memory string buffer.
-    pub fn from_str(s: &'a str) -> XmlReader<&'a [u8]> {
-        XmlReader::from_reader(s.as_bytes())
-    }
-}
-
 /// Iterator on xml returning `Event`s
 impl<B: BufRead> Iterator for XmlReader<B> {
 
@@ -442,8 +441,8 @@ impl<B: BufRead> Iterator for XmlReader<B> {
 ///
 /// - no attribute parsing: use lazy `Attributes` iterator only when needed
 /// - no namespace awareness as it requires parsing all `Start` element attributes
-/// - no utf8 conversion: prefer searching statically known bytes patterns when possible 
-/// (`e.name() == b"myname"`), then use the `as_str` or `into_string` methods
+/// - no utf8 conversion: prefer searching statically binary comparisons
+/// then use the `as_str` or `into_string` methods
 pub struct Element {
     /// content of the element, before any utf8 conversion
     buf: Vec<u8>,
@@ -710,7 +709,7 @@ fn read_until<R: BufRead>(r: &mut R, byte: u8, buf: &mut Vec<u8>) -> Result<usiz
 /// use std::iter;
 /// 
 /// let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;
-/// let reader = XmlReader::from_str(xml).trim_text(true);
+/// let reader = XmlReader::from(xml).trim_text(true);
 /// let mut writer = XmlWriter::new(Cursor::new(Vec::new()));
 /// for r in reader {
 ///     match r {

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,4 +1,4 @@
-//! Module for managing XmlnsReader iterator
+//! Module for managing `XmlnsReader` iterator
 
 use {XmlReader, Event};
 use error::ResultPos;
@@ -20,7 +20,7 @@ impl Namespace {
     }
 }
 
-/// XmlnsReader iterator which wraps XmlReader iterator and
+/// `XmlnsReader` iterator which wraps `XmlReader` iterator and
 /// adds namespace resolutions
 ///
 /// # Example
@@ -92,7 +92,7 @@ impl<R: BufRead> Iterator for XmlnsReader<R> {
                 // increment existing namespace level if this same element
                 {
                     let name = e.name();
-                    for n in self.namespaces.iter_mut() {
+                    for n in &mut self.namespaces {
                         if name == &*n.element_name {
                             n.level += 1;
                         }
@@ -123,7 +123,7 @@ impl<R: BufRead> Iterator for XmlnsReader<R> {
                 // decrement levels and remove namespaces with 0 level
                 {
                     let name = e.name();
-                    for n in self.namespaces.iter_mut() {
+                    for n in &mut self.namespaces {
                         if name == &*n.element_name {
                             n.level -= 1;
                         }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -33,7 +33,7 @@ impl Namespace {
 ///                 <tag2><!--Test comment-->Test</tag2>
 ///                 <tag2>Test 2</tag2>
 ///             </tag1>"#;
-/// let mut reader = XmlReader::from_str(xml).trim_text(true)
+/// let mut reader = XmlReader::from(xml).trim_text(true)
 ///                  .namespaced();
 /// let mut count = 0;
 /// let mut txt = Vec::new();

--- a/src/test.rs
+++ b/src/test.rs
@@ -30,25 +30,25 @@ macro_rules! next_eq {
 
 #[test]
 fn test_start() {
-    let mut r = XmlReader::from_str("<a>").trim_text(true);
+    let mut r = XmlReader::from("<a>").trim_text(true);
     next_eq!(r, Start, b"a");
 }
    
 #[test]
 fn test_start_end() {
-    let mut r = XmlReader::from_str("<a/>").trim_text(true);
+    let mut r = XmlReader::from("<a/>").trim_text(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
    
 #[test]
 fn test_start_end_attr() {
-    let mut r = XmlReader::from_str("<a b=\"test\" />").trim_text(true);
+    let mut r = XmlReader::from("<a b=\"test\" />").trim_text(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
    
 #[test]
 fn test_start_end_comment() {
-    let mut r = XmlReader::from_str("<b><a b=\"test\" c=\"test\" /> <a  /><!--t--></b>").trim_text(true);
+    let mut r = XmlReader::from("<b><a b=\"test\" c=\"test\" /> <a  /><!--t--></b>").trim_text(true);
     next_eq!(r, 
              Start, b"b",
              Start, b"a", 
@@ -62,19 +62,19 @@ fn test_start_end_comment() {
 
 #[test]
 fn test_start_txt_end() {
-    let mut r = XmlReader::from_str("<a>test</a>").trim_text(true);
+    let mut r = XmlReader::from("<a>test</a>").trim_text(true);
     next_eq!(r, Start, b"a", Text, b"test", End, b"a");
 }
 
 #[test]
 fn test_comment() {
-    let mut r = XmlReader::from_str("<!--test-->").trim_text(true);
+    let mut r = XmlReader::from("<!--test-->").trim_text(true);
     next_eq!(r, Comment, b"test");
 }
 
 #[test]
 fn test_xml_decl() {
-    let mut r = XmlReader::from_str("<?xml version=\"1.0\" encoding='utf-8'?>").trim_text(true);
+    let mut r = XmlReader::from("<?xml version=\"1.0\" encoding='utf-8'?>").trim_text(true);
     match r.next() {
         Some(Ok(Decl(ref e))) => {
             match e.version() {
@@ -102,13 +102,13 @@ fn test_xml_decl() {
 #[test]
 fn test_trim_test() {
     let txt = "<a><b>  </b></a>";
-    let mut r = XmlReader::from_str(&txt).trim_text(true);
+    let mut r = XmlReader::from(txt).trim_text(true);
     next_eq!(r, Start, b"a",
                 Start, b"b",
                 End, b"b",
                 End, b"a");
 
-    let mut r = XmlReader::from_str(&txt).trim_text(false);
+    let mut r = XmlReader::from(txt).trim_text(false);
     next_eq!(r, Text, b"",
                 Start, b"a",
                 Text, b"",
@@ -121,25 +121,25 @@ fn test_trim_test() {
 
 #[test]
 fn test_cdata() {
-    let mut r = XmlReader::from_str("<![CDATA[test]]>").trim_text(true);
+    let mut r = XmlReader::from("<![CDATA[test]]>").trim_text(true);
     next_eq!(r, CData, b"test");
 }
 
 #[test]
 fn test_cdata_open_close() {
-    let mut r = XmlReader::from_str("<![CDATA[test <> test]]>").trim_text(true);
+    let mut r = XmlReader::from("<![CDATA[test <> test]]>").trim_text(true);
     next_eq!(r, CData, b"test <> test");
 }
 
 #[test]
 fn test_start_attr() {
-    let mut r = XmlReader::from_str("<a b=\"c\">").trim_text(true);
+    let mut r = XmlReader::from("<a b=\"c\">").trim_text(true);
     next_eq!(r, Start, b"a");
 }
 
 #[test]
 fn test_nested() {
-    let mut r = XmlReader::from_str("<a><b>test</b><c/></a>").trim_text(true);
+    let mut r = XmlReader::from("<a><b>test</b><c/></a>").trim_text(true);
     next_eq!(r, 
              Start, b"a", 
              Start, b"b", 
@@ -153,22 +153,22 @@ fn test_nested() {
 
 #[test]
 fn test_writer() {
-    let str = r#"<?xml version="1.0" encoding="utf-8"?><manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.github.sample" android:versionName="Lollipop" android:versionCode="5.1"><application android:label="SampleApplication"></application></manifest>"#;
-    let reader = XmlReader::from_str(&str).trim_text(true);
+    let txt = r#"<?xml version="1.0" encoding="utf-8"?><manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.github.sample" android:versionName="Lollipop" android:versionCode="5.1"><application android:label="SampleApplication"></application></manifest>"#;
+    let reader = XmlReader::from(txt).trim_text(true);
     let mut writer = XmlWriter::new(Cursor::new(Vec::new()));
     for event in reader {
         assert!(writer.write(event.unwrap()).is_ok());
     }
 
     let result = writer.into_inner().into_inner();
-    assert_eq!(result, str.as_bytes());
+    assert_eq!(result, txt.as_bytes());
 }
 
 #[test]
 fn test_write_attrs() {
     let str_from = r#"<source attr="val"></source>"#;
     let expected = r#"<copy attr="val" a="b" c="d" x="y"></copy>"#;
-    let reader = XmlReader::from_str(&str_from).trim_text(true);
+    let reader = XmlReader::from(str_from).trim_text(true);
     let mut writer = XmlWriter::new(Cursor::new(Vec::new()));
     for event in reader {
         let event = event.unwrap();
@@ -192,7 +192,7 @@ fn test_write_attrs() {
 
 #[test]
 fn test_buf_position() {
-    let mut r = XmlReader::from_str("</a>")
+    let mut r = XmlReader::from("</a>")
         .trim_text(true).with_check(true);
 
     match r.next() {
@@ -201,7 +201,7 @@ fn test_buf_position() {
         e => assert!(false, "expecting error, found {:?}", e),
     }
 
-    r = XmlReader::from_str("<a><!--b>")
+    r = XmlReader::from("<a><!--b>")
         .trim_text(true).with_check(true);
 
     next_eq!(r, Start, b"a");
@@ -216,7 +216,7 @@ fn test_buf_position() {
 
 #[test]
 fn test_namespace() {
-    let mut r = XmlReader::from_str("<a xmlns:myns='www1'><myns:b>in namespace!</myns:b></a>")
+    let mut r = XmlReader::from("<a xmlns:myns='www1'><myns:b>in namespace!</myns:b></a>")
         .trim_text(true).namespaced();;
 
     if let Some(Ok((None, Start(_)))) = r.next() {        
@@ -237,7 +237,7 @@ fn test_namespace() {
 
 #[test]
 fn test_escaped_content() {
-    let mut r = XmlReader::from_str("<a>&lt;test&gt;</a>").trim_text(true);
+    let mut r = XmlReader::from("<a>&lt;test&gt;</a>").trim_text(true);
     next_eq!(r, Start, b"a");
     match r.next() {
         Some(Ok(Text(ref e))) => {


### PR DESCRIPTION
There is a breaking change: renamed `from_str` and use `From<&str>` trait instead