### PR TITLE
Handle '>' in attribute values

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 ## master
 - feat: apply default namespaces (`xmlns="..."`) to unqualified elements
 - fix: scope for namespace resolution on empty elements
+- fix: parsing of `>` in attribute values
 
 ## 0.4.2
 - feat: add `into_unescaped_string`

--- a/src/test.rs
+++ b/src/test.rs
@@ -430,3 +430,87 @@ fn test_read_write_roundtrip_results_in_identity() {
     let result = writer.into_inner().into_inner();
     assert_eq!(result, input.as_bytes());
 }
+
+#[test]
+fn test_closing_bracket_in_single_quote_attr() {
+    let mut r = XmlReader::from("<a attr='>' check='2'></a>").trim_text(true);
+    match r.next() {
+        Some(Ok(Start(e))) => {
+            let mut attrs = e.attributes();
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"attr"[..], &b">"[..]), attr),
+                x => panic!("expected attribute 'attr', got {:?}", x)
+            }
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"check"[..], &b"2"[..]), attr),
+                x => panic!("expected attribute 'check', got {:?}", x)
+            }
+            assert!(attrs.next().is_none(), "expected only two attributes");
+        },
+        x => panic!("expected <a attr='>'>, got {:?}", x)
+    }
+    next_eq!(r, End, b"a");
+}
+
+#[test]
+fn test_closing_bracket_in_double_quote_attr() {
+    let mut r = XmlReader::from("<a attr=\">\" check=\"2\"></a>").trim_text(true);
+    match r.next() {
+        Some(Ok(Start(e))) => {
+            let mut attrs = e.attributes();
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"attr"[..], &b">"[..]), attr),
+                x => panic!("expected attribute 'attr', got {:?}", x)
+            }
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"check"[..], &b"2"[..]), attr),
+                x => panic!("expected attribute 'check', got {:?}", x)
+            }
+            assert!(attrs.next().is_none(), "expected only two attributes");
+        },
+        x => panic!("expected <a attr='>'>, got {:?}", x)
+    }
+    next_eq!(r, End, b"a");
+}
+
+#[test]
+fn test_closing_bracket_in_double_quote_mixed() {
+    let mut r = XmlReader::from("<a attr=\"'>'\" check=\"'2'\"></a>").trim_text(true);
+    match r.next() {
+        Some(Ok(Start(e))) => {
+            let mut attrs = e.attributes();
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"attr"[..], &b"'>'"[..]), attr),
+                x => panic!("expected attribute 'attr', got {:?}", x)
+            }
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"check"[..], &b"'2'"[..]), attr),
+                x => panic!("expected attribute 'check', got {:?}", x)
+            }
+            assert!(attrs.next().is_none(), "expected only two attributes");
+        },
+        x => panic!("expected <a attr='>'>, got {:?}", x)
+    }
+    next_eq!(r, End, b"a");
+}
+
+#[test]
+fn test_closing_bracket_in_single_quote_mixed() {
+    let mut r = XmlReader::from("<a attr='\">\"' check='\"2\"'></a>").trim_text(true);
+    match r.next() {
+        Some(Ok(Start(e))) => {
+            let mut attrs = e.attributes();
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"attr"[..], &b"\">\""[..]), attr),
+                x => panic!("expected attribute 'attr', got {:?}", x)
+            }
+            match attrs.next() {
+                Some(Ok(attr)) => assert_eq!((&b"check"[..], &b"\"2\""[..]), attr),
+                x => panic!("expected attribute 'check', got {:?}", x)
+            }
+            assert!(attrs.next().is_none(), "expected only two attributes");
+        },
+        x => panic!("expected <a attr='>'>, got {:?}", x)
+    }
+    next_eq!(r, End, b"a");
+}


### PR DESCRIPTION
When looking for the end of a start/empty tag, we use an alternate
version of `read_until` that employs a small state machine to *not*
match on the end byte ('>') when we are currently in an attribute
value.

Fixes #34

I didn't re-enable the tests mentioned in the issue because they would then fail for other reasons. First because of the comment that seems to be parsed correctly but doesn't appear in the test and then because the CData section doesn't match the expected Text event. `quick-xml`s behaviour seems correct.