### PR TITLE
Read unescaped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick-xml"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "High performance xml reader and writer"
 


### PR DESCRIPTION
Add a `read_text_unescaped` method to easily escape text content.