### PR TITLE
Allow writer to borrow event

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## master
+- feat: allow `Writer` to borrow `Event` (using `AsRef<Event>`)
+
 ## 0.8.0
 - fix: make the reader borrow the namespace buffer so it can be used repetitively
 - refactor: bump dependencies

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -42,10 +42,8 @@ use events::Event;
 ///             assert!(writer.write_event(Event::End(BytesEnd::borrowed(b"my_elem"))).is_ok());
 ///         },
 ///         Ok(Event::Eof) => break,
-///         Ok(e) => assert!(writer.write_event(e).is_ok()),
-///         // or using the buffer
-///         // Ok(e) => assert!(writer.write(&buf).is_ok()),
-///
+///         // we can either move or borrow the event to write, depending on your use-case
+///         Ok(e) => assert!(writer.write_event(&e).is_ok()),
 ///         // error are chained, the last one usually being the
 ///         // position where the error has happened
 ///         Err(e) => panic!("{:?}", e.iter().map(|e| format!("{:?} -", e)).collect::<String>()),
@@ -75,7 +73,7 @@ impl<W: Write> Writer<W> {
     }
 
     /// Writes the given event to the underlying writer.
-    pub fn write_event(&mut self, event: Event) -> Result<usize> {
+    pub fn write_event<'a, E: AsRef<Event<'a>>>(&mut self, event: E) -> Result<usize> {
         match event {
             Event::Start(ref e) => self.write_wrapped(b"<", e, b">"),
             Event::End(ref e) => self.write_wrapped(b"</", e, b">"),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -74,7 +74,7 @@ impl<W: Write> Writer<W> {
 
     /// Writes the given event to the underlying writer.
     pub fn write_event<'a, E: AsRef<Event<'a>>>(&mut self, event: E) -> Result<usize> {
-        match *event {
+        match *event.as_ref() {
             Event::Start(ref e) => self.write_wrapped(b"<", e, b">"),
             Event::End(ref e) => self.write_wrapped(b"</", e, b">"),
             Event::Empty(ref e) => self.write_wrapped(b"<", e, b"/>"),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -74,7 +74,7 @@ impl<W: Write> Writer<W> {
 
     /// Writes the given event to the underlying writer.
     pub fn write_event<'a, E: AsRef<Event<'a>>>(&mut self, event: E) -> Result<usize> {
-        match event {
+        match *event {
             Event::Start(ref e) => self.write_wrapped(b"<", e, b">"),
             Event::End(ref e) => self.write_wrapped(b"</", e, b">"),
             Event::Empty(ref e) => self.write_wrapped(b"<", e, b"/>"),

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -240,6 +240,25 @@ fn test_writer() {
 }
 
 #[test]
+fn test_writer_borrow() {
+    let txt = include_str!("../tests/documents/test_writer.xml").trim();
+    let mut reader = Reader::from_str(txt);
+    reader.trim_text(true);
+    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(Eof) => break,
+            Ok(e) => assert!(writer.write_event(&e).is_ok()), // either `e` or `&e`
+            Err(e) => panic!(e),
+        }
+    }
+
+    let result = writer.into_inner().into_inner();
+    assert_eq!(result, txt.as_bytes());
+}
+
+#[test]
 fn test_write_empty_element_attrs() {
     let str_from = r#"<source attr="val"/>"#;
     let expected = r#"<source attr="val"/>"#;


### PR DESCRIPTION
should fix https://github.com/tafia/quick-xml/pull/56#issuecomment-310488378