### PR TITLE
Make the dependency on `failure` optional; use `derive_more` for deriving `Display`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ before_script:
 script:
   - if [[ $(rustup show active-toolchain) == stable* ]]; then cargo fmt -- --check; fi;
   - cargo build
+  - cargo build --no-default-features
   - cargo test
+  - cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
 encoding_rs = "0.8.14"
-failure = "0.1.5"
+derive_more = "0.14"
 memchr = "2.1.2"
 log = "0.4.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
 encoding_rs = "0.8.14"
+failure = { version = "0.1.5", optional = true }
 derive_more = "0.14"
 memchr = "2.1.2"
 log = "0.4.6"
@@ -26,3 +27,6 @@ xml-rs = "0.8.0"
 
 [lib]
 bench = false
+
+[features]
+default = ["failure"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,10 +27,7 @@ pub enum Error {
     #[display(fmt = "Cannot read text, expecting Event::Text")]
     TextNotFound,
 
-    #[display(
-        fmt = "XmlDecl must start with 'version' attribute, found {:?}",
-        "_0"
-    )]
+    #[display(fmt = "XmlDecl must start with 'version' attribute, found {:?}", "_0")]
     XmlDeclWithoutVersion(Option<String>),
 
     #[display(
@@ -53,7 +50,9 @@ pub enum Error {
 
     #[display(
         fmt = "error while parsing attribute at position {}: Duplicate attribute at position {} and {}",
-        "_0", "_1", "_0"
+        "_0",
+        "_1",
+        "_0"
     )]
     DuplicatedAttribute(usize, usize),
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,13 +3,14 @@
 #![allow(missing_docs)]
 
 /// The error type used by this crate.
+#[cfg_attr(feature = "failure", derive(Fail))]
 #[derive(Display, Debug)]
 pub enum Error {
     #[display(fmt = "I/O error: {}", "_0")]
-    Io(::std::io::Error),
+    Io(#[cfg_attr(feature = "failure", cause)] ::std::io::Error),
 
     #[display(fmt = "UTF8 error: {}", "_0")]
-    Utf8(::std::str::Utf8Error),
+    Utf8(#[cfg_attr(feature = "failure", cause)] ::std::str::Utf8Error),
 
     #[display(fmt = "Unexpected EOF during reading {}.", "_0")]
     UnexpectedEof(String),
@@ -57,7 +58,7 @@ pub enum Error {
     DuplicatedAttribute(usize, usize),
 
     #[display(fmt = "{}", "_0")]
-    EscapeError(::escape::EscapeError),
+    EscapeError(#[cfg_attr(feature = "failure", cause)] ::escape::EscapeError),
 }
 
 impl From<::std::io::Error> for Error {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,61 +3,61 @@
 #![allow(missing_docs)]
 
 /// The error type used by this crate.
-#[derive(Fail, Debug)]
+#[derive(Display, Debug)]
 pub enum Error {
-    #[fail(display = "I/O error")]
-    Io(#[cause] ::std::io::Error),
+    #[display(fmt = "I/O error: {}", "_0")]
+    Io(::std::io::Error),
 
-    #[fail(display = "UTF8 error")]
-    Utf8(#[cause] ::std::str::Utf8Error),
+    #[display(fmt = "UTF8 error: {}", "_0")]
+    Utf8(::std::str::Utf8Error),
 
-    #[fail(display = "Unexpected EOF during reading {}.", _0)]
+    #[display(fmt = "Unexpected EOF during reading {}.", "_0")]
     UnexpectedEof(String),
 
-    #[fail(display = "Expecting </{}> found </{}>", expected, found)]
+    #[display(fmt = "Expecting </{}> found </{}>", expected, found)]
     EndEventMismatch { expected: String, found: String },
 
-    #[fail(display = "Unexpected token '{}'", _0)]
+    #[display(fmt = "Unexpected token '{}'", "_0")]
     UnexpectedToken(String),
 
-    #[fail(display = "Only Comment, CDATA and DOCTYPE nodes can start with a '!'")]
+    #[display(fmt = "Only Comment, CDATA and DOCTYPE nodes can start with a '!'")]
     UnexpectedBang,
 
-    #[fail(display = "Cannot read text, expecting Event::Text")]
+    #[display(fmt = "Cannot read text, expecting Event::Text")]
     TextNotFound,
 
-    #[fail(
-        display = "XmlDecl must start with 'version' attribute, found {:?}",
-        _0
+    #[display(
+        fmt = "XmlDecl must start with 'version' attribute, found {:?}",
+        "_0"
     )]
     XmlDeclWithoutVersion(Option<String>),
 
-    #[fail(
-        display = "error while parsing attribute at position {}: Attribute key cannot contain quote.",
-        _0
+    #[display(
+        fmt = "error while parsing attribute at position {}: Attribute key cannot contain quote.",
+        "_0"
     )]
     NameWithQuote(usize),
 
-    #[fail(
-        display = "error while parsing attribute at position {}: Attribute key must be directly followed by = or space",
-        _0
+    #[display(
+        fmt = "error while parsing attribute at position {}: Attribute key must be directly followed by = or space",
+        "_0"
     )]
     NoEqAfterName(usize),
 
-    #[fail(
-        display = "error while parsing attribute at position {}: Attribute value must start with a quote.",
-        _0
+    #[display(
+        fmt = "error while parsing attribute at position {}: Attribute value must start with a quote.",
+        "_0"
     )]
     UnquotedValue(usize),
 
-    #[fail(
-        display = "error while parsing attribute at position {}: Duplicate attribute at position {} and {}",
-        _0, _1, _0
+    #[display(
+        fmt = "error while parsing attribute at position {}: Duplicate attribute at position {} and {}",
+        "_0", "_1", "_0"
     )]
     DuplicatedAttribute(usize, usize),
 
-    #[fail(display = "{}", _0)]
-    EscapeError(#[cause] ::escape::EscapeError),
+    #[display(fmt = "{}", "_0")]
+    EscapeError(::escape::EscapeError),
 }
 
 impl From<::std::io::Error> for Error {

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -15,7 +15,8 @@ pub enum EscapeError {
 
     #[display(
         fmt = "Error while escaping character at range {:?}: Unrecognized escape symbol: {:?}",
-        "_0", "_1"
+        "_0",
+        "_1"
     )]
     UnrecognizedSymbol(
         ::std::ops::Range<usize>,

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -4,6 +4,7 @@ use memchr;
 use std::borrow::Cow;
 
 #[allow(missing_docs)]
+#[cfg_attr(feature = "failure", derive(Fail))]
 #[derive(Display, Debug)]
 pub enum EscapeError {
     #[display(

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -4,39 +4,39 @@ use memchr;
 use std::borrow::Cow;
 
 #[allow(missing_docs)]
-#[derive(Fail, Debug)]
+#[derive(Display, Debug)]
 pub enum EscapeError {
-    #[fail(
-        display = "Error while escaping character at range {:?}: Null character entity not allowed",
-        _0
+    #[display(
+        fmt = "Error while escaping character at range {:?}: Null character entity not allowed",
+        "_0"
     )]
     EntityWithNull(::std::ops::Range<usize>),
 
-    #[fail(
-        display = "Error while escaping character at range {:?}: Unrecognized escape symbol: {:?}",
-        _0, _1
+    #[display(
+        fmt = "Error while escaping character at range {:?}: Unrecognized escape symbol: {:?}",
+        "_0", "_1"
     )]
     UnrecognizedSymbol(
         ::std::ops::Range<usize>,
         ::std::result::Result<String, ::std::string::FromUtf8Error>,
     ),
 
-    #[fail(
-        display = "Error while escaping character at range {:?}: Cannot find ';' after '&'",
-        _0
+    #[display(
+        fmt = "Error while escaping character at range {:?}: Cannot find ';' after '&'",
+        "_0"
     )]
     UnterminatedEntity(::std::ops::Range<usize>),
 
-    #[fail(display = "Cannot convert hexadecimal to utf8")]
+    #[display(fmt = "Cannot convert hexadecimal to utf8")]
     TooLongHexadecimal,
 
-    #[fail(display = "'{}' is not a valid hexadecimal character", _0)]
+    #[display(fmt = "'{}' is not a valid hexadecimal character", "_0")]
     InvalidHexadecimal(char),
 
-    #[fail(display = "Cannot convert decimal to utf8")]
+    #[display(fmt = "Cannot convert decimal to utf8")]
     TooLongDecimal,
 
-    #[fail(display = "'{}' is not a valid decimal character", _0)]
+    #[display(fmt = "'{}' is not a valid decimal character", "_0")]
     InvalidDecimal(char),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 
 extern crate encoding_rs;
 #[macro_use]
-extern crate failure;
+extern crate derive_more;
 extern crate memchr;
 
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,9 @@
 #![recursion_limit = "1024"]
 
 extern crate encoding_rs;
+#[cfg(feature = "failure")]
+#[macro_use]
+extern crate failure;
 #[macro_use]
 extern crate derive_more;
 extern crate memchr;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -12,10 +12,8 @@ use events::Event;
 /// # Examples
 ///
 /// ```rust
-/// # extern crate failure;
 /// # extern crate quick_xml;
 /// # fn main() {
-/// use failure::Fail;
 /// use quick_xml::{Reader, Writer};
 /// use quick_xml::events::{Event, BytesEnd, BytesStart};
 /// use std::io::Cursor;
@@ -48,9 +46,7 @@ use events::Event;
 ///         Ok(Event::Eof) => break,
 ///         // we can either move or borrow the event to write, depending on your use-case
 ///         Ok(e) => assert!(writer.write_event(&e).is_ok()),
-///         // errors are chained, the last one usually being the
-///         // position where the error has happened
-///         Err(e) => panic!("{:?}", e.causes().map(|e| format!("{:?} -", e)).collect::<String>()),
+///         Err(e) => panic!("{}", e),
 ///     }
 ///     buf.clear();
 /// }

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -1,4 +1,3 @@
-extern crate failure;
 extern crate quick_xml;
 
 use quick_xml::events::{BytesStart, Event};


### PR DESCRIPTION
I'm not sure if this is acceptable, but it seemed simple and easy enough so I decided to try and create a PR.

A little backstory - at work we have a [CPU profiler written in Rust](https://github.com/nokia/not-perf); recently I've added support so that our profiler can natively generate profiling flamegraphs using the [`inferno`](https://github.com/jonhoo/inferno) crate. The `inferno` crate uses `quick-xml` for its XML needs.

Now here's the problem - `quick-xml` requires the `failure` crate, and the `failure` crate requires `backtrace`, which requires `backtrace-sys`. This is a problem for our CPU profiler as `backtrace-sys` is not a pure Rust dependency - it actually requires a full C toolchain to be installed, so adding an innocent dependency which is only supposed to generate a bit of XML surprisingly broke our cross-compilation, and it even broke `cargo check --target=$arch` (as seen [on Travis here](https://travis-ci.org/nokia/not-perf/jobs/514131389)) since now even that has to invoke a cross-toolchain.

This made me realize that maybe using `failure` in crates which are meant to be used as a library might not be the greatest idea. From what I can see there even seems to be more-or-less a consensus across the community [that it's preferable to avoid `failure`](https://www.reddit.com/r/rust/comments/a9wbs8/eli5_error_handling_errorchain_failure_upcoming/), and the general direction seems to be [to fix the `Error` trait instead of replacing it wholesale](https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md).

Of course I realize that it's silly to demand anything from `quick-xml` here as this isn't really the `quick-xml`'s fault, however I do in general feel like this would nevertheless be an improvement. Please feel free to close this PR if you disagree. (: