### PR TITLE
Use memchr in reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ error-chain = "0.10.0"
 memchr = "1.0.1"
 
 [dev-dependencies]
-xml-rs = "0.6.0"
+xml-rs = "0.6.1"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ travis-ci = { repository = "tafia/quick-xml" }
 [dependencies]
 encoding_rs = "0.6.11"
 error-chain = "0.10.0"
+memchr = "1.0.1"
 
 [dev-dependencies]
 xml-rs = "0.6.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## master
+- perf: use memchr crate and rewrite some loops with iterators
+- docs: remove duplicate `Reader` doc in lib.rs
+
 ## 0.9.0
 - feat: add getter for encoding to reader
 - feat: escape Text events on write (breaking change)

--- a/README.md
+++ b/README.md
@@ -117,16 +117,16 @@ assert_eq!(result, expected.as_bytes());
 
 ## Performance
 
-quick-xml is around **40 times faster** than [xml-rs](https://crates.io/crates/xml-rs) crate.
+quick-xml is around **50 times faster** than [xml-rs](https://crates.io/crates/xml-rs) crate.
 
 ```
 // quick-xml benches
-test bench_quick_xml            ... bench:     336,590 ns/iter (+/- 15,800)
-test bench_quick_xml_escaped    ... bench:     433,673 ns/iter (+/- 17,880)
-test bench_quick_xml_namespaced ... bench:     501,155 ns/iter (+/- 107,318)
+test bench_quick_xml            ... bench:     256,921 ns/iter (+/- 18,306)
+test bench_quick_xml_escaped    ... bench:     324,320 ns/iter (+/- 19,968)
+test bench_quick_xml_namespaced ... bench:     396,318 ns/iter (+/- 23,663)
 
 // same bench with xml-rs
-test bench_xml_rs               ... bench:  13,022,289 ns/iter (+/- 1,532,129)
+test bench_xml_rs               ... bench:  14,839,533 ns/iter (+/- 2,377,647)
 ```
 
 ## Contribute

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -90,8 +90,11 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>> {
                     ByteOrChar::Char(parse_hexadecimal(&bytes[2..])?)
                 }
                 bytes if bytes.starts_with(b"#") => ByteOrChar::Char(parse_decimal(&bytes[1..])?),
-                bytes => bail!(Escape(format!("Unrecognized escape symbol: {:?}",
-                                              ::std::str::from_utf8(bytes)), start..end)),
+                bytes => {
+                    bail!(Escape(format!("Unrecognized escape symbol: {:?}",
+                                         ::std::str::from_utf8(bytes)),
+                                 start..end))
+                }
             };
             escapes.push((start - 1..end, b_o_c));
             start = end + 1;

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use errors::Result;
 use errors::ErrorKind::Escape;
+use memchr;
 
 // UTF-8 ranges and tags for encoding characters
 const TAG_CONT: u8 = 0b1000_0000;
@@ -71,13 +72,12 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>> {
     let mut escapes = Vec::new();
 
     let mut start = 0;
-    let mut bytes = raw.iter();
-    while let Some(i) = bytes.by_ref().position(|b| *b == b'&') {
-        start += i;
-        if let Some(j) = bytes.by_ref().position(|b| *b == b';') {
-            let end = start + j + 1;
+    while let Some(i) = memchr::memchr(b'&', &raw[start..]) {
+        start += i + 1;
+        if let Some(j) = memchr::memchr(b';', &raw[start..]) {
+            let end = start + j;
             // search for character correctness
-            let b_o_c = match &raw[start + 1..end] {
+            let b_o_c = match &raw[start..end] {
                 b"lt" => ByteOrChar::Byte(b'<'),
                 b"gt" => ByteOrChar::Byte(b'>'),
                 b"amp" => ByteOrChar::Byte(b'&'),
@@ -90,12 +90,13 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>> {
                     ByteOrChar::Char(parse_hexadecimal(&bytes[2..])?)
                 }
                 bytes if bytes.starts_with(b"#") => ByteOrChar::Char(parse_decimal(&bytes[1..])?),
-                _ => bail!(Escape("".to_string(), start..end)),
+                bytes => bail!(Escape(format!("Unrecognized escape symbol: {:?}",
+                                              ::std::str::from_utf8(bytes)), start..end)),
             };
-            escapes.push((start..end, b_o_c));
+            escapes.push((start - 1..end, b_o_c));
             start = end + 1;
         } else {
-            bail!(Escape("Cannot find ';' after '&'".to_string(), i..bytes.len()));
+            bail!(Escape("Cannot find ';' after '&'".to_string(), start..raw.len()));
         }
     }
     if escapes.is_empty() {

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -113,7 +113,9 @@ impl<'a> Iterator for Attributes<'a> {
         }
 
         // search first space
-        let mut start_key = match self.bytes[p..len - 1].iter().position(|&b| is_whitespace(b)) {
+        let mut start_key = match self.bytes[p..len - 1]
+                  .iter()
+                  .position(|&b| is_whitespace(b)) {
             Some(i) => p + i + 1,
             None => {
                 self.position = len;
@@ -122,7 +124,9 @@ impl<'a> Iterator for Attributes<'a> {
         };
 
         // now search first non space
-        start_key += match self.bytes[start_key..len - 1].iter().position(|&b| !is_whitespace(b)) {
+        start_key += match self.bytes[start_key..len - 1]
+                  .iter()
+                  .position(|&b| !is_whitespace(b)) {
             Some(i) => i,
             None => {
                 self.position = len;
@@ -131,8 +135,9 @@ impl<'a> Iterator for Attributes<'a> {
         };
 
         // key end with either whitespace or =
-        let end_key = match self.bytes[start_key + 1..len - 1].iter()
-            .position(|&b| b == b'=' || is_whitespace(b)) {
+        let end_key = match self.bytes[start_key + 1..len - 1]
+                  .iter()
+                  .position(|&b| b == b'=' || is_whitespace(b)) {
             Some(i) => start_key + 1 + i,
             None => {
                 self.position = len;
@@ -141,13 +146,16 @@ impl<'a> Iterator for Attributes<'a> {
         };
 
         if self.with_checks {
-            if let Some(i) = self.bytes[start_key..end_key].iter().position(|&b| b == b'\'' || b == b'"') {
+            if let Some(i) = self.bytes[start_key..end_key]
+                   .iter()
+                   .position(|&b| b == b'\'' || b == b'"') {
                 return Some(self.error("Attribute key cannot contain quote", start_key + i));
             }
-            if let Some(r) = self.consumed
-                   .iter()
-                   .cloned()
-                   .find(|ref r| &self.bytes[(**r).clone()] == &self.bytes[start_key..end_key]) {
+            if let Some(r) = 
+                self.consumed
+                    .iter()
+                    .cloned()
+                    .find(|ref r| &self.bytes[(**r).clone()] == &self.bytes[start_key..end_key]) {
                 return Some(self.error(format!("Duplicate attribute at position {} and {}",
                                                r.start,
                                                start_key),
@@ -166,18 +174,22 @@ impl<'a> Iterator for Attributes<'a> {
         };
 
         if self.with_checks {
-            if let Some(i) = self.bytes[end_key..start_val - 1].iter().position(|&b| !is_whitespace(b)) {
-                return Some(self.error("Attribute key must be directly followed by = or space", end_key + i));
+            if let Some(i) = self.bytes[end_key..start_val - 1]
+                   .iter()
+                   .position(|&b| !is_whitespace(b)) {
+                return Some(self.error("Attribute key must be directly followed by = or space",
+                                       end_key + i));
             }
         }
 
         // value starts with a quote
         let (quote, start_val) = match self.bytes[start_val..len - 1]
-            .iter()
-            .enumerate()
-            .filter(|&(_, &b)| !is_whitespace(b))
-            .next() {
-            Some((i, b @ &b'\''))  | Some((i, b @ &b'"')) => (*b, start_val + i + 1),
+                  .iter()
+                  .enumerate()
+                  .filter(|&(_, &b)| !is_whitespace(b))
+                  .next() {
+            Some((i, b @ &b'\'')) |
+            Some((i, b @ &b'"')) => (*b, start_val + i + 1),
             Some((i, _)) => {
                 return Some(self.error("Attribute value must start with a quote", start_val + i));
             }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -6,7 +6,9 @@ use std::ops::Range;
 use std::io::BufRead;
 use errors::Result;
 use escape::unescape;
-use reader::Reader;
+use reader::{Reader, is_whitespace};
+
+use memchr;
 
 /// Iterator over attributes key/value pairs
 #[derive(Clone)]
@@ -110,96 +112,95 @@ impl<'a> Iterator for Attributes<'a> {
             return None;
         }
 
-        let mut iter = self.bytes[p..].iter().cloned().enumerate();
-
-        let start_key = {
-            let mut found_space = false;
-            let start: usize;
-            loop {
-                match iter.next() {
-                    Some((_, b' ')) | Some((_, b'\r')) | Some((_, b'\n')) | Some((_, b'\t')) => {
-                        if !found_space {
-                            found_space = true;
-                        }
-                    }
-                    Some((i, _)) => {
-                        if found_space {
-                            start = i;
-                            break;
-                        }
-                    }
-                    None => {
-                        self.position = len;
-                        return None;
-                    }
-                }
+        // search first space
+        let mut start_key = match self.bytes[p..len - 1].iter().position(|&b| is_whitespace(b)) {
+            Some(i) => p + i + 1,
+            None => {
+                self.position = len;
+                return None;
             }
-            start
         };
 
-        let mut has_equal = false;
-        let mut end_key = None;
-        let mut start_val = None;
-        let mut end_val = None;
-        let mut quote = 0;
-        loop {
-            match iter.next() {
-                Some((i, b' ')) | Some((i, b'\r')) | Some((i, b'\n')) | Some((i, b'\t')) => {
-                    if end_key.is_none() {
-                        end_key = Some(i);
-                    }
-                }
-                Some((i, b'=')) => {
-                    if start_val.is_none() {
-                        if has_equal {
-                            return Some(self.error("Got 2 '=' tokens", p + i));
-                        }
-                        has_equal = true;
-                        if end_key.is_none() {
-                            end_key = Some(i);
-                        }
-                    }
-                }
-                Some((i, q @ b'"')) |
-                Some((i, q @ b'\'')) => {
-                    if !has_equal {
-                        return Some(self.error("Unexpected quote before '='", p + i));
-                    }
-                    if start_val.is_none() {
-                        start_val = Some(i + 1);
-                        quote = q;
-                    } else if quote == q && end_val.is_none() {
-                        end_val = Some(i);
-                        break;
-                    }
-                }
-                None => {
-                    self.position = len;
-                    return None;
-                }
-                Some((_, _)) => (),
+        // now search first non space
+        start_key += match self.bytes[start_key..len - 1].iter().position(|&b| !is_whitespace(b)) {
+            Some(i) => i,
+            None => {
+                self.position = len;
+                return None;
             }
-        }
-        self.position += end_val.unwrap() + 1;
+        };
 
-        let r = (p + start_key)..(p + end_key.unwrap());
+        // key end with either whitespace or =
+        let end_key = match self.bytes[start_key + 1..len - 1].iter()
+            .position(|&b| b == b'=' || is_whitespace(b)) {
+            Some(i) => start_key + 1 + i,
+            None => {
+                self.position = len;
+                return None;
+            }
+        };
+
         if self.with_checks {
-            let name = &self.bytes[r.clone()];
-            if let Some(ref r2) = self.consumed
+            if let Some(i) = self.bytes[start_key..end_key].iter().position(|&b| b == b'\'' || b == b'"') {
+                return Some(self.error("Attribute key cannot contain quote", start_key + i));
+            }
+            if let Some(r) = self.consumed
                    .iter()
                    .cloned()
-                   .find(|r2| &self.bytes[r2.clone()] == name) {
+                   .find(|ref r| &self.bytes[(**r).clone()] == &self.bytes[start_key..end_key]) {
                 return Some(self.error(format!("Duplicate attribute at position {} and {}",
-                                               r2.start,
-                                               r.start),
-                                       r.start));
+                                               r.start,
+                                               start_key),
+                                       start_key));
             }
-            self.consumed.push(r.clone());
+            self.consumed.push(start_key..end_key);
         }
 
+        // values starts after =
+        let start_val = match memchr::memchr(b'=', &self.bytes[end_key..len - 1]) {
+            Some(i) => end_key + 1 + i,
+            None => {
+                self.position = len;
+                return None;
+            }
+        };
+
+        if self.with_checks {
+            if let Some(i) = self.bytes[end_key..start_val - 1].iter().position(|&b| !is_whitespace(b)) {
+                return Some(self.error("Attribute key must be directly followed by = or space", end_key + i));
+            }
+        }
+
+        // value starts with a quote
+        let (quote, start_val) = match self.bytes[start_val..len - 1]
+            .iter()
+            .enumerate()
+            .filter(|&(_, &b)| !is_whitespace(b))
+            .next() {
+            Some((i, b @ &b'\''))  | Some((i, b @ &b'"')) => (*b, start_val + i + 1),
+            Some((i, _)) => {
+                return Some(self.error("Attribute value must start with a quote", start_val + i));
+            }
+            None => {
+                self.position = len;
+                return None;
+            }
+        };
+
+        // value ends with the same quote
+        let end_val = match memchr::memchr(quote, &self.bytes[start_val..]) {
+            Some(i) => start_val + i,
+            None => {
+                self.position = len;
+                return None;
+            }
+        };
+
+        self.position = end_val + 1;
+
         Some(Ok(Attribute {
-                    key: &self.bytes[r],
-                    value: &self.bytes[(p + start_val.unwrap())..(p + end_val.unwrap())],
+                    key: &self.bytes[start_key..end_key],
+                    value: &self.bytes[start_val..end_val],
                 }))
     }
 }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -151,7 +151,7 @@ impl<'a> Iterator for Attributes<'a> {
                    .position(|&b| b == b'\'' || b == b'"') {
                 return Some(self.error("Attribute key cannot contain quote", start_key + i));
             }
-            if let Some(r) = 
+            if let Some(r) =
                 self.consumed
                     .iter()
                     .cloned()

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -13,6 +13,8 @@ use self::attributes::{Attributes, Attribute};
 use errors::Result;
 use reader::Reader;
 
+use memchr;
+
 /// A struct to manage `Event::Start` events
 ///
 /// Provides in particular an iterator over attributes
@@ -73,11 +75,8 @@ impl<'a> BytesStart<'a> {
     /// and including the first ':' character)
     #[inline]
     pub fn local_name(&self) -> &[u8] {
-        if let Some(i) = self.name().iter().position(|b| *b == b':') {
-            &self.name()[i + 1..]
-        } else {
-            self.name()
-        }
+        let name = self.name();
+        memchr::memchr(b':', name).map_or(name, |i| &name[i + 1..])
     }
 
     /// gets unescaped content

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@
 extern crate encoding_rs;
 #[macro_use]
 extern crate error_chain;
+extern crate memchr;
 
 pub mod errors;
 pub mod reader;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -749,8 +749,9 @@ fn read_elem_until<R: BufRead>(r: &mut R, end_byte: u8, buf: &mut Vec<u8>) -> Re
     Ok(read)
 }
 
+/// A function to check whether the byte is a whitespace (blank, new line, carriage return or tab)
 #[inline]
-fn is_whitespace(b: u8) -> bool {
+pub(crate) fn is_whitespace(b: u8) -> bool {
     match b {
         b' ' | b'\r' | b'\n' | b'\t' => true,
         _ => false,

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -491,13 +491,12 @@ fn test_default_namespace_reset() {
                    b"www1",
                    "expecting outer start element with to resolve to 'www1'");
     } else {
-        assert!(false,
-                "expecting outer start element with to resolve to 'www1'");
+        panic!("expecting outer start element with to resolve to 'www1'");
     }
 
-    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
-    } else {
-        assert!(false, "expecting inner start element");
+    match r.read_namespaced_event(&mut buf, &mut ns_buf) {
+        Ok((None, Start(_))) => (),
+        e => panic!("expecting inner start element, got {:?}", e),
     }
     if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
@@ -509,8 +508,7 @@ fn test_default_namespace_reset() {
                    b"www1",
                    "expecting outer end element with to resolve to 'www1'");
     } else {
-        assert!(false,
-                "expecting outer end element with to resolve to 'www1'");
+        panic!("expecting outer end element with to resolve to 'www1'");
     }
 }
 

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -135,11 +135,11 @@ fn issue_83_duplicate_attributes() {
 #[test]
 fn issue_93_large_characters_in_entity_references() {
     test(r#"<hello>&𤶼;</hello>"#.as_bytes(),
-         br#"
+         r#"
             |StartElement(hello)
-            |1:10 Error while escaping character at range 0..5:
+            |1:10 Error while escaping character at range 1..5: Unrecognized escape symbol: Ok("𤶼")
             |EndElement(hello)
-        "#,
+        "#.as_bytes(),
          true)
 }
 


### PR DESCRIPTION
Simpler and faster ...

```
$ cargo benchcmp old new4
 name                        old ns/iter  new4 ns/iter  diff ns/iter   diff %  speedup
 bench_quick_xml             312,089      260,867            -51,222  -16.41%   x 1.20
 bench_quick_xml_escaped     389,427      350,760            -38,667   -9.93%   x 1.11
 bench_quick_xml_namespaced  456,217      432,114            -24,103   -5.28%   x 1.06
 bench_xml_rs                14,702,444   14,960,577         258,133    1.76%   x 0.98
```

