### PR TITLE
add getter for encoding to reader

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -550,6 +550,13 @@ impl<B: BufRead> Reader<B> {
         }
     }
 
+    /// Returns the `Reader`s encoding
+    ///
+    /// The used encoding may change after parsing the xml declaration
+    pub fn encoding(&self) -> &'static Encoding {
+        self.encoding
+    }
+
     /// Decodes a slice using the xml specified encoding
     ///
     /// Decode complete input to Cow<'a, str> with BOM sniffing and with malformed sequences


### PR DESCRIPTION
closes issue #79.

A second PR replacing #80 without messed up formatting, sorry for all that. That is a nifty `.travis.yml` you got there! I'll adopt some of it for my projects ;-).