### PR TITLE
Clarify and extend the API Surface of BytesText

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -303,7 +303,7 @@ pub struct BytesText<'a> {
 }
 
 impl<'a> BytesText<'a> {
-    /// Creates a new text event from an escaped byte sequence.
+    /// Creates a new `BytesText` from an escaped byte sequence.
     #[inline]
     pub fn from_escaped<C: Into<Cow<'a, [u8]>>>(content: C) -> BytesText<'a> {
         BytesText {
@@ -311,15 +311,16 @@ impl<'a> BytesText<'a> {
         }
     }
 
-    /// Creates a new text event from an unescaped byte sequence.
+    /// Creates a new `BytesText` from a byte sequence. The byte sequence is
+    /// expected not to be escaped.
     #[inline]
-    pub fn from_unescaped(content: &'a [u8]) -> BytesText<'a> {
+    pub fn from_plain(content: &'a [u8]) -> BytesText<'a> {
         BytesText {
             content: escape(content),
         }
     }
 
-    /// Creates a new text event from an escaped string.
+    /// Creates a new `BytesText` from an escaped string.
     #[inline]
     pub fn from_escaped_str<C: Into<Cow<'a, str>>>(content: C) -> BytesText<'a> {
         Self::from_escaped(match content.into() {
@@ -328,13 +329,14 @@ impl<'a> BytesText<'a> {
         })
     }
 
-    /// Creates a new text event from an unescaped string.
+    /// Creates a new `BytesText` from a string. The string is expected not to
+    /// be escaped.
     #[inline]
-    pub fn from_unescaped_str(content: &'a str) -> BytesText<'a> {
-        Self::from_unescaped(content.as_bytes())
+    pub fn from_plain_str(content: &'a str) -> BytesText<'a> {
+        Self::from_plain(content.as_bytes())
     }
 
-    /// Ensures that all data is owned to extend the event's lifetime if
+    /// Ensures that all data is owned to extend the object's lifetime if
     /// necessary.
     #[inline]
     pub fn into_owned(self) -> BytesText<'static> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -196,7 +196,7 @@ impl<B: BufRead> Reader<B> {
                 } else {
                     (buf_start, buf.len())
                 };
-                Ok(Event::Text(BytesText::borrowed(&buf[start..len])))
+                Ok(Event::Text(BytesText::from_escaped(&buf[start..len])))
             }
             Err(e) => Err(e),
         }
@@ -328,7 +328,7 @@ impl<B: BufRead> Reader<B> {
                     offset -= 1;
                 }
             }
-            Ok(Event::Comment(BytesText::borrowed(
+            Ok(Event::Comment(BytesText::from_escaped(
                 &buf[buf_start + 3..len - 2],
             )))
         } else if len >= buf_start + 8 {
@@ -347,7 +347,7 @@ impl<B: BufRead> Reader<B> {
                         }
                         len = buf.len();
                     }
-                    Ok(Event::CData(BytesText::borrowed(
+                    Ok(Event::CData(BytesText::from_escaped(
                         &buf[buf_start + 8..len - 2],
                     )))
                 }
@@ -370,7 +370,7 @@ impl<B: BufRead> Reader<B> {
                         }
                     }
                     let len = buf.len();
-                    Ok(Event::DocType(BytesText::borrowed(
+                    Ok(Event::DocType(BytesText::from_escaped(
                         &buf[buf_start + 8..len],
                     )))
                 }
@@ -395,7 +395,7 @@ impl<B: BufRead> Reader<B> {
                 }
                 Ok(Event::Decl(event))
             } else {
-                Ok(Event::PI(BytesText::borrowed(&buf[1..len - 1])))
+                Ok(Event::PI(BytesText::from_escaped(&buf[1..len - 1])))
             }
         } else {
             self.buf_position -= len;

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3,7 +3,7 @@ extern crate quick_xml;
 use std::str::from_utf8;
 use std::io::Cursor;
 
-use quick_xml::{Reader, Writer, Result};
+use quick_xml::{Reader, Result, Writer};
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::events::Event::*;
 
@@ -663,7 +663,7 @@ fn test_read_write_roundtrip_escape() {
                 let t = e.escaped();
                 assert!(
                     writer
-                        .write_event(Event::Text(BytesText::owned(t.to_vec())))
+                        .write_event(Event::Text(BytesText::from_escaped(t.to_vec())))
                         .is_ok()
                 );
             }
@@ -698,7 +698,7 @@ fn test_read_write_roundtrip_escape_text() {
                 let t = e.unescape_and_decode(&reader).unwrap();
                 assert!(
                     writer
-                        .write_event(Event::Text(BytesText::from_str(t)))
+                        .write_event(Event::Text(BytesText::from_unescaped_str(&t)))
                         .is_ok()
                 );
             }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -698,7 +698,7 @@ fn test_read_write_roundtrip_escape_text() {
                 let t = e.unescape_and_decode(&reader).unwrap();
                 assert!(
                     writer
-                        .write_event(Event::Text(BytesText::from_unescaped_str(&t)))
+                        .write_event(Event::Text(BytesText::from_plain_str(&t)))
                         .is_ok()
                 );
             }


### PR DESCRIPTION
Neither of the 3 constructors `borrowed`, `owned` and `from_str` documented if they expect pre-escaped data. This behavior also silently changed completely in #96 causing a few bugs here and there. The API was therefore completely revamped in order to allow constructing text events from either escaped or unescaped text.