### PR TITLE
Move reader, writer and errors module to crate root

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,7 @@ extern crate test;
 
 use test::Bencher;
 use quick_xml::events::Event;
-use quick_xml::reader::Reader;
+use quick_xml::Reader;
 
 #[bench]
 fn bench_quick_xml(b: &mut Bencher) {

--- a/examples/issue68.rs
+++ b/examples/issue68.rs
@@ -2,7 +2,7 @@
 
 extern crate quick_xml;
 
-use quick_xml::reader::Reader;
+use quick_xml::Reader;
 use quick_xml::events::Event;
 use std::io::Read;
 

--- a/examples/read_texts.rs
+++ b/examples/read_texts.rs
@@ -1,7 +1,7 @@
 extern crate quick_xml;
 
 fn main() {
-    use quick_xml::reader::Reader;
+    use quick_xml::Reader;
     use quick_xml::events::Event;
 
     let xml = "<tag1>text1</tag1><tag1>text2</tag1>\

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -2,7 +2,7 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate quick_xml;
 
-use quick_xml::reader::Reader;
+use quick_xml::Reader;
 use quick_xml::events::Event;
 use std::io::Cursor;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! ### Reader
 //!
 //! ```rust
-//! use quick_xml::reader::Reader;
+//! use quick_xml::Reader;
 //! use quick_xml::events::Event;
 //!
 //! let xml = r#"<tag1 att1 = "test">
@@ -58,9 +58,9 @@
 //! ### Writer
 //!
 //! ```rust
-//! use quick_xml::writer::Writer;
+//! use quick_xml::Writer;
 //! use quick_xml::events::{Event, BytesEnd, BytesStart};
-//! use quick_xml::reader::Reader;
+//! use quick_xml::Reader;
 //! use std::io::Cursor;
 //! use std::iter;
 //!
@@ -110,11 +110,13 @@ extern crate encoding_rs;
 extern crate failure;
 extern crate memchr;
 
-pub mod errors;
-pub mod reader;
-pub mod writer;
+mod errors;
+mod reader;
+mod writer;
 pub mod events;
 mod escape;
 
 // reexports
 pub use writer::Writer;
+pub use reader::Reader;
+pub use errors::{Error, Result};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -25,7 +25,7 @@ enum TagState {
 /// Consumes a `BufRead` and streams xml `Event`s
 ///
 /// ```
-/// use quick_xml::reader::Reader;
+/// use quick_xml::Reader;
 /// use quick_xml::events::Event;
 ///
 /// let xml = r#"<tag1 att1 = "test">
@@ -424,7 +424,7 @@ impl<B: BufRead> Reader<B> {
     ///
     /// # Examples
     /// ```
-    /// use quick_xml::reader::Reader;
+    /// use quick_xml::Reader;
     /// use quick_xml::events::Event;
     ///
     /// let xml = r#"<tag1 att1 = "test">
@@ -485,7 +485,7 @@ impl<B: BufRead> Reader<B> {
     /// # Examples
     /// ```
     /// use std::str::from_utf8;
-    /// use quick_xml::reader::Reader;
+    /// use quick_xml::Reader;
     /// use quick_xml::events::Event;
     ///
     /// let xml = r#"<x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
@@ -617,7 +617,7 @@ impl<B: BufRead> Reader<B> {
     /// # Examples
     ///
     /// ```
-    /// use quick_xml::reader::Reader;
+    /// use quick_xml::Reader;
     /// use quick_xml::events::Event;
     ///
     /// let mut xml = Reader::from_reader(b"<a>&lt;b&gt;</a>" as &[u8]);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -14,9 +14,8 @@ use events::Event;
 /// # extern crate quick_xml;
 /// # fn main() {
 /// use failure::Fail;
-/// use quick_xml::writer::Writer;
+/// use quick_xml::{Reader, Writer};
 /// use quick_xml::events::{Event, BytesEnd, BytesStart};
-/// use quick_xml::reader::Reader;
 /// use std::io::Cursor;
 ///
 /// let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 extern crate quick_xml;
 
-use quick_xml::reader::Reader;
+use quick_xml::Reader;
 use quick_xml::events::Event::*;
 use quick_xml::events::attributes::Attribute;
 use std::io::Cursor;

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3,11 +3,9 @@ extern crate quick_xml;
 use std::str::from_utf8;
 use std::io::Cursor;
 
-use quick_xml::reader::Reader;
-use quick_xml::writer::Writer;
+use quick_xml::{Reader, Writer, Result};
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::events::Event::*;
-use quick_xml::errors::Result;
 
 macro_rules! next_eq_name {
     ($r: expr, $t:tt, $bytes:expr) => {

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -6,8 +6,7 @@ use failure::Fail;
 use std::io::BufRead;
 use std::str::from_utf8;
 
-use quick_xml::errors::Result;
-use quick_xml::reader::Reader;
+use quick_xml::{Reader, Result};
 use quick_xml::events::{BytesStart, Event};
 
 use std::fmt;


### PR DESCRIPTION
These modules either only contain a single type, or stuff that really belongs into the crate root per conventions (Error and Result).