### PR TITLE
Allow writer to borrow Event, using Deref

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -76,7 +76,9 @@ impl<W: Write> Writer<W> {
     }
 
     /// Writes the given event to the underlying writer.
-    pub fn write_event<'a, E: Deref<Event<'a>>>(&mut self, event: E) -> Result<usize> {
+    pub fn write_event<'a, E>(&mut self, event: E) -> Result<usize>
+        where E: Deref<Target = Event<'a>>
+    {
         match *event {
             Event::Start(ref e) => self.write_wrapped(b"<", e, b">"),
             Event::End(ref e) => self.write_wrapped(b"</", e, b">"),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 
 use errors::Result;
 use events::Event;
+use std::ops::Deref;
 
 /// Xml writer
 ///
@@ -75,8 +76,8 @@ impl<W: Write> Writer<W> {
     }
 
     /// Writes the given event to the underlying writer.
-    pub fn write_event(&mut self, event: Event) -> Result<usize> {
-        match event {
+    pub fn write_event<'a, E: Deref<Event<'a>>(&mut self, event: E) -> Result<usize> {
+        match *event {
             Event::Start(ref e) => self.write_wrapped(b"<", e, b">"),
             Event::End(ref e) => self.write_wrapped(b"</", e, b">"),
             Event::Empty(ref e) => self.write_wrapped(b"<", e, b"/>"),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -76,7 +76,7 @@ impl<W: Write> Writer<W> {
     }
 
     /// Writes the given event to the underlying writer.
-    pub fn write_event<'a, E: Deref<Event<'a>>(&mut self, event: E) -> Result<usize> {
+    pub fn write_event<'a, E: Deref<Event<'a>>>(&mut self, event: E) -> Result<usize> {
         match *event {
             Event::Start(ref e) => self.write_wrapped(b"<", e, b">"),
             Event::End(ref e) => self.write_wrapped(b"</", e, b">"),


### PR DESCRIPTION
This pull request strictly improves the current situation (shouldn't be a breaking change).  

Will probably fix situations like https://github.com/tafia/quick-xml/pull/56#issuecomment-310488378