### PR TITLE
Have read_namespace_event borrow the ns buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick-xml"
-version = "0.7.3"
+version = "0.8.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "High performance xml reader and writer"
 
@@ -16,11 +16,11 @@ license-file = "LICENSE-MIT.md"
 travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
-encoding_rs = "0.6.6"
+encoding_rs = "0.6.11"
 error-chain = "0.10.0"
 
 [dev-dependencies]
-xml-rs = "0.4.1"
+xml-rs = "0.6.0"
 
 [lib]
 bench = false

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## 0.8.0
+- fix: make the reader borrow the namespace buffer so it can be used repetitively
+
 ## 0.7.3
 - fix: fix Event::Text slice always starting at the beginning of the buffer
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 ## 0.8.0
 - fix: make the reader borrow the namespace buffer so it can be used repetitively
+- refactor: bump dependencies
 
 ## 0.7.3
 - fix: fix Event::Text slice always starting at the beginning of the buffer

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Syntax is inspired by [xml-rs](https://github.com/netvl/xml-rs).
 
 ```toml
 [dependencies]
-quick-xml = "0.7.0"
+quick-xml = "0.8.0"
 ```
 ``` rust
 extern crate quick_xml;
@@ -49,11 +49,7 @@ let mut buf = Vec::new();
 // The `Reader` does not implement `Iterator` because it outputs borrowed data (`Cow`s)
 loop {
     match reader.read_event(&mut buf) {
-    // for triggering namespaced events, use this instead:
-    // match reader.read_namespaced_event(&mut buf) {
         Ok(Event::Start(ref e)) => {
-        // for namespaced:
-        // Ok((ref namespace_value, Event::Start(ref e)))
             match e.name() {
                 b"tag1" => println!("attributes values: {:?}",
                                     e.attributes().map(|a| a.unwrap().value).collect::<Vec<_>>()),

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -36,8 +36,9 @@ fn bench_quick_xml_namespaced(b: &mut Bencher) {
         r.check_end_names(false).check_comments(false);
         let mut count = test::black_box(0);
         let mut buf = Vec::new();
+        let mut ns_buf = Vec::new();
         loop {
-            match r.read_namespaced_event(&mut buf) {
+            match r.read_namespaced_event(&mut buf, &mut ns_buf) {
                 Ok((_, Event::Start(_))) |
                 Ok((_, Event::Empty(_))) => count += 1,
                 Ok((_, Event::Eof)) => break,

--- a/examples/issue68.rs
+++ b/examples/issue68.rs
@@ -121,7 +121,7 @@ fn parse_report(xml_data: &str) -> Vec<Resource> {
 fn main() {
     let test_data = r#"
 <?xml version="1.0" encoding="UTF-8"?>
-<d:multistatus xmlns:d="dav:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
+<D:multistatus xmlns:D="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
     xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
  <D:response xmlns:carddav="urn:ietf:params:xml:ns:carddav"
     xmlns:cm="http://cal.me.com/_namespace/" xmlns:md="urn:mobileme:davservices">

--- a/examples/issue68.rs
+++ b/examples/issue68.rs
@@ -119,11 +119,11 @@ fn parse_report(xml_data: &str) -> Vec<Resource> {
 }
 
 fn main() {
-    let test_data = r#" 
+    let test_data = r#"
 <?xml version="1.0" encoding="UTF-8"?>
-<D:multistatus xmlns:D="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav" 
+<D:multistatus xmlns:D="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
     xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
- <D:response xmlns:carddav="urn:ietf:params:xml:ns:carddav" 
+ <D:response xmlns:carddav="urn:ietf:params:xml:ns:carddav"
     xmlns:cm="http://cal.me.com/_namespace/" xmlns:md="urn:mobileme:davservices">
   <D:href>
   /caldav/v2/johndoh%40gmail.com/events/07b7it7uonpnlnvjldr0l1ckg8%40google.com.ics

--- a/examples/issue68.rs
+++ b/examples/issue68.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 extern crate quick_xml;
 
 use quick_xml::reader::Reader;
@@ -74,7 +76,6 @@ fn parse_report(xml_data: &str) -> Vec<Resource> {
 
     let mut responses = Vec::<Response>::new();
     let mut current_response = Response::new();
-    let mut current_prop_stat = PropStat::new();
     let mut current_prop = Prop::new();
 
     let mut depth = 0;

--- a/examples/issue68.rs
+++ b/examples/issue68.rs
@@ -121,7 +121,7 @@ fn parse_report(xml_data: &str) -> Vec<Resource> {
 fn main() {
     let test_data = r#"
 <?xml version="1.0" encoding="UTF-8"?>
-<D:multistatus xmlns:D="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
+<d:multistatus xmlns:d="dav:" xmlns:caldav="urn:ietf:params:xml:ns:caldav"
     xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
  <D:response xmlns:carddav="urn:ietf:params:xml:ns:carddav"
     xmlns:cm="http://cal.me.com/_namespace/" xmlns:md="urn:mobileme:davservices">

--- a/examples/issue68.rs
+++ b/examples/issue68.rs
@@ -121,9 +121,13 @@ fn parse_report(xml_data: &str) -> Vec<Resource> {
 fn main() {
     let test_data = r#" 
 <?xml version="1.0" encoding="UTF-8"?>
-<D:multistatus xmlns:D="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
- <D:response xmlns:carddav="urn:ietf:params:xml:ns:carddav" xmlns:cm="http://cal.me.com/_namespace/" xmlns:md="urn:mobileme:davservices">
-  <D:href>/caldav/v2/johndoh%40gmail.com/events/07b7it7uonpnlnvjldr0l1ckg8%40google.com.ics</D:href>
+<D:multistatus xmlns:D="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav" 
+    xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
+ <D:response xmlns:carddav="urn:ietf:params:xml:ns:carddav" 
+    xmlns:cm="http://cal.me.com/_namespace/" xmlns:md="urn:mobileme:davservices">
+  <D:href>
+  /caldav/v2/johndoh%40gmail.com/events/07b7it7uonpnlnvjldr0l1ckg8%40google.com.ics
+  </D:href>
   <D:propstat>
    <D:status>HTTP/1.1 200 OK</D:status>
    <D:prop>

--- a/examples/issue68.rs
+++ b/examples/issue68.rs
@@ -1,0 +1,138 @@
+extern crate quick_xml;
+
+use quick_xml::reader::Reader;
+use quick_xml::events::Event;
+use std::io::Read;
+
+struct Resource {
+    etag: String,
+    calendar_data: String,
+}
+
+struct Prop {
+    namespace: String,
+    local_name: String,
+    value: String,
+}
+
+impl Prop {
+    fn new() -> Prop {
+        Prop {
+            namespace: String::new(),
+            local_name: String::new(),
+            value: String::new(),
+        }
+    }
+}
+
+struct PropStat {
+    status: String,
+    props: Vec<Prop>,
+}
+
+impl PropStat {
+    fn new() -> PropStat {
+        PropStat {
+            status: String::new(),
+            props: Vec::<Prop>::new(),
+        }
+    }
+}
+
+struct Response {
+    href: String,
+    propstats: Vec<PropStat>,
+}
+
+impl Response {
+    fn new() -> Response {
+        Response {
+            href: String::new(),
+            propstats: Vec::<PropStat>::new(),
+        }
+    }
+}
+
+fn parse_report(xml_data: &str) -> Vec<Resource> {
+    let result = Vec::<Resource>::new();
+
+    let mut reader = Reader::from_str(xml_data);
+    reader.trim_text(true);
+
+    let mut count = 0;
+    let mut buf = Vec::new();
+    let mut ns_buffer = Vec::new();
+
+    #[derive(Clone, Copy)]
+    enum State {
+        Root,
+        MultiStatus,
+        Response,
+        Success,
+        Error,
+    };
+
+    let mut responses = Vec::<Response>::new();
+    let mut current_response = Response::new();
+    let mut current_prop_stat = PropStat::new();
+    let mut current_prop = Prop::new();
+
+    let mut depth = 0;
+    let mut state = State::MultiStatus;
+
+    loop {
+
+        match reader.read_namespaced_event(&mut buf, &mut ns_buffer) {
+            Ok((namespace_value, Event::Start(e))) => {
+                let namespace_value = namespace_value.unwrap_or_default();
+                match (depth, state, namespace_value, e.local_name()) {
+                    (0, State::Root, b"DAV:", b"multistatus") => state = State::MultiStatus,
+                    (1, State::MultiStatus, b"DAV:", b"response") => {
+                        state = State::Response;
+                        current_response = Response::new();
+                    }
+                    (2, State::Response, b"DAV:", b"href") => {
+                        current_response.href = e.unescape_and_decode(&reader).unwrap();
+                    }
+                    _ => {}
+                }
+                depth += 1;
+            }
+            Ok((namespace_value, Event::End(e))) => {
+                let namespace_value = namespace_value.unwrap_or_default();
+                let local_name = e.local_name();
+                match (depth, state, &*namespace_value, local_name) {
+                    (1, State::MultiStatus, b"DAV:", b"multistatus") => state = State::Root,
+                    (2, State::MultiStatus, b"DAV:", b"multistatus") => state = State::MultiStatus,
+                    _ => {}
+                }
+                depth -= 1;
+            }
+            Ok((_, Event::Eof)) => break,
+            Err(e) => break,
+            _ => (),
+        }
+
+    }
+    result
+}
+
+fn main() {
+    let test_data = r#" 
+<?xml version="1.0" encoding="UTF-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
+ <D:response xmlns:carddav="urn:ietf:params:xml:ns:carddav" xmlns:cm="http://cal.me.com/_namespace/" xmlns:md="urn:mobileme:davservices">
+  <D:href>/caldav/v2/johndoh%40gmail.com/events/07b7it7uonpnlnvjldr0l1ckg8%40google.com.ics</D:href>
+  <D:propstat>
+   <D:status>HTTP/1.1 200 OK</D:status>
+   <D:prop>
+    <D:getetag>"63576798396"</D:getetag>
+    <caldav:calendar-data>BEGIN:VCALENDAR</caldav:calendar-data>
+   </D:prop>
+  </D:propstat>
+ </D:response>
+</D:multistatus>
+"#;
+
+    parse_report(test_data);
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -406,8 +406,7 @@ fn local_name() {
     let mut buf = Vec::new();
     let mut parsed_local_names = Vec::new();
     loop {
-        match rdr.read_event(&mut buf)
-                  .expect("unable to read xml event") {
+        match rdr.read_event(&mut buf).expect("unable to read xml event") {
             Event::Start(ref e) => {
                 parsed_local_names.push(from_utf8(e.local_name())
                                             .expect("unable to build str from local_name")

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -157,7 +157,7 @@ impl<'a> BytesDecl<'a> {
             Some(Ok(a)) => {
                 Err(format!("XmlDecl must start with 'version' attribute, found {:?}",
                             from_utf8(a.key))
-                            .into())
+                        .into())
             }
             None => Err("XmlDecl must start with 'version' attribute, found none".into()),
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -155,9 +155,7 @@ impl<B: BufRead> Reader<B> {
             Ok(n) => {
                 self.buf_position += n;
                 let (start, len) = if self.trim_text {
-                    match buf.iter()
-                              .skip(buf_start)
-                              .position(|&b| !is_whitespace(b)) {
+                    match buf.iter().skip(buf_start).position(|&b| !is_whitespace(b)) {
                         Some(start) => {
                             (buf_start + start,
                              buf.iter()
@@ -319,10 +317,7 @@ impl<B: BufRead> Reader<B> {
                     Ok(Event::CData(BytesText::borrowed(&buf[buf_start + 8..len - 2])))
                 }
                 b"DOCTYPE" => {
-                    let mut count = buf.iter()
-                        .skip(buf_start)
-                        .filter(|&&b| b == b'<')
-                        .count();
+                    let mut count = buf.iter().skip(buf_start).filter(|&&b| b == b'<').count();
                     while count > 0 {
                         buf.push(b'>');
                         match read_until(&mut self.reader, b'>', buf) {
@@ -384,9 +379,7 @@ impl<B: BufRead> Reader<B> {
     fn read_start<'a, 'b>(&'a mut self, buf: &'b [u8]) -> Result<Event<'b>> {
         // TODO: do this directly when reading bufreader ...
         let len = buf.len();
-        let name_end = buf.iter()
-            .position(|&b| is_whitespace(b))
-            .unwrap_or(len);
+        let name_end = buf.iter().position(|&b| is_whitespace(b)).unwrap_or(len);
         if let Some(&b'/') = buf.last() {
             let end = if name_end < len { name_end } else { len - 1 };
             if self.expand_empty_elements {
@@ -527,7 +520,7 @@ impl<B: BufRead> Reader<B> {
     pub fn decode<'b, 'c>(&'b self, bytes: &'c [u8]) -> Cow<'c, str> {
         self.encoding.decode(bytes).0
     }
-    
+
     /// Reads until end element is found
     ///
     /// Manages nested cases where parent and child elements have the same name
@@ -813,9 +806,7 @@ impl NamespaceBufferIndex {
         self.nesting_level -= 1;
         let current_level = self.nesting_level;
         // from the back (most deeply nested scope), look for the first scope that is still valid
-        match self.slices
-                  .iter()
-                  .rposition(|n| n.level <= current_level) {
+        match self.slices.iter().rposition(|n| n.level <= current_level) {
             // none of the namespaces are valid, remove all of them
             None => {
                 buffer.clear();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -651,7 +651,7 @@ fn read_until<R: BufRead>(r: &mut R, byte: u8, buf: &mut Vec<u8>) -> Result<usiz
 /// level)
 #[inline]
 fn read_elem_until<R: BufRead>(r: &mut R, end_byte: u8, buf: &mut Vec<u8>) -> Result<usize> {
-    #[derive(Debug,Clone,Copy,PartialEq,Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum ElemReadState {
         /// The initial state (inside element, but outside of attribute value)
         Elem,
@@ -759,7 +759,7 @@ impl Namespace {
             None
         } else {
             Some(&ns_buffer[self.start + self.prefix_len..
-                  self.start + self.prefix_len + self.value_len])
+                            self.start + self.prefix_len + self.value_len])
         }
     }
 }
@@ -834,25 +834,23 @@ impl NamespaceBufferIndex {
                         None => {
                             let start = buffer.len();
                             buffer.extend_from_slice(v);
-                            self.slices
-                                .push(Namespace {
-                                          start: start,
-                                          prefix_len: 0,
-                                          value_len: v.len(),
-                                          level: level,
-                                      });
+                            self.slices.push(Namespace {
+                                                 start: start,
+                                                 prefix_len: 0,
+                                                 value_len: v.len(),
+                                                 level: level,
+                                             });
                         }
                         Some(&b':') => {
                             let start = buffer.len();
                             buffer.extend_from_slice(&k[6..]);
                             buffer.extend_from_slice(v);
-                            self.slices
-                                .push(Namespace {
-                                          start: start,
-                                          prefix_len: k.len() - 6,
-                                          value_len: v.len(),
-                                          level: level,
-                                      });
+                            self.slices.push(Namespace {
+                                                 start: start,
+                                                 prefix_len: k.len() - 6,
+                                                 value_len: v.len(),
+                                                 level: level,
+                                             });
                         }
                         _ => break,
                     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -470,6 +470,46 @@ impl<B: BufRead> Reader<B> {
     }
 
     /// Reads the next event and resolve its namespace
+    ///
+    /// # Examples
+    /// ```
+    /// use std::str::from_utf8;
+    /// use quick_xml::reader::Reader;
+    /// use quick_xml::events::Event;
+    ///
+    /// let xml = r#"<x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
+    ///                 <y:tag2><!--Test comment-->Test</y:tag2>
+    ///                 <y:tag2>Test 2</y:tag2>
+    ///             </x:tag1>"#;
+    /// let mut reader = Reader::from_str(xml);
+    /// reader.trim_text(true);
+    /// let mut count = 0;
+    /// let mut buf = Vec::new();
+    /// let mut ns_buf = Vec::new();
+    /// let mut txt = Vec::new();
+    /// loop {
+    ///     match reader.read_namespaced_event(&mut buf, &mut ns_buf) {
+    ///         Ok((ref ns, Event::Start(ref e))) => {
+    ///             count += 1;
+    ///             match (*ns, e.local_name()) {
+    ///                 (Some(b"www.xxxx"), b"tag1") => (),
+    ///                 (Some(b"www.yyyy"), b"tag2") => (),
+    ///                 (ns, n) => panic!("Namespace and local name mismatch"),
+    ///             }
+    ///             println!("Resolved namespace: {:?}", ns.and_then(|ns| from_utf8(ns).ok()));
+    ///         }
+    ///         Ok((_, Event::Text(e))) => {
+    ///             txt.push(e.unescape_and_decode(&reader).expect("Error!"))
+    ///         },
+    ///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+    ///         Ok((_, Event::Eof)) => break,
+    ///         _ => (),
+    ///     }
+    ///     buf.clear();
+    /// }
+    /// println!("Found {} start events", count);
+    /// println!("Text events: {:?}", txt);
+    /// ```
     pub fn read_namespaced_event<'a, 'b, 'c>(&'a mut self,
                                              buf: &'b mut Vec<u8>,
                                              namespace_buffer: &'c mut Vec<u8>)

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -400,12 +400,13 @@ fn test_namespace() {
     r.trim_text(true);;
 
     let mut buf = Vec::new();
-    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf) {
+    let mut ns_buf = Vec::new();
+    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
         assert!(false, "expecting start element with no namespace");
     }
 
-    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf) {
+    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
         if &*a == b"www1" {
             assert!(true);
         } else {
@@ -423,13 +424,14 @@ fn test_default_namespace() {
 
     // <a>
     let mut buf = Vec::new();
-    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf) {
+    let mut ns_buf = Vec::new();
+    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
         assert!(false, "expecting outer start element with no namespace");
     }
 
     // <b>
-    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf) {
+    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
         if &*a == b"www1" {
             assert!(true);
         } else {
@@ -440,7 +442,7 @@ fn test_default_namespace() {
     }
 
     // </b>
-    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf) {
+    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
         if &*a == b"www1" {
             assert!(true);
         } else {
@@ -452,7 +454,7 @@ fn test_default_namespace() {
 
     // </a> very important: a should not be in any namespace. The default namespace only applies to
     // the sub-document it is defined on.
-    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf) {
+    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
         assert!(false, "expecting outer end element with no namespace");
     }
@@ -464,7 +466,8 @@ fn test_default_namespace_reset() {
     r.trim_text(true);;
 
     let mut buf = Vec::new();
-    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf) {
+    let mut ns_buf = Vec::new();
+    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
         assert_eq!(&a[..],
                    b"www1",
                    "expecting outer start element with to resolve to 'www1'");
@@ -473,16 +476,16 @@ fn test_default_namespace_reset() {
                 "expecting outer start element with to resolve to 'www1'");
     }
 
-    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf) {
+    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
         assert!(false, "expecting inner start element");
     }
-    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf) {
+    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
         assert!(false, "expecting inner end element");
     }
 
-    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf) {
+    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
         assert_eq!(&a[..],
                    b"www1",
                    "expecting outer end element with to resolve to 'www1'");

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -134,7 +134,7 @@ fn issue_83_duplicate_attributes() {
 
 #[test]
 fn issue_93_large_characters_in_entity_references() {
-    test(r#"<hello>&𤶼;</hello>"#.as_bytes(),
+    test(r#"<hello>&ð¤¶¼;</hello>"#.as_bytes(),
          br#"
             |StartElement(hello)
             |1:10 Error while escaping character at range 0..5:
@@ -270,6 +270,7 @@ fn test(input: &[u8], output: &[u8], is_short: bool) {
         .enumerate();
 
     let mut buf = Vec::new();
+    let mut ns_buffer = Vec::new();
 
     if !is_short {
         reader.read_event(&mut buf).unwrap();
@@ -278,7 +279,7 @@ fn test(input: &[u8], output: &[u8], is_short: bool) {
     loop {
         {
             let line = {
-                let e = reader.read_namespaced_event(&mut buf);
+                let e = reader.read_namespaced_event(&mut buf, &mut ns_buffer);
                 format!("{}", OptEvent(e))
             };
             if let Some((n, spec)) = spec_lines.next() {

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -305,11 +305,10 @@ fn test(input: &[u8], output: &[u8], is_short: bool) {
             if !is_short && line.starts_with("StartDocument") {
                 // advance next Characters(empty space) ...
                 if let Ok(Event::Text(ref e)) = reader.read_event(&mut buf) {
-                    if e.iter()
-                           .any(|b| match *b {
-                                    b' ' | b'\r' | b'\n' | b'\t' => false,
-                                    _ => true,
-                                }) {
+                    if e.iter().any(|b| match *b {
+                                        b' ' | b'\r' | b'\n' | b'\t' => false,
+                                        _ => true,
+                                    }) {
                         panic!("Reader expects empty Text event after a StartDocument");
                     }
                 } else {

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -134,7 +134,7 @@ fn issue_83_duplicate_attributes() {
 
 #[test]
 fn issue_93_large_characters_in_entity_references() {
-    test(r#"<hello>&ð¤¶¼;</hello>"#.as_bytes(),
+    test(r#"<hello>&𤶼;</hello>"#.as_bytes(),
          br#"
             |StartElement(hello)
             |1:10 Error while escaping character at range 0..5:


### PR DESCRIPTION
The current situation, where the reader owns the namespace buffer leads to an inconvenient api.

In the inner loop of the `read_namespaced_event`, the reader, mutably borrowed cannot be used, notably for decoding the event. The workaround, having temporary variables is not satisfactory (more boilerplate and additional checks).

Making the caller own the buffer fixes the situation, while still avoiding extra allocation.

See #68