### PR TITLE
Add a constructor to XmlDecl

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
 ## master
+- feat: constructor for `XmlDecl`
 
 ## 0.5.0
 - feat: apply default namespaces (`xmlns="..."`) to unqualified elements

--- a/src/test.rs
+++ b/src/test.rs
@@ -262,6 +262,69 @@ fn test_write_attrs() {
 }
 
 #[test]
+fn test_new_xml_decl_full() {
+    let mut writer = XmlWriter::new(Vec::new());
+    writer.write(Decl(super::XmlDecl::new(b"1.2", Some(b"utf-X"), Some(b"yo"))))
+        .expect("writing xml decl should succeed");
+
+    let result = writer.into_inner();
+    assert_eq!(String::from_utf8(result).expect("utf-8 output"),
+        "<?xml version=\"1.2\" encoding=\"utf-X\" standalone=\"yo\"?>".to_owned(),
+        "writer output (LHS)");
+}
+
+#[test]
+fn test_new_xml_decl_standalone() {
+    let mut writer = XmlWriter::new(Vec::new());
+    writer.write(Decl(super::XmlDecl::new(b"1.2", None, Some(b"yo"))))
+        .expect("writing xml decl should succeed");
+
+    let result = writer.into_inner();
+    assert_eq!(String::from_utf8(result).expect("utf-8 output"),
+        "<?xml version=\"1.2\" standalone=\"yo\"?>".to_owned(),
+        "writer output (LHS)");
+}
+
+#[test]
+fn test_new_xml_decl_encoding() {
+    let mut writer = XmlWriter::new(Vec::new());
+    writer.write(Decl(super::XmlDecl::new(b"1.2", Some(b"utf-X"), None)))
+        .expect("writing xml decl should succeed");
+
+    let result = writer.into_inner();
+    assert_eq!(String::from_utf8(result).expect("utf-8 output"),
+        "<?xml version=\"1.2\" encoding=\"utf-X\"?>".to_owned(),
+        "writer output (LHS)");
+}
+
+#[test]
+fn test_new_xml_decl_version() {
+    let mut writer = XmlWriter::new(Vec::new());
+    writer.write(Decl(super::XmlDecl::new(b"1.2", None, None)))
+        .expect("writing xml decl should succeed");
+
+    let result = writer.into_inner();
+    assert_eq!(String::from_utf8(result).expect("utf-8 output"),
+        "<?xml version=\"1.2\"?>".to_owned(),
+        "writer output (LHS)");
+}
+
+/// This test ensures that empty XML declaration attribute values are not a problem.
+#[test]
+fn test_new_xml_decl_empty() {
+    let mut writer = XmlWriter::new(Vec::new());
+    // An empty version should arguably be an error, but we don't expect anyone to actually supply
+    // an empty version.
+    writer.write(Decl(super::XmlDecl::new(b"", Some(b""), Some(b""))))
+        .expect("writing xml decl should succeed");
+
+    let result = writer.into_inner();
+    assert_eq!(String::from_utf8(result).expect("utf-8 output"),
+    "<?xml version=\"\" encoding=\"\" standalone=\"\"?>".to_owned(),
+    "writer output (LHS)");
+}
+
+#[test]
 fn test_buf_position() {
     let mut r = XmlReader::from("</a>")
         .trim_text(true)


### PR DESCRIPTION
Unless I'm overlooking something, there currently does not seem to be any way for a consumer of `quick-xml` to construct a new `XmlDecl` struct for _writing_ an XML document (I can't find a constructor and the `element` field is private). One would have to assemble the declaration as a string and then parse it using the `XmlReader`. Not exactly ideal for 'write-only' use cases.

This patch adds a constructor (`XmlDecl::new`) that assembles the `Element` from the supplied attribute values for _version_, _encoding_ and _standalone_ (the latter two are option, of course). According to the [W3C XML 1.1 spec](http://www.w3.org/TR/xml11/#sec-prolog-dtd), those are the only attributes allowed on an XML declaration

(I'm currently referencing the quick-xml crate via github in my project, so a release on crates.io is not super urgent for me)