### PR TITLE
Encourage users to use the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Syntax is inspired by [xml-rs](https://github.com/netvl/xml-rs).
 
 ```toml
 [dependencies]
-quick-xml = "0.1.9"
+quick-xml = "0.4.0"
 ```
 ``` rust
 extern crate quick_xml;


### PR DESCRIPTION
The README tells users to install v0.1.9 instead of the latest v0.4.0.