### PR TITLE
Extend attributes fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ loop {
             let mut elem = BytesStart::owned(b"my_elem".to_vec(), "my_elem".len());
 
             // collect existing attributes
-            elem.with_attributes(e.attributes().map(|attr| attr.unwrap()));
+            elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
 
             // copy existing attributes, adds a new my-key="some value" attribute
             elem.push_attribute(("my-key", "some value"));

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -23,7 +23,7 @@ enum ByteOrChar {
 /// xml escaped characters ('&...;') into their corresponding value
 pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>> {
     let mut escapes = Vec::new();
-    
+
     let mut bytes = raw.iter().enumerate();
     while let Some((i, _)) = bytes.by_ref().find(|&(_, b)| *b == b'&') {
         if let Some((j, _)) = bytes.find(|&(_, &b)| b == b';') {
@@ -36,7 +36,8 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>> {
                 b"apos" => escapes.push((i..j, ByteOrChar::Byte(b'\''))),
                 b"quot" => escapes.push((i..j, ByteOrChar::Byte(b'\"'))),
                 b"#x0" | b"#0" => {
-                    return Err(Escape("Null character entity is not allowed".to_string(), i..j).into())
+                    return Err(Escape("Null character entity is not allowed".to_string(), i..j)
+                        .into())
                 }
                 bytes if bytes.len() > 1 && bytes[0] == b'#' => {
                     let code = if bytes[1] == b'x' {
@@ -46,7 +47,7 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>> {
                     };
                     escapes.push((i..j, ByteOrChar::Char(
                                 code.map_err(|e| Escape(format!("{:?}", e), i..j))?)));
-                },
+                }
                 _ => return Err(Escape("".to_owned(), i..j).into()),
             }
         } else {
@@ -96,7 +97,8 @@ fn push_utf8(buf: &mut Vec<u8>, code: u32) {
 fn test_escape() {
     assert_eq!(&*unescape(b"test").unwrap(), b"test");
     assert_eq!(&*unescape(b"&lt;test&gt;").unwrap(), b"<test>");
-    println!("{}", ::std::str::from_utf8(&*unescape(b"&#xa9;").unwrap()).unwrap());
+    println!("{}",
+             ::std::str::from_utf8(&*unescape(b"&#xa9;").unwrap()).unwrap());
     assert_eq!(&*unescape(b"&#x30;").unwrap(), b"0");
     assert_eq!(&*unescape(b"&#48;").unwrap(), b"0");
 }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -19,13 +19,12 @@ pub struct Attributes<'a> {
     exit: bool,
     /// if true, checks for duplicate names
     with_checks: bool,
-    /// if `with_checks`, contains the ranges corresponding to the 
+    /// if `with_checks`, contains the ranges corresponding to the
     /// attribute names already parsed in this `Element`
     consumed: Vec<Range<usize>>,
 }
 
 impl<'a> Attributes<'a> {
-
     /// creates a new attribute iterator from a buffer
     pub fn new(buf: &'a [u8], pos: usize) -> Attributes<'a> {
         Attributes {
@@ -62,7 +61,6 @@ pub struct Attribute<'a> {
 }
 
 impl<'a> Attribute<'a> {
-
     /// unescapes the value
     pub fn unescaped_value(&self) -> Result<Cow<[u8]>> {
         unescape(self.value)
@@ -73,21 +71,26 @@ impl<'a> Attribute<'a> {
     /// for performance reasons (could avoid allocating a `String`), it might be wiser to manually use
     /// 1. Attributes::unescaped_value()
     /// 2. Reader::decode(...)
-    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>)
-        -> Result<String> {
+    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
         self.unescaped_value().map(|e| reader.decode(&*e).into_owned())
     }
 }
 
-impl<'a> From<(&'a[u8], &'a[u8])> for Attribute<'a> {
-    fn from(val:(&'a[u8], &'a[u8])) -> Attribute<'a> {
-        Attribute { key: val.0, value: val.1 }
+impl<'a> From<(&'a [u8], &'a [u8])> for Attribute<'a> {
+    fn from(val: (&'a [u8], &'a [u8])) -> Attribute<'a> {
+        Attribute {
+            key: val.0,
+            value: val.1,
+        }
     }
 }
 
 impl<'a> From<(&'a str, &'a str)> for Attribute<'a> {
-    fn from(val:(&'a str, &'a str)) -> Attribute<'a> {
-        Attribute { key: val.0.as_bytes(), value: val.1.as_bytes() }
+    fn from(val: (&'a str, &'a str)) -> Attribute<'a> {
+        Attribute {
+            key: val.0.as_bytes(),
+            value: val.1.as_bytes(),
+        }
     }
 }
 
@@ -112,8 +115,7 @@ impl<'a> Iterator for Attributes<'a> {
             let start: usize;
             loop {
                 match iter.next() {
-                    Some((_, b' ')) | Some((_, b'\r')) 
-                        | Some((_, b'\n')) | Some((_, b'\t')) => {
+                    Some((_, b' ')) | Some((_, b'\r')) | Some((_, b'\n')) | Some((_, b'\t')) => {
                         if !found_space {
                             found_space = true;
                         }
@@ -140,8 +142,7 @@ impl<'a> Iterator for Attributes<'a> {
         let mut quote = 0;
         loop {
             match iter.next() {
-                Some((i, b' ')) | Some((i, b'\r')) 
-                    | Some((i, b'\n')) | Some((i, b'\t')) => {
+                Some((i, b' ')) | Some((i, b'\r')) | Some((i, b'\n')) | Some((i, b'\t')) => {
                     if end_key.is_none() {
                         end_key = Some(i);
                     }
@@ -186,8 +187,10 @@ impl<'a> Iterator for Attributes<'a> {
                 .iter()
                 .cloned()
                 .find(|r2| &self.bytes[r2.clone()] == name) {
-                    return Some(self.error(format!("Duplicate attribute at position {} and {}", 
-                                    r2.start, r.start), r.start));
+                return Some(self.error(format!("Duplicate attribute at position {} and {}",
+                                               r2.start,
+                                               r.start),
+                                       r.start));
             }
             self.consumed.push(r.clone());
         }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -21,14 +21,13 @@ pub struct BytesStart<'a> {
     /// content of the element, before any utf8 conversion
     buf: Cow<'a, [u8]>,
     /// end of the element name, the name starts at that the start of `buf`
-    name_len: usize
+    name_len: usize,
 }
 
 impl<'a> BytesStart<'a> {
-
     /// Creates a new `BytesStart` from the given name.
     #[inline]
-    pub fn borrowed(content: &'a[u8], name_len: usize) -> BytesStart<'a> {
+    pub fn borrowed(content: &'a [u8], name_len: usize) -> BytesStart<'a> {
         BytesStart {
             buf: Cow::Borrowed(content),
             name_len: name_len,
@@ -88,7 +87,7 @@ impl<'a> BytesStart<'a> {
     /// like byte slices and strings.
     pub fn extend_attributes<'b, I>(&mut self, attributes: I) -> &mut BytesStart<'a>
         where I: IntoIterator,
-              I::Item: Into<Attribute<'b>>,
+              I::Item: Into<Attribute<'b>>
     {
         for attr in attributes {
             self.push_attribute(attr);
@@ -108,8 +107,7 @@ impl<'a> BytesStart<'a> {
     /// Adds an attribute to this element from the given key and value.
     /// Key and value can be anything that implements the AsRef<[u8]> trait,
     /// like byte slices and strings.
-    pub fn push_attribute<'b, A: Into<Attribute<'b>>>(&mut self, attr: A)
-    {
+    pub fn push_attribute<'b, A: Into<Attribute<'b>>>(&mut self, attr: A) {
         let a = attr.into();
         let bytes = self.buf.to_mut();
         bytes.push(b' ');
@@ -118,7 +116,6 @@ impl<'a> BytesStart<'a> {
         bytes.extend_from_slice(a.value);
         bytes.push(b'"');
     }
-
 }
 
 /// Wrapper around `BytesElement` to parse/write `XmlDecl`
@@ -141,9 +138,12 @@ impl<'a> BytesDecl<'a> {
     pub fn version(&self) -> Result<&[u8]> {
         match self.element.attributes().next() {
             Some(Err(e)) => Err(e),
-            Some(Ok(Attribute { key: b"version", value: v})) => Ok(v),
-            Some(Ok(a)) => Err(format!("XmlDecl must start with 'version' attribute, \
-                                        found {:?}", from_utf8(a.key)).into()),
+            Some(Ok(Attribute { key: b"version", value: v })) => Ok(v),
+            Some(Ok(a)) => {
+                Err(format!("XmlDecl must start with 'version' attribute, found {:?}",
+                            from_utf8(a.key))
+                    .into())
+            }
             None => Err("XmlDecl must start with 'version' attribute, found none".into()),
         }
     }
@@ -153,7 +153,7 @@ impl<'a> BytesDecl<'a> {
         for a in self.element.attributes() {
             match a {
                 Err(e) => return Some(Err(e)),
-                Ok(Attribute { key: b"encoding", value: v}) => return Some(Ok(v)),
+                Ok(Attribute { key: b"encoding", value: v }) => return Some(Ok(v)),
                 _ => (),
             }
         }
@@ -179,12 +179,23 @@ impl<'a> BytesDecl<'a> {
     /// Does not escape any of its inputs. Always uses double quotes to wrap the attribute values.
     /// The caller is responsible for escaping attribute values. Shouldn't usually be relevant since
     /// the double quote character is not allowed in any of the attribute values.
-    pub fn new(version: &[u8], encoding: Option<&[u8]>, standalone: Option<&[u8]>) -> BytesDecl<'static> {
+    pub fn new(version: &[u8],
+               encoding: Option<&[u8]>,
+               standalone: Option<&[u8]>)
+               -> BytesDecl<'static> {
         // Compute length of the buffer based on supplied attributes
         // ' encoding=""'   => 12
-        let encoding_attr_len = if let Some(xs) = encoding { 12 + xs.len() } else { 0 };
+        let encoding_attr_len = if let Some(xs) = encoding {
+            12 + xs.len()
+        } else {
+            0
+        };
         // ' standalone=""' => 14
-        let standalone_attr_len = if let Some(xs) = standalone { 14 + xs.len() } else { 0 };
+        let standalone_attr_len = if let Some(xs) = standalone {
+            14 + xs.len()
+        } else {
+            0
+        };
         // 'xml version=""' => 14
         let mut buf = Vec::with_capacity(14 + encoding_attr_len + standalone_attr_len);
 
@@ -216,7 +227,7 @@ impl<'a> BytesDecl<'a> {
 /// A struct to manage `Event::End` events
 #[derive(Clone, Debug)]
 pub struct BytesEnd<'a> {
-    name: Cow<'a, [u8]>
+    name: Cow<'a, [u8]>,
 }
 
 impl<'a> BytesEnd<'a> {
@@ -242,7 +253,7 @@ impl<'a> BytesEnd<'a> {
 /// A struct to manage `Event::End` events
 #[derive(Clone, Debug)]
 pub struct BytesText<'a> {
-    content: Cow<'a, [u8]>
+    content: Cow<'a, [u8]>,
 }
 
 impl<'a> BytesText<'a> {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -55,10 +55,9 @@ impl<'a> BytesStart<'a> {
     /// over (key, value) tuples.
     /// Key and value can be anything that implements the AsRef<[u8]> trait,
     /// like byte slices and strings.
-    pub fn with_attributes<'b, I>(&mut self, attributes: I) -> &mut Self
+    pub fn with_attributes<'b, I>(mut self, attributes: I) -> Self
         where I: IntoIterator,
-              I::Item: Into<Attribute<'b>>,
-
+              I::Item: Into<Attribute<'b>>
     {
         self.extend_attributes(attributes);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,15 @@
 //! ## Writer
 //!
 //! `Writer`: to write xmls. Can be nested with readers if you want to transform xmls
-//! 
+//!
 //! ## Examples
-//! 
+//!
 //! ### Reader
-//! 
+//!
 //! ```rust
 //! use quick_xml::reader::Reader;
 //! use quick_xml::events::Event;
-//! 
+//!
 //! let xml = r#"<tag1 att1 = "test">
 //!                 <tag2><!--Test comment-->Test</tag2>
 //!                 <tag2>
@@ -59,7 +59,7 @@
 //!     buf.clear();
 //! }
 //! ```
-//! 
+//!
 //! ### Writer
 //!
 //! ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //!             let mut elem = BytesStart::owned(b"my_elem".to_vec(), "my_elem".len());
 //!
 //!             // collect existing attributes
-//!             elem.with_attributes(e.attributes().map(|attr| attr.unwrap()));
+//!             elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
 //!
 //!             // copy existing attributes, adds a new my-key="some value" attribute
 //!             elem.push_attribute(("my-key", "some value"));

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -30,7 +30,7 @@ use events::Event;
 ///             let mut elem = BytesStart::owned(b"my_elem".to_vec(), "my_elem".len());
 ///
 ///             // collect existing attributes
-///             elem.with_attributes(e.attributes().map(|attr| attr.unwrap()));
+///             elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
 ///
 ///             // copy existing attributes, adds a new my-key="some value" attribute
 ///             elem.push_attribute(("my-key", "some value"));

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -46,7 +46,7 @@ use events::Event;
 ///         // or using the buffer
 ///         // Ok(e) => assert!(writer.write(&buf).is_ok()),
 ///
-///         // error are chained, the last one usually being the 
+///         // error are chained, the last one usually being the
 ///         // position where the error has happened
 ///         Err(e) => panic!("{:?}", e.iter().map(|e| format!("{:?} -", e)).collect::<String>()),
 ///     }
@@ -98,8 +98,6 @@ impl<W: Write> Writer<W> {
 
     #[inline]
     fn write_wrapped(&mut self, before: &[u8], value: &[u8], after: &[u8]) -> Result<usize> {
-        Ok(self.writer.write(before)?
-           + self.writer.write(value)?
-           + self.writer.write(after)?)
+        Ok(self.writer.write(before)? + self.writer.write(value)? + self.writer.write(after)?)
     }
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -54,14 +54,14 @@ fn test_start() {
 #[test]
 fn test_start_end() {
     let mut r = Reader::from_str("<a></a>");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
 
 #[test]
 fn test_start_end_attr() {
     let mut r = Reader::from_str("<a b=\"test\"></a>");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
 
@@ -106,14 +106,14 @@ fn test_start_end_comment() {
 #[test]
 fn test_start_txt_end() {
     let mut r = Reader::from_str("<a>test</a>");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, Start, b"a", Text, b"test", End, b"a");
 }
 
 #[test]
 fn test_comment() {
     let mut r = Reader::from_str("<!--test-->");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, Comment, b"test");
 }
 
@@ -122,7 +122,7 @@ fn test_xml_decl() {
     let mut r = Reader::from_str("<?xml version=\"1.0\" encoding='utf-8'?>");
     r.trim_text(true);
     let mut buf = Vec::new();
-	match r.read_event(&mut buf).unwrap() {
+    match r.read_event(&mut buf).unwrap() {
         Decl(ref e) => {
             match e.version() {
                 Ok(v) => {
@@ -154,11 +154,11 @@ fn test_xml_decl() {
 fn test_trim_test() {
     let txt = "<a><b>  </b></a>";
     let mut r = Reader::from_str(txt);
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, Start, b"a", Start, b"b", End, b"b", End, b"a");
 
     let mut r = Reader::from_str(txt);
-	r.trim_text(false);
+    r.trim_text(false);
     next_eq!(r,
              Text,
              b"",
@@ -181,21 +181,21 @@ fn test_trim_test() {
 #[test]
 fn test_cdata() {
     let mut r = Reader::from_str("<![CDATA[test]]>");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, CData, b"test");
 }
 
 #[test]
 fn test_cdata_open_close() {
     let mut r = Reader::from_str("<![CDATA[test <> test]]>");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, CData, b"test <> test");
 }
 
 #[test]
 fn test_start_attr() {
     let mut r = Reader::from_str("<a b=\"c\">");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, Start, b"a");
 }
 
@@ -222,7 +222,7 @@ fn test_nested() {
 fn test_writer() {
     let txt = r#"<?xml version="1.0" encoding="utf-8"?><manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.github.sample" android:versionName="Lollipop" android:versionCode="5.1"><application android:label="SampleApplication"></application></manifest>"#;
     let mut reader = Reader::from_str(txt);
-	reader.trim_text(true);
+    reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
     loop {
@@ -262,7 +262,7 @@ fn test_write_attrs() {
     let str_from = r#"<source attr="val"></source>"#;
     let expected = r#"<copy attr="val" a="b" c="d" x="y"></copy>"#;
     let mut reader = Reader::from_str(str_from);
-	reader.trim_text(true);
+    reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
     loop {
@@ -270,7 +270,8 @@ fn test_write_attrs() {
             Ok(Eof) => break,
             Ok(Start(elem)) => {
                 let mut attrs = elem.attributes()
-                    .collect::<Result<Vec<_>>>().unwrap();
+                    .collect::<Result<Vec<_>>>()
+                    .unwrap();
                 attrs.extend_from_slice(&[("a", "b").into(), ("c", "d").into()]);
                 let mut elem = BytesStart::owned(b"copy".to_vec(), 4);
                 elem.with_attributes(attrs);
@@ -296,8 +297,8 @@ fn test_new_xml_decl_full() {
 
     let result = writer.into_inner();
     assert_eq!(String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\" encoding=\"utf-X\" standalone=\"yo\"?>".to_owned(),
-        "writer output (LHS)");
+               "<?xml version=\"1.2\" encoding=\"utf-X\" standalone=\"yo\"?>".to_owned(),
+               "writer output (LHS)");
 }
 
 #[test]
@@ -308,8 +309,8 @@ fn test_new_xml_decl_standalone() {
 
     let result = writer.into_inner();
     assert_eq!(String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\" standalone=\"yo\"?>".to_owned(),
-        "writer output (LHS)");
+               "<?xml version=\"1.2\" standalone=\"yo\"?>".to_owned(),
+               "writer output (LHS)");
 }
 
 #[test]
@@ -320,8 +321,8 @@ fn test_new_xml_decl_encoding() {
 
     let result = writer.into_inner();
     assert_eq!(String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\" encoding=\"utf-X\"?>".to_owned(),
-        "writer output (LHS)");
+               "<?xml version=\"1.2\" encoding=\"utf-X\"?>".to_owned(),
+               "writer output (LHS)");
 }
 
 #[test]
@@ -332,8 +333,8 @@ fn test_new_xml_decl_version() {
 
     let result = writer.into_inner();
     assert_eq!(String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\"?>".to_owned(),
-        "writer output (LHS)");
+               "<?xml version=\"1.2\"?>".to_owned(),
+               "writer output (LHS)");
 }
 
 /// This test ensures that empty XML declaration attribute values are not a problem.
@@ -347,8 +348,8 @@ fn test_new_xml_decl_empty() {
 
     let result = writer.into_inner();
     assert_eq!(String::from_utf8(result).expect("utf-8 output"),
-    "<?xml version=\"\" encoding=\"\" standalone=\"\"?>".to_owned(),
-    "writer output (LHS)");
+               "<?xml version=\"\" encoding=\"\" standalone=\"\"?>".to_owned(),
+               "writer output (LHS)");
 }
 
 #[test]
@@ -357,9 +358,13 @@ fn test_buf_position() {
     r.trim_text(true).check_end_names(true);
 
     let mut buf = Vec::new();
-	match r.read_event(&mut buf) {
+    match r.read_event(&mut buf) {
         Err(_) if r.buffer_position() == 2 => assert!(true), // error at char 2: no opening tag
-        Err(e) => panic!("expecting buf_pos = 2, found {}, err: {:?}", r.buffer_position(), e),
+        Err(e) => {
+            panic!("expecting buf_pos = 2, found {}, err: {:?}",
+                   r.buffer_position(),
+                   e)
+        }
         e => panic!("expecting error, found {:?}", e),
     }
 
@@ -369,9 +374,13 @@ fn test_buf_position() {
     next_eq!(r, Start, b"a");
 
     let mut buf = Vec::new();
-	match r.read_event(&mut buf) {
+    match r.read_event(&mut buf) {
         Err(_) if r.buffer_position() == 5 => assert!(true), // error at char 5: no closing --> tag found
-        Err(e) => panic!("expecting buf_pos = 5, found {}, err: {:?}", r.buffer_position(), e),
+        Err(e) => {
+            panic!("expecting buf_pos = 5, found {}, err: {:?}",
+                   r.buffer_position(),
+                   e)
+        }
         e => assert!(false, "expecting error, found {:?}", e),
     }
 
@@ -448,9 +457,12 @@ fn test_default_namespace_reset() {
 
     let mut buf = Vec::new();
     if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf) {
-        assert_eq!(&a[..], b"www1", "expecting outer start element with to resolve to 'www1'");
+        assert_eq!(&a[..],
+                   b"www1",
+                   "expecting outer start element with to resolve to 'www1'");
     } else {
-        assert!(false, "expecting outer start element with to resolve to 'www1'");
+        assert!(false,
+                "expecting outer start element with to resolve to 'www1'");
     }
 
     if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf) {
@@ -463,19 +475,22 @@ fn test_default_namespace_reset() {
     }
 
     if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf) {
-        assert_eq!(&a[..], b"www1", "expecting outer end element with to resolve to 'www1'");
+        assert_eq!(&a[..],
+                   b"www1",
+                   "expecting outer end element with to resolve to 'www1'");
     } else {
-        assert!(false, "expecting outer end element with to resolve to 'www1'");
+        assert!(false,
+                "expecting outer end element with to resolve to 'www1'");
     }
 }
 
 #[test]
 fn test_escaped_content() {
     let mut r = Reader::from_str("<a>&lt;test&gt;</a>");
-	r.trim_text(true);
+    r.trim_text(true);
     next_eq!(r, Start, b"a");
     let mut buf = Vec::new();
-	match r.read_event(&mut buf) {
+    match r.read_event(&mut buf) {
         Ok(Text(e)) => {
             if &*e != b"&lt;test&gt;" {
                 panic!("content unexpected: expecting '&lt;test&gt;', got '{:?}'",
@@ -488,12 +503,19 @@ fn test_escaped_content() {
                                from_utf8(c))
                     }
                 }
-                Err(e) => panic!("cannot escape content at position {}: {:?}",
-                                 r.buffer_position(), e),
+                Err(e) => {
+                    panic!("cannot escape content at position {}: {:?}",
+                           r.buffer_position(),
+                           e)
+                }
             }
         }
         Ok(e) => panic!("Expecting text event, got {:?}", e),
-        Err(e) => panic!("Cannot get next event at position {}: {:?}", r.buffer_position(), e),
+        Err(e) => {
+            panic!("Cannot get next event at position {}: {:?}",
+                   r.buffer_position(),
+                   e)
+        }
     }
     next_eq!(r, End, b"a");
 }
@@ -528,22 +550,22 @@ fn test_read_write_roundtrip_results_in_identity() {
 #[test]
 fn test_closing_bracket_in_single_quote_attr() {
     let mut r = Reader::from_str("<a attr='>' check='2'></a>");
-	r.trim_text(true);
+    r.trim_text(true);
     let mut buf = Vec::new();
-	match r.read_event(&mut buf) {
+    match r.read_event(&mut buf) {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("attr", ">").into()),
-                x => panic!("expected attribute 'attr', got {:?}", x)
+                x => panic!("expected attribute 'attr', got {:?}", x),
             }
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("check", "2").into()),
-                x => panic!("expected attribute 'check', got {:?}", x)
+                x => panic!("expected attribute 'check', got {:?}", x),
             }
             assert!(attrs.next().is_none(), "expected only two attributes");
-        },
-        x => panic!("expected <a attr='>'>, got {:?}", x)
+        }
+        x => panic!("expected <a attr='>'>, got {:?}", x),
     }
     next_eq!(r, End, b"a");
 }
@@ -551,22 +573,22 @@ fn test_closing_bracket_in_single_quote_attr() {
 #[test]
 fn test_closing_bracket_in_double_quote_attr() {
     let mut r = Reader::from_str("<a attr=\">\" check=\"2\"></a>");
-	r.trim_text(true);
+    r.trim_text(true);
     let mut buf = Vec::new();
-	match r.read_event(&mut buf) {
+    match r.read_event(&mut buf) {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("attr", ">").into()),
-                x => panic!("expected attribute 'attr', got {:?}", x)
+                x => panic!("expected attribute 'attr', got {:?}", x),
             }
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("check", "2").into()),
-                x => panic!("expected attribute 'check', got {:?}", x)
+                x => panic!("expected attribute 'check', got {:?}", x),
             }
             assert!(attrs.next().is_none(), "expected only two attributes");
-        },
-        x => panic!("expected <a attr='>'>, got {:?}", x)
+        }
+        x => panic!("expected <a attr='>'>, got {:?}", x),
     }
     next_eq!(r, End, b"a");
 }
@@ -574,22 +596,22 @@ fn test_closing_bracket_in_double_quote_attr() {
 #[test]
 fn test_closing_bracket_in_double_quote_mixed() {
     let mut r = Reader::from_str("<a attr=\"'>'\" check=\"'2'\"></a>");
-	r.trim_text(true);
+    r.trim_text(true);
     let mut buf = Vec::new();
     match r.read_event(&mut buf) {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("attr", "'>'").into()),
-                x => panic!("expected attribute 'attr', got {:?}", x)
+                x => panic!("expected attribute 'attr', got {:?}", x),
             }
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("check", "'2'").into()),
-                x => panic!("expected attribute 'check', got {:?}", x)
+                x => panic!("expected attribute 'check', got {:?}", x),
             }
             assert!(attrs.next().is_none(), "expected only two attributes");
-        },
-        x => panic!("expected <a attr='>'>, got {:?}", x)
+        }
+        x => panic!("expected <a attr='>'>, got {:?}", x),
     }
     next_eq!(r, End, b"a");
 }
@@ -597,22 +619,22 @@ fn test_closing_bracket_in_double_quote_mixed() {
 #[test]
 fn test_closing_bracket_in_single_quote_mixed() {
     let mut r = Reader::from_str("<a attr='\">\"' check='\"2\"'></a>");
-	r.trim_text(true);
+    r.trim_text(true);
     let mut buf = Vec::new();
     match r.read_event(&mut buf) {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("attr", "\">\"").into()),
-                x => panic!("expected attribute 'attr', got {:?}", x)
+                x => panic!("expected attribute 'attr', got {:?}", x),
             }
             match attrs.next() {
                 Some(Ok(attr)) => assert_eq!(attr, ("check", "\"2\"").into()),
-                x => panic!("expected attribute 'check', got {:?}", x)
+                x => panic!("expected attribute 'check', got {:?}", x),
             }
             assert!(attrs.next().is_none(), "expected only two attributes");
-        },
-        x => panic!("expected <a attr='>'>, got {:?}", x)
+        }
+        x => panic!("expected <a attr='>'>, got {:?}", x),
     }
     next_eq!(r, End, b"a");
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -274,7 +274,7 @@ fn test_write_attrs() {
                     .unwrap();
                 attrs.extend_from_slice(&[("a", "b").into(), ("c", "d").into()]);
                 let mut elem = BytesStart::owned(b"copy".to_vec(), 4);
-                elem.with_attributes(attrs);
+                elem.extend_attributes(attrs);
                 elem.push_attribute(("x", "y"));
                 Start(elem)
             }


### PR DESCRIPTION
This is a **breaking change**. `with_attributes` is documented as consuming `self`, but it in fact takes a `&mut self`. This makes it effectively the same as `extend_attributes` (which it is implemented in terms of). This patch changes `with_attributes` to consume `self`, and updates spurious usage of `with_attributes` to be `extend_attributes` in tests & doctests.