### PR TITLE
Migrate from 'error-chain' to 'failure'.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
 encoding_rs = "0.7.1"
-error-chain = "0.11.0"
+failure = "0.1.1"
 memchr = "2.0.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 
 extern crate encoding_rs;
 #[macro_use]
-extern crate error_chain;
+extern crate failure;
 extern crate memchr;
 
 pub mod errors;

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -1,4 +1,7 @@
+extern crate failure;
 extern crate quick_xml;
+
+use failure::Fail;
 
 use std::io::BufRead;
 use std::str::from_utf8;
@@ -93,12 +96,12 @@ fn sample_ns_short() {
 
 #[test]
 fn eof_1() {
-    test(br#"<?xml"#, br#"Error: XmlDecl"#, true);
+    test(br#"<?xml"#, br#"Error: Unexpected EOF during reading XmlDecl."#, true);
 }
 
 #[test]
 fn bad_1() {
-    test(br#"<?xml&.,"#, br#"1:6 Error: XmlDecl"#, true);
+    test(br#"<?xml&.,"#, br#"1:6 Error: Unexpected EOF during reading XmlDecl."#, true);
 }
 
 #[test]
@@ -422,7 +425,7 @@ impl<'a, 'b> fmt::Display for OptEvent<'a, 'b> {
             Ok((_, Event::PI(ref e))) => {
                 write!(f, "ProcessingInstruction(PI={:?})", from_utf8(e).unwrap())
             }
-            Err(ref e) => write!(f, "Error: {}", e.iter().last().unwrap()),
+            Err(ref e) => write!(f, "Error: {}", e.root_cause()),
             Ok((_, Event::DocType(ref e))) => write!(f, "DocType({})", from_utf8(e).unwrap()),
         }
     }


### PR DESCRIPTION
**Do not merge**

I've introduced enums for different errors. There are still few string-based errors.
I'm not sure if such granularity of errors is needed. Docs are also missing.