### PR TITLE
One vector for all namespaces and prefixes.

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -364,11 +364,7 @@ fn test_namespace() {
     }
 
     if let Some(Ok((Some(a), Start(_)))) = r.next() {
-        if &*a == b"www1" {
-            assert!(true);
-        } else {
-            assert!(false, "expecting namespace to resolve to 'www1'");
-        }
+        assert_eq!(a, b"www1", "expecting namespace to resolve to 'www1'");
     } else {
         assert!(false, "expecting namespace resolution");
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -364,7 +364,8 @@ fn test_namespace() {
     }
 
     if let Some(Ok((Some(a), Start(_)))) = r.next() {
-        assert_eq!(a, b"www1", "expecting namespace to resolve to 'www1'");
+        use std::ops::Deref;
+        assert_eq!(a.deref(), b"www1", "expecting namespace to resolve to 'www1'");
     } else {
         assert!(false, "expecting namespace resolution");
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -170,7 +170,8 @@ fn test_default_ns_shadowing_empty() {
     // <inner att1='a' xmlns='urn:example:i' />
     match r.next() {
         Some(Ok((Some(ns), Empty(e)))) => {
-            assert_eq!(String::from_utf8(ns).unwrap(), "urn:example:i");
+            use std::ops::Deref;
+            assert_eq!(String::from_utf8(ns.deref().clone()).unwrap(), "urn:example:i");
             assert_eq!(e.name(), b"e");
             let mut atts = e.attributes()
                 .map(|ar| ar.expect("Expecting attribute parsing to succeed."))

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -315,6 +315,13 @@ fn test(input: &[u8], output: &[u8], is_short: bool) {
 
     loop {
         let e = reader.next();
+        use std::ops::Deref;
+        let e = match e {
+             Some(Ok((Some(a),b))) => Some(Ok((Some(a.deref().clone()),b))),
+             Some(Err(e)) => Some(Err(e)),
+             Some(Ok((None, b))) => Some(Ok((None, b))),
+             None => None
+        };
         
         let line = format!("{}", OptEvent(e));
 


### PR DESCRIPTION
Allocations are expensive. The iterator over `XmlnsReader` returns a new Vec<u8> at every step. In addition most encountered namespace declarations require two allocations.

This PR changes add one Vec<u8> to the `XmlnsReader`. This vec grows and shrinks as namespaces are added and removed. The struct `Namespace` gets a `NamespaceSlice` instead of `Vec<u8>`.

All tests pass. However, the benchmarks do not show a measurable difference, probably because even ` bench_quick_xml_namespaced` does not use the namespaces.