### PR TITLE
fix escape wrong offset when more than 2 occurences

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -45,14 +45,12 @@ pub fn escape(raw: &[u8]) -> Cow<[u8]> {
         }
         loc += 1;
     }
-    println!("escapes: {:?}", escapes);
 
     if escapes.is_empty() {
         Cow::Borrowed(raw)
     } else {
         let len = raw.len();
         let mut v = Vec::with_capacity(len);
-
         let mut start = 0;
         for (i, r) in escapes {
             v.extend_from_slice(&raw[start..i]);


### PR DESCRIPTION
Closes #87 

The issue was only triggering at the 3rd character to escape. I believe this is the reason why we haven't spotted it sooner. Anyway, added some missing test.  

@epage, Thanks again for reporting the issue and sorry for that.
I have tested the cobalt test. Can you please confirm everything is ok on your side?

cc @huntiep who has worked on escape. Just so if you have some tests on your side, might be good to double check everything is still ok!