### PR TITLE
add standard type conversions for Error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,6 +60,22 @@ pub enum Error {
     EscapeError(#[cause] ::escape::EscapeError),
 }
 
+impl From<::std::io::Error> for Error {
+    /// Creates a new `Error::Io` from the given error
+    #[inline]
+    fn from(error: ::std::io::Error) -> Error {
+        Error::Io(error)
+    }
+}
+
+impl From<::std::str::Utf8Error> for Error {
+    /// Creates a new `Error::Utf8` from the given error
+    #[inline]
+    fn from(error: ::std::str::Utf8Error) -> Error {
+        Error::Utf8(error)
+    }
+}
+
 /// A specialized `Result` type where the error is hard-wired to [`Error`].
 ///
 /// [`Error`]: enum.Error.html

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -126,7 +126,7 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
                     return Err(EscapeError::UnrecognizedSymbol(
                         start..end,
                         String::from_utf8(bytes.to_vec()),
-                    ))
+                    ));
                 }
             };
             escapes.push((start - 1..end, b_o_c));


### PR DESCRIPTION
I noticed while trying to use [tokio::codec::Decoder](https://tokio-rs.github.io/tokio/tokio/codec/trait.Decoder.html) that while `Error` does wrap two standard error types, it didn't implement any conversions from them. To work with `Decoder` I'd need to make a newtype around `Error` and implement `From<std::io::Error>` myself, but this seems like something that could sensibly go on `Error` directly.

All `Error::Io` and `Utf8` instances that currently get created are done so through `map_err`, and it seems like the user would want to continue funneling any and all `std::io::Error`s into `Error::Io`. I tried to keep my changes consistent with what I noticed in the rest of the codebase, but I'm fairly new to Rust so please let me know if I'm missing something here.