### PR TITLE
use license identifier instead of file in Metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tafia/quick-xml"
 readme = "README.md"
 keywords = ["xml", "reader", "parser", "writer", "html"]
 categories = ["encoding", "parsing", "text-processing"]
-license-file = "LICENSE-MIT.md"
+license = "MIT"
 
 [badges]
 travis-ci = { repository = "tafia/quick-xml" }


### PR DESCRIPTION
This will help the cargo `license` subcommand to correctly identify this as an MIT license, instead of non-standard. Great job with the library by the way. Helped me speed up parsing xml files by factor 30.