### PR TITLE
Html attributes

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -10,7 +10,8 @@ pub enum EscapeError {
     EntityWithNull(::std::ops::Range<usize>),
 
     #[fail(display = "Error while escaping character at range {:?}: Unrecognized escape symbol: {:?}", _0, _1)]
-    UnrecognizedSymbol(::std::ops::Range<usize>, ::std::result::Result<String, ::std::string::FromUtf8Error>),
+    UnrecognizedSymbol(::std::ops::Range<usize>,
+                       ::std::result::Result<String, ::std::string::FromUtf8Error>),
 
     #[fail(display = "Error while escaping character at range {:?}: Cannot find ';' after '&'", _0)]
     UnterminatedEntity(::std::ops::Range<usize>),
@@ -110,10 +111,12 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
                     ByteOrChar::Char(parse_hexadecimal(&bytes[2..])?)
                 }
                 bytes if bytes.starts_with(b"#") => ByteOrChar::Char(parse_decimal(&bytes[1..])?),
-                bytes => return Err(EscapeError::UnrecognizedSymbol(
-                    start..end,
-                    String::from_utf8(bytes.to_vec())
-                )),
+                bytes => {
+                    return Err(EscapeError::UnrecognizedSymbol(
+                        start..end,
+                        String::from_utf8(bytes.to_vec()),
+                    ))
+                }
             };
             escapes.push((start - 1..end, b_o_c));
             start = end + 1;

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -125,7 +125,6 @@ impl<'a> From<(&'a str, &'a str)> for Attribute<'a> {
 impl<'a> Iterator for Attributes<'a> {
     type Item = Result<Attribute<'a>>;
     fn next(&mut self) -> Option<Self::Item> {
-
         let len = self.bytes.len();
 
         macro_rules! err {
@@ -159,15 +158,20 @@ impl<'a> Iterator for Attributes<'a> {
         let mut bytes = self.bytes.iter().enumerate().skip(self.position);
 
         // key starts after the whitespace
-        let start_key = match bytes.by_ref()
+        let start_key = match bytes
+            .by_ref()
             .skip_while(|&(_, &b)| !is_whitespace(b))
-            .find(|&(_, &b)| !is_whitespace(b)) {
+            .find(|&(_, &b)| !is_whitespace(b))
+        {
             Some((i, _)) => i,
             None => attr!(self.position..len),
         };
 
         // key ends with either whitespace or =
-        let end_key = match bytes.by_ref().find(|&(_, &b)| b == b'=' || is_whitespace(b)) {
+        let end_key = match bytes
+            .by_ref()
+            .find(|&(_, &b)| b == b'=' || is_whitespace(b))
+        {
             Some((i, &b'=')) => i,
             Some((i, &b'\'')) | Some((i, &b'"')) if self.with_checks => {
                 err!(Error::NameWithQuote(i));
@@ -213,9 +217,12 @@ impl<'a> Iterator for Attributes<'a> {
                     }
                     None => err!(Error::UnquotedValue(i)),
                 }
-            },
+            }
             Some((i, _)) if self.html => {
-                let j = bytes.by_ref().find(|&(_, &b)| is_whitespace(b)).map_or(len, |(j, _)| j);
+                let j = bytes
+                    .by_ref()
+                    .find(|&(_, &b)| is_whitespace(b))
+                    .map_or(len, |(j, _)| j);
                 self.position = j;
                 attr!(start_key..end_key, i..j)
             }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -8,8 +8,6 @@ use errors::{Error, Result};
 use escape::{escape, unescape};
 use reader::{is_whitespace, Reader};
 
-use memchr;
-
 /// Iterator over attributes key/value pairs
 #[derive(Clone)]
 pub struct Attributes<'a> {
@@ -17,10 +15,10 @@ pub struct Attributes<'a> {
     bytes: &'a [u8],
     /// current position of the iterator
     position: usize,
-    /// shall the next iterator early exit because there were an error last time
-    exit: bool,
     /// if true, checks for duplicate names
     with_checks: bool,
+    /// allows attribute without quote or `=`
+    html: bool,
     /// if `with_checks`, contains the ranges corresponding to the
     /// attribute names already parsed in this `Element`
     consumed: Vec<Range<usize>>,
@@ -32,7 +30,18 @@ impl<'a> Attributes<'a> {
         Attributes {
             bytes: buf,
             position: pos,
-            exit: false,
+            html: false,
+            with_checks: true,
+            consumed: Vec::new(),
+        }
+    }
+
+    /// creates a new attribute iterator from a buffer, allowing html attribute syntax
+    pub fn html(buf: &'a [u8], pos: usize) -> Attributes<'a> {
+        Attributes {
+            bytes: buf,
+            position: pos,
+            html: true,
             with_checks: true,
             consumed: Vec::new(),
         }
@@ -44,9 +53,15 @@ impl<'a> Attributes<'a> {
         self
     }
 
+    /// allow attributes without quote or `=`
+    pub fn html_style(&mut self, val: bool) -> &mut Attributes<'a> {
+        self.html = val;
+        self
+    }
+
     /// sets `self.exit = true` to terminate the iterator
-    fn error(&mut self, err: Error) -> Result<Attribute<'a>> {
-        self.exit = true;
+    fn error(&mut self, err: Error, len: usize) -> Result<Attribute<'a>> {
+        self.position = len;
         Err(err.into())
     }
 }
@@ -122,118 +137,173 @@ impl<'a> From<(&'a str, &'a str)> for Attribute<'a> {
 impl<'a> Iterator for Attributes<'a> {
     type Item = Result<Attribute<'a>>;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.exit {
-            return None;
-        }
 
         let len = self.bytes.len();
-        let p = self.position;
-        if len <= p {
+
+        // helper macro for last attribute
+        macro_rules! attr {
+            ($key: expr) => {
+                {
+                    self.position = len;
+                    if self.html {
+                        attr!($key, 0..0)
+                    } else {
+                        return None;
+                    };
+                }
+            };
+            ($key:expr, $val: expr) => {
+                return Some(Ok(Attribute {
+                    key: &self.bytes[$key],
+                    value: Cow::Borrowed(&self.bytes[$val]),
+                }));
+            };
+        }
+
+        if len <= self.position {
             return None;
         }
 
-        // search first space
-        let mut start_key = match self.bytes[p..len - 1]
-            .iter()
-            .position(|&b| is_whitespace(b))
-        {
-            Some(i) => p + i + 1,
-            None => {
-                self.position = len;
-                return None;
-            }
+        let mut bytes = self.bytes.iter().enumerate().skip(self.position);
+
+        // key starts after the whitespace
+        let start_key = match bytes.by_ref()
+            .skip_while(|&(_, &b)| !is_whitespace(b))
+            .find(|&(_, &b)| !is_whitespace(b)) {
+            Some((i, _)) => i,
+            None => attr!(self.position..len),
         };
 
-        // now search first non space
-        start_key += match self.bytes[start_key..len - 1]
-            .iter()
-            .position(|&b| !is_whitespace(b))
-        {
-            Some(i) => i,
-            None => {
-                self.position = len;
-                return None;
+        // key ends with either whitespace or =
+        let end_key = match bytes.by_ref().find(|&(_, &b)| b == b'=' || is_whitespace(b)) {
+            Some((i, &b'=')) => i,
+            Some((i, &b'\'')) | Some((i, &b'"')) if self.with_checks => {
+                return Some(self.error(Error::NameWithQuote(i), len));
             }
-        };
-
-        // key end with either whitespace or =
-        let end_key = match self.bytes[start_key + 1..len - 1]
-            .iter()
-            .position(|&b| b == b'=' || is_whitespace(b))
-        {
-            Some(i) => start_key + 1 + i,
-            None => {
-                self.position = len;
-                return None;
+            Some((i, _)) => {
+                // consume until `=` or return if html
+                match bytes.by_ref().find(|&(_, &b)| !is_whitespace(b)) {
+                    Some((_, &b'=')) => i,
+                    Some((j, _)) => {
+                        if self.html {
+                            self.position = j - 1;
+                            attr!(start_key..i, 0..0);
+                        }
+                        return Some(self.error(Error::NoEqAfterName(j), len));
+                    }
+                    None if self.html => {
+                        self.position = len;
+                        attr!(start_key..len, 0..0);
+                    }
+                    None => return Some(self.error(Error::NoEqAfterName(len), len)),
+                }
             }
+            None => attr!(start_key..len),
         };
 
         if self.with_checks {
-            if let Some(i) = self.bytes[start_key..end_key]
+            if let Some(start) = self.consumed
                 .iter()
-                .position(|&b| b == b'\'' || b == b'"')
+                .filter(|r| r.len() == end_key - start_key)
+                .find(|r| &self.bytes[(*r).clone()] == &self.bytes[start_key..end_key])
+                .map(|ref r| r.start)
             {
-                return Some(self.error(Error::NameWithQuote(start_key + i)));
-            }
-            if let Some(r) = self.consumed
-                .iter()
-                .cloned()
-                .find(|ref r| &self.bytes[(**r).clone()] == &self.bytes[start_key..end_key])
-            {
-                return Some(self.error(Error::DuplicatedAttribute(start_key, r.start)));
+                return Some(self.error(Error::DuplicatedAttribute(start_key, start), len));
             }
             self.consumed.push(start_key..end_key);
         }
 
-        // values starts after =
-        let start_val = match memchr::memchr(b'=', &self.bytes[end_key..len - 1]) {
-            Some(i) => end_key + 1 + i,
-            None => {
-                self.position = len;
-                return None;
+        // value has quote if not html
+        match bytes.by_ref().find(|&(_, &b)| !is_whitespace(b)) {
+            Some((i, quote @ &b'\'')) | Some((i, quote @ &b'"')) => {
+                match bytes.by_ref().find(|&(_, &b)| b == *quote) {
+                    Some((j, _)) => {
+                        self.position = j + 1;
+                        attr!(start_key..end_key, i + 1..j)
+                    }
+                    None => Some(self.error(Error::UnquotedValue(i), len)),
+                }
+            },
+            Some((i, _)) if self.html => {
+                let j = bytes.by_ref().find(|&(_, &b)| is_whitespace(b)).map_or(len, |(j, _)| j);
+                self.position = j;
+                attr!(start_key..end_key, i..j)
             }
-        };
-
-        if self.with_checks {
-            if let Some(i) = self.bytes[end_key..start_val - 1]
-                .iter()
-                .position(|&b| !is_whitespace(b))
-            {
-                return Some(self.error(Error::NoEqAfterName(end_key + i)));
-            }
+            Some((i, _)) => Some(self.error(Error::UnquotedValue(i), len)),
+            None => attr!(start_key..end_key),
         }
+    }
+}
 
-        // value starts with a quote
-        let (quote, start_val) = match self.bytes[start_val..len - 1]
-            .iter()
-            .enumerate()
-            .filter(|&(_, &b)| !is_whitespace(b))
-            .next()
-        {
-            Some((i, b @ &b'\'')) | Some((i, b @ &b'"')) => (*b, start_val + i + 1),
-            Some((i, _)) => {
-                return Some(self.error(Error::UnquotedValue(start_val + i)));
-            }
-            None => {
-                self.position = len;
-                return None;
-            }
-        };
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        // value ends with the same quote
-        let end_val = match memchr::memchr(quote, &self.bytes[start_val..]) {
-            Some(i) => start_val + i,
-            None => {
-                self.position = len;
-                return None;
-            }
-        };
+    #[test]
+    fn regular() {
+        let event = b"name a='a' b = 'b'";
+        let mut attributes = Attributes::new(event, 0);
+        attributes.with_checks(true);
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"a");
+        assert_eq!(&*a.value, b"a");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"b");
+        assert_eq!(&*a.value, b"b");
+        assert!(attributes.next().is_none());
+    }
 
-        self.position = end_val + 1;
+    #[test]
+    fn mixed_quote() {
+        let event = b"name a='a' b = \"b\" c='cc\"cc'";
+        let mut attributes = Attributes::new(event, 0);
+        attributes.with_checks(true);
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"a");
+        assert_eq!(&*a.value, b"a");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"b");
+        assert_eq!(&*a.value, b"b");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"c");
+        assert_eq!(&*a.value, b"cc\"cc");
+        assert!(attributes.next().is_none());
+    }
 
-        Some(Ok(Attribute {
-            key: &self.bytes[start_key..end_key],
-            value: Cow::from(&self.bytes[start_val..end_val]),
-        }))
+    #[test]
+    fn html_fail() {
+        let event = b"name a='a' b=b c";
+        let mut attributes = Attributes::new(event, 0);
+        attributes.with_checks(true);
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"a");
+        assert_eq!(&*a.value, b"a");
+        assert!(attributes.next().unwrap().is_err());
+    }
+
+    #[test]
+    fn html_ok() {
+        let event = b"name a='a' e b=b c d ee=ee";
+        let mut attributes = Attributes::new(event, 0);
+        attributes.with_checks(true).html_style(true);
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"a");
+        assert_eq!(&*a.value, b"a");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"e");
+        assert_eq!(&*a.value, b"");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"b");
+        assert_eq!(&*a.value, b"b");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"c");
+        assert_eq!(&*a.value, b"");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"d");
+        assert_eq!(&*a.value, b"");
+        let a = attributes.next().unwrap().unwrap();
+        assert_eq!(a.key, b"ee");
+        assert_eq!(&*a.value, b"ee");
+        assert!(attributes.next().is_none());
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -93,6 +93,11 @@ impl<'a> BytesStart<'a> {
         Attributes::new(self, self.name_len)
     }
 
+    /// gets attributes iterator with html syntax (no mandatory quote or =)
+    pub fn html_attributes(&self) -> Attributes {
+        Attributes::html(self, self.name_len)
+    }
+
     /// extend the attributes of this element from an iterator over (key, value) tuples.
     /// Key and value can be anything that implements the AsRef<[u8]> trait,
     /// like byte slices and strings.

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -163,7 +163,7 @@ impl<'a> BytesDecl<'a> {
             Some(Ok(a)) => {
                 let found = from_utf8(a.key).map_err(Error::Utf8)?.to_string();
                 Err(Error::XmlDeclWithoutVersion(Some(found)))
-            },
+            }
             None => Err(Error::XmlDeclWithoutVersion(None)),
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -249,7 +249,7 @@ impl<B: BufRead> Reader<B> {
                             expected: from_utf8(&self.opened_buffer[start..])
                                 .unwrap_or("")
                                 .to_owned(),
-                            found: from_utf8(&buf[1..]).unwrap_or("").to_owned()
+                            found: from_utf8(&buf[1..]).unwrap_or("").to_owned(),
                         });
                     }
                     self.opened_buffer.truncate(start);
@@ -258,7 +258,7 @@ impl<B: BufRead> Reader<B> {
                     self.buf_position -= len;
                     return Err(Error::EndEventMismatch {
                         expected: "".to_owned(),
-                        found: from_utf8(&buf[1..]).unwrap_or("").to_owned()
+                        found: from_utf8(&buf[1..]).unwrap_or("").to_owned(),
                     });
                 }
             }
@@ -347,7 +347,7 @@ impl<B: BufRead> Reader<B> {
                         &buf[buf_start + 8..len],
                     )))
                 }
-                _ => return Err(Error::UnexpectedBang)
+                _ => return Err(Error::UnexpectedBang),
             }
         } else {
             self.buf_position -= buf.len();


### PR DESCRIPTION
This PR allows iterating on html syntax attributes.

Html attributes are more permissive than xml, in particular:
- attribute values do not need quotes if there is no whitespace
- for empty attribute values, we don't even need the `=` character

The simplest way to use it is though the new `BytesStart::html_attributes` function.

Note that depending on your use case, it may have a small performance penalty (within 2-3%) but most of my tests perform similarly. The main reason is that I do not use `memchar` in attributes iterator but a direct `Iter`. The code is simpler and less error prone.

It also add several new tests for attributes.
  