### PR TITLE
Use Range instead of indexes in Element items

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ## 0.2.2
 - style: code refactoring, split largest functions into smaller ones
+- style: use `Range` instead of `usize`s in `Element` definition
 
 ## 0.2.1
 - feat: add `Clone` to more structs

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -9,18 +9,22 @@ use escape::unescape;
 /// Iterator over attributes key/value pairs
 #[derive(Clone)]
 pub struct Attributes<'a> {
+    /// slice of `Element` corresponding to attributes
     bytes: &'a [u8],
+    /// current position of the iterator
     position: usize,
+    /// shall the next iterator early exit because there were an error last time
     exit: bool,
+    /// if true, checks for duplicate names
     with_checks: bool,
+    /// if `with_checks`, contains the ranges corresponding to the 
+    /// attribute names already parsed in this `Element`
     consumed: Vec<Range<usize>>,
 }
 
 impl<'a> Attributes<'a> {
-    /// creates a new attribute from a buffer
-    ///
-    /// pos represents current position of the iterator
-    /// (starts after start element name)
+
+    /// creates a new attribute iterator from a buffer
     pub fn new(buf: &'a [u8], pos: usize) -> Attributes<'a> {
         Attributes {
             bytes: buf,

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -49,8 +49,7 @@ pub fn unescape(raw: &[u8]) -> ResultPos<Cow<[u8]>> {
                                 None => {
                                     return Err((Error::Malformed(
                                                 format!("Invalid hexadecimal character number \
-                                                        in an entity: {}", name)), 
-                                            i))
+                                                        in an entity: {}", name)), i))
                                 }
                             }
                         } else {
@@ -61,22 +60,18 @@ pub fn unescape(raw: &[u8]) -> ResultPos<Cow<[u8]>> {
                                 None => {
                                     return Err((Error::Malformed(
                                                 format!("Invalid decimal character number \
-                                                        in an entity: {}", name)), 
-                                            i))
+                                                        in an entity: {}", name)), i))
                                 }
                             }
                         }
                     }
                     bytes => {
                         return Err((Error::Malformed(format!("Unexpected entity: {:?}",
-                                                             bytes.as_str())),
-                                    i))
+                                                             bytes.as_str())), i))
                     }
                 }
             } else {
-                return Err((Error::Malformed(
-                            "Cannot find ';' after '&'".to_string()), 
-                        i));
+                return Err((Error::Malformed("Cannot find ';' after '&'".to_string()), i));
             }
         }
     }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -9,7 +9,7 @@ struct Namespace {
     prefix: Vec<u8>,
     value: Vec<u8>,
     element_name: Vec<u8>,
-    level: u8,
+    level: usize,
 }
 
 impl Namespace {
@@ -101,7 +101,7 @@ impl<R: BufRead> Iterator for XmlnsReader<R> {
                     }
                 }
                 // adds new namespaces for attributes starting with 'xmlns:'
-                for a in e.attributes() {
+                for a in e.attributes().with_checks(false) {
                     if let Ok((k, v)) = a {
                         if k.len() > 6 && &k[..6] == b"xmlns:" {
                             self.namespaces.push(Namespace {
@@ -111,6 +111,8 @@ impl<R: BufRead> Iterator for XmlnsReader<R> {
                                 level: 1,
                             });
                         }
+                    } else {
+                        break;
                     }
                 }
                 // search namespace value


### PR DESCRIPTION
Also use `e.attributes().with_check(false)` in namespace iterator to save some extra time.
No noticeable change on benchmarks, this is mainly to simplify code readability