### PR TITLE
Inline some small functions

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -25,6 +25,7 @@ pub struct Attributes<'a> {
 impl<'a> Attributes<'a> {
 
     /// creates a new attribute iterator from a buffer
+    #[inline]
     pub fn new(buf: &'a [u8], pos: usize) -> Attributes<'a> {
         Attributes {
             bytes: buf,
@@ -39,11 +40,13 @@ impl<'a> Attributes<'a> {
     ///
     /// all escaped characters ('&...;') in attribute values are replaced
     /// with their corresponding character
+    #[inline]
     pub fn unescaped(self) -> UnescapedAttributes<'a> {
         UnescapedAttributes { inner: self }
     }
 
     /// check if attributes are distincts
+    #[inline]
     pub fn with_checks(mut self, val: bool) -> Attributes<'a> {
         self.with_checks = val;
         self
@@ -51,6 +54,7 @@ impl<'a> Attributes<'a> {
 
     /// return Err((e, p))
     /// sets `self.exit = true` to terminate the iterator
+    #[inline]
     fn error(&mut self, e: Error, p: usize) -> ResultPos<(&'a [u8], &'a [u8])> {
         self.exit = true;
         Err((e, p))
@@ -173,6 +177,7 @@ pub struct UnescapedAttributes<'a> {
 
 impl<'a> Iterator for UnescapedAttributes<'a> {
     type Item = ResultPos<(&'a [u8], Cow<'a, [u8]>)>;
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -25,7 +25,6 @@ pub struct Attributes<'a> {
 impl<'a> Attributes<'a> {
 
     /// creates a new attribute iterator from a buffer
-    #[inline]
     pub fn new(buf: &'a [u8], pos: usize) -> Attributes<'a> {
         Attributes {
             bytes: buf,
@@ -40,13 +39,11 @@ impl<'a> Attributes<'a> {
     ///
     /// all escaped characters ('&...;') in attribute values are replaced
     /// with their corresponding character
-    #[inline]
     pub fn unescaped(self) -> UnescapedAttributes<'a> {
         UnescapedAttributes { inner: self }
     }
 
     /// check if attributes are distincts
-    #[inline]
     pub fn with_checks(mut self, val: bool) -> Attributes<'a> {
         self.with_checks = val;
         self
@@ -54,7 +51,6 @@ impl<'a> Attributes<'a> {
 
     /// return Err((e, p))
     /// sets `self.exit = true` to terminate the iterator
-    #[inline]
     fn error(&mut self, e: Error, p: usize) -> ResultPos<(&'a [u8], &'a [u8])> {
         self.exit = true;
         Err((e, p))
@@ -177,7 +173,6 @@ pub struct UnescapedAttributes<'a> {
 
 impl<'a> Iterator for UnescapedAttributes<'a> {
     type Item = ResultPos<(&'a [u8], Cow<'a, [u8]>)>;
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,6 @@ impl<'a> ::std::convert::From<&'a str> for XmlReader<&'a [u8]> {
 
 impl<B: BufRead> XmlReader<B> {
     /// Creates a XmlReader from a generic BufReader
-    #[inline]
     pub fn from_reader(reader: B) -> XmlReader<B> {
         XmlReader {
             reader: reader,
@@ -137,7 +136,6 @@ impl<B: BufRead> XmlReader<B> {
     }
 
     /// Converts into a `XmlnsReader` iterator
-    #[inline]
     pub fn namespaced(self) -> XmlnsReader<B> {
         XmlnsReader::new(self)
     }
@@ -146,7 +144,6 @@ impl<B: BufRead> XmlReader<B> {
     ///
     /// When set to true, all `Empty` events are expanded into an `Open` event
     /// followed by a `Close` Event.
-    #[inline]
     pub fn expand_empty_elements(mut self, val: bool) -> XmlReader<B> {
         self.expand_empty_elements = val;
         self
@@ -156,7 +153,6 @@ impl<B: BufRead> XmlReader<B> {
     ///
     /// When set to true, all Text events are trimed.
     /// If they are empty, no event if pushed
-    #[inline]
     pub fn trim_text(mut self, val: bool) -> XmlReader<B> {
         self.trim_text = val;
         self
@@ -167,7 +163,6 @@ impl<B: BufRead> XmlReader<B> {
     /// When set to true, it won't check if End node match last Start node.
     /// If the xml is known to be sane (already processed etc ...)
     /// this saves extra time
-    #[inline]
     pub fn with_check(mut self, val: bool) -> XmlReader<B> {
         self.with_check = val;
         self
@@ -178,7 +173,6 @@ impl<B: BufRead> XmlReader<B> {
     /// When set to true, every Comment event will be checked for not containing `--`
     /// Most of the time we don't want comments at all so we don't really care about
     /// comment correctness, thus default value is false for performance reason
-    #[inline]
     pub fn check_comments(mut self, val: bool) -> XmlReader<B> {
         self.check_comments = val;
         self
@@ -237,7 +231,6 @@ impl<B: BufRead> XmlReader<B> {
 
     /// Gets the current BufRead position
     /// Useful when debugging errors
-    #[inline]
     pub fn buffer_position(&self) -> usize {
         self.buf_position
     }
@@ -435,7 +428,6 @@ impl<B: BufRead> XmlReader<B> {
 
 impl XmlReader<BufReader<File>> {
     /// Creates a xml reader from a file path
-    #[inline]
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<XmlReader<BufReader<File>>> {
         let reader = BufReader::new(try!(File::open(path)));
         Ok(XmlReader::from_reader(reader))
@@ -493,7 +485,6 @@ impl Element {
     /// Creates a new Element from the given name.
     /// name is a reference that can be converted to a byte slice,
     /// such as &[u8] or &str
-    #[inline]
     pub fn new<A>(name: A) -> Element
         where A: AsRef<[u8]>
     {
@@ -518,7 +509,6 @@ impl Element {
     /// over (key, value) tuples.
     /// Key and value can be anything that implements the AsRef<[u8]> trait,
     /// like byte slices and strings.
-    #[inline]
     pub fn with_attributes<K, V, I>(mut self, attributes: I) -> Self
         where K: AsRef<[u8]>,
               V: AsRef<[u8]>,
@@ -529,13 +519,11 @@ impl Element {
     }
 
     /// name as &[u8] (without eventual attributes)
-    #[inline]
     pub fn name(&self) -> &[u8] {
         &self.buf[self.name.clone()]
     }
 
     /// whole content as &[u8] (including eventual attributes)
-    #[inline]
     pub fn content(&self) -> &[u8] {
         &self.buf[self.content.clone()]
     }
@@ -544,20 +532,17 @@ impl Element {
     ///
     /// Searches for '&' into content and try to escape the coded character if possible
     /// returns Malformed error with index within element if '&' is not followed by ';'
-    #[inline]
     pub fn unescaped_content(&self) -> ResultPos<Cow<[u8]>> {
         unescape(self.content())
     }
 
     /// gets attributes iterator
-    #[inline]
     pub fn attributes(&self) -> Attributes {
         Attributes::new(self.content(), self.name.end)
     }
 
     /// gets attributes iterator whose attribute values are unescaped ('&...;' replaced
     /// by their corresponding character)
-    #[inline]
     pub fn unescaped_attributes(&self) -> UnescapedAttributes {
         self.attributes().unescaped()
     }
@@ -579,7 +564,6 @@ impl Element {
     /// consumes entire self (including eventual attributes!) and returns `String`
     ///
     /// useful when we need to get Text event value (which don't have attributes)
-    #[inline]
     pub fn into_string(self) -> Result<String> {
         ::std::string::String::from_utf8(self.buf)
             .map_err(|e| Error::Utf8(e.utf8_error()))
@@ -805,13 +789,11 @@ pub struct XmlWriter<W: Write> {
 
 impl<W: Write> XmlWriter<W> {
     /// Creates a XmlWriter from a generic Write
-    #[inline]
     pub fn new(inner: W) -> XmlWriter<W> {
         XmlWriter { writer: inner }
     }
 
     /// Consumes this `XmlWriter`, returning the underlying writer.
-    #[inline]
     pub fn into_inner(self) -> W {
         self.writer
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ impl<'a> ::std::convert::From<&'a str> for XmlReader<&'a [u8]> {
 
 impl<B: BufRead> XmlReader<B> {
     /// Creates a XmlReader from a generic BufReader
+    #[inline]
     pub fn from_reader(reader: B) -> XmlReader<B> {
         XmlReader {
             reader: reader,
@@ -136,6 +137,7 @@ impl<B: BufRead> XmlReader<B> {
     }
 
     /// Converts into a `XmlnsReader` iterator
+    #[inline]
     pub fn namespaced(self) -> XmlnsReader<B> {
         XmlnsReader::new(self)
     }
@@ -144,6 +146,7 @@ impl<B: BufRead> XmlReader<B> {
     ///
     /// When set to true, all `Empty` events are expanded into an `Open` event
     /// followed by a `Close` Event.
+    #[inline]
     pub fn expand_empty_elements(mut self, val: bool) -> XmlReader<B> {
         self.expand_empty_elements = val;
         self
@@ -153,6 +156,7 @@ impl<B: BufRead> XmlReader<B> {
     ///
     /// When set to true, all Text events are trimed.
     /// If they are empty, no event if pushed
+    #[inline]
     pub fn trim_text(mut self, val: bool) -> XmlReader<B> {
         self.trim_text = val;
         self
@@ -163,6 +167,7 @@ impl<B: BufRead> XmlReader<B> {
     /// When set to true, it won't check if End node match last Start node.
     /// If the xml is known to be sane (already processed etc ...)
     /// this saves extra time
+    #[inline]
     pub fn with_check(mut self, val: bool) -> XmlReader<B> {
         self.with_check = val;
         self
@@ -173,6 +178,7 @@ impl<B: BufRead> XmlReader<B> {
     /// When set to true, every Comment event will be checked for not containing `--`
     /// Most of the time we don't want comments at all so we don't really care about
     /// comment correctness, thus default value is false for performance reason
+    #[inline]
     pub fn check_comments(mut self, val: bool) -> XmlReader<B> {
         self.check_comments = val;
         self
@@ -231,6 +237,7 @@ impl<B: BufRead> XmlReader<B> {
 
     /// Gets the current BufRead position
     /// Useful when debugging errors
+    #[inline]
     pub fn buffer_position(&self) -> usize {
         self.buf_position
     }
@@ -428,6 +435,7 @@ impl<B: BufRead> XmlReader<B> {
 
 impl XmlReader<BufReader<File>> {
     /// Creates a xml reader from a file path
+    #[inline]
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<XmlReader<BufReader<File>>> {
         let reader = BufReader::new(try!(File::open(path)));
         Ok(XmlReader::from_reader(reader))
@@ -485,6 +493,7 @@ impl Element {
     /// Creates a new Element from the given name.
     /// name is a reference that can be converted to a byte slice,
     /// such as &[u8] or &str
+    #[inline]
     pub fn new<A>(name: A) -> Element
         where A: AsRef<[u8]>
     {
@@ -494,6 +503,7 @@ impl Element {
     }
 
     /// private function to create a new element from a buffer.
+    #[inline]
     fn from_buffer(buf: Vec<u8>, start: usize, end: usize, name_end: usize)
         -> Element
     {
@@ -508,6 +518,7 @@ impl Element {
     /// over (key, value) tuples.
     /// Key and value can be anything that implements the AsRef<[u8]> trait,
     /// like byte slices and strings.
+    #[inline]
     pub fn with_attributes<K, V, I>(mut self, attributes: I) -> Self
         where K: AsRef<[u8]>,
               V: AsRef<[u8]>,
@@ -518,11 +529,13 @@ impl Element {
     }
 
     /// name as &[u8] (without eventual attributes)
+    #[inline]
     pub fn name(&self) -> &[u8] {
         &self.buf[self.name.clone()]
     }
 
     /// whole content as &[u8] (including eventual attributes)
+    #[inline]
     pub fn content(&self) -> &[u8] {
         &self.buf[self.content.clone()]
     }
@@ -531,17 +544,20 @@ impl Element {
     ///
     /// Searches for '&' into content and try to escape the coded character if possible
     /// returns Malformed error with index within element if '&' is not followed by ';'
+    #[inline]
     pub fn unescaped_content(&self) -> ResultPos<Cow<[u8]>> {
         unescape(self.content())
     }
 
     /// gets attributes iterator
+    #[inline]
     pub fn attributes(&self) -> Attributes {
         Attributes::new(self.content(), self.name.end)
     }
 
     /// gets attributes iterator whose attribute values are unescaped ('&...;' replaced
     /// by their corresponding character)
+    #[inline]
     pub fn unescaped_attributes(&self) -> UnescapedAttributes {
         self.attributes().unescaped()
     }
@@ -563,6 +579,7 @@ impl Element {
     /// consumes entire self (including eventual attributes!) and returns `String`
     ///
     /// useful when we need to get Text event value (which don't have attributes)
+    #[inline]
     pub fn into_string(self) -> Result<String> {
         ::std::string::String::from_utf8(self.buf)
             .map_err(|e| Error::Utf8(e.utf8_error()))
@@ -687,6 +704,7 @@ impl Event {
     }
 }
 
+#[inline]
 fn is_whitespace(b: u8) -> bool {
     match b {
         b' ' | b'\r' | b'\n' | b'\t' => true,
@@ -787,11 +805,13 @@ pub struct XmlWriter<W: Write> {
 
 impl<W: Write> XmlWriter<W> {
     /// Creates a XmlWriter from a generic Write
+    #[inline]
     pub fn new(inner: W) -> XmlWriter<W> {
         XmlWriter { writer: inner }
     }
 
     /// Consumes this `XmlWriter`, returning the underlying writer.
+    #[inline]
     pub fn into_inner(self) -> W {
         self.writer
     }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -13,6 +13,7 @@ struct Namespace {
 }
 
 impl Namespace {
+    #[inline]
     fn is_match(&self, name: &[u8]) -> bool {
         let len = self.prefix.len();
         name.len() > len && name[len] == b':' && &name[..len] == &*self.prefix
@@ -68,6 +69,7 @@ pub struct XmlnsReader<R: BufRead> {
 
 impl<R: BufRead> XmlnsReader<R> {
     /// Converts a `XmlReader` into a `XmlnsReader` iterator
+    #[inline]
     pub fn new(reader: XmlReader<R>) -> XmlnsReader<R> {
         XmlnsReader {
             reader: reader,

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -69,7 +69,6 @@ pub struct XmlnsReader<R: BufRead> {
 
 impl<R: BufRead> XmlnsReader<R> {
     /// Converts a `XmlReader` into a `XmlnsReader` iterator
-    #[inline]
     pub fn new(reader: XmlReader<R>) -> XmlnsReader<R> {
         XmlnsReader {
             reader: reader,


### PR DESCRIPTION
By adding the `#[inline]` attribute to these one line functions we can improve performance by quite a bit.

Before:
```
test bench_quick_xml            ... bench:     693,300 ns/iter (+/- 144,792)
test bench_quick_xml_escaped    ... bench:     832,738 ns/iter (+/- 449,167)
test bench_quick_xml_namespaced ... bench:     924,916 ns/iter (+/- 293,450)
```

After:
```
test bench_quick_xml            ... bench:     635,208 ns/iter (+/- 120,462)
test bench_quick_xml_escaped    ... bench:     791,582 ns/iter (+/- 366,737)
test bench_quick_xml_namespaced ... bench:     837,721 ns/iter (+/- 267,540)
```