### PR TITLE
Update encoding_rs to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
-encoding_rs = "0.6.11"
+encoding_rs = "0.7.0"
 error-chain = "0.10.0"
 memchr = "1.0.1"
 


### PR DESCRIPTION
This is a performance improvement. The theoretically breaking changes (removal of a cargo feature and removal of `Encoding::for_name()`) don't affect quick-xml.