### PR TITLE
Allow less bloat plus some speedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ encoding_rs = { version = "0.8.17", optional = true }
 failure = { version = "0.1.5", optional = true }
 derive_more = "0.15"
 memchr = "2.2.1"
-log = "0.4.8"
 
 [dev-dependencies]
 xml-rs = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick-xml"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "High performance xml reader and writer"
 
@@ -16,11 +16,11 @@ license = "MIT"
 travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
-encoding_rs = "0.8.14"
+encoding_rs = { version = "0.8.17", optional = true }
 failure = { version = "0.1.5", optional = true }
-derive_more = "0.14"
-memchr = "2.1.2"
-log = "0.4.6"
+derive_more = "0.15"
+memchr = "2.2.1"
+log = "0.4.8"
 
 [dev-dependencies]
 xml-rs = "0.8.0"
@@ -29,4 +29,6 @@ xml-rs = "0.8.0"
 bench = false
 
 [features]
-default = ["failure"]
+default = []
+encoding = ["encoding_rs"]
+use-failure = ["failure"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## 0.16.0
+- feat: set failure and encoding_rs crates as optional. You should now use respectively 
+`use-failure` and `encoding` features to get the old behavior
+
 ## 0.15.0
 - feat: remove Seek bound
 - style: rustfmt

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ High performance xml pull reader/writer.
 The reader:
 - is almost zero-copy (use of `Cow` whenever possible)
 - is easy on memory allocation (the API provides a way to reuse buffers)
-- support various encoding, namespaces resolution, special characters.
+- support various encoding (with `encoding` feature), namespaces resolution, special characters.
 
 [docs.rs](https://docs.rs/quick-xml)
 
@@ -104,6 +104,12 @@ let result = writer.into_inner().into_inner();
 let expected = r#"<my_elem k1="v1" k2="v2" my-key="some value"><child>text</child></my_elem>"#;
 assert_eq!(result, expected.as_bytes());
 ```
+
+# Features
+
+quick-xml supports 2 additional features, non activated by default:
+- `encoding`: support non utf8 xmls
+- `use-failure`: support for failure chainable error
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ Here on my particular file, quick-xml is around **50 times faster** than [xml-rs
 
 ```
 // quick-xml benches
-test bench_quick_xml            ... bench:     256,921 ns/iter (+/- 18,306)
-test bench_quick_xml_escaped    ... bench:     324,320 ns/iter (+/- 19,968)
-test bench_quick_xml_namespaced ... bench:     396,318 ns/iter (+/- 23,663)
+test bench_quick_xml            ... bench:     198,866 ns/iter (+/- 9,663)
+test bench_quick_xml_escaped    ... bench:     282,740 ns/iter (+/- 61,625)
+test bench_quick_xml_namespaced ... bench:     389,977 ns/iter (+/- 32,045)
 
 // same bench with xml-rs
-test bench_xml_rs               ... bench:  14,839,533 ns/iter (+/- 2,377,647)
+test bench_xml_rs               ... bench:  14,468,930 ns/iter (+/- 321,171)
 ```
 
 For a feature and performance comparison, you can also have a look at RazrFalcon's [choose-your-xml-rs](https://github.com/RazrFalcon/choose-your-xml-rs).

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -185,9 +185,9 @@ fn parse_hexadecimal(bytes: &[u8]) -> Result<u32, EscapeError> {
     for &b in bytes {
         code <<= 4;
         code += match b {
-            b'0'...b'9' => b - b'0',
-            b'a'...b'f' => b - b'a' + 10,
-            b'A'...b'F' => b - b'A' + 10,
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            b'A'..=b'F' => b - b'A' + 10,
             b => return Err(EscapeError::InvalidHexadecimal(b as char)),
         } as u32;
     }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -203,7 +203,7 @@ fn parse_decimal(bytes: &[u8]) -> Result<u32, EscapeError> {
     for &b in bytes {
         code *= 10;
         code += match b {
-            b'0'...b'9' => b - b'0',
+            b'0'..=b'9' => b - b'0',
             b => return Err(EscapeError::InvalidDecimal(b as char)),
         } as u32;
     }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -106,9 +106,26 @@ impl<'a> Attribute<'a> {
     ///
     /// [`unescaped_value()`]: #method.unescaped_value
     /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
+    #[cfg(feature = "encoding_rs")]
     pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
         self.unescaped_value()
             .map(|e| reader.decode(&*e).into_owned())
+    }
+
+    /// Returns the unescaped and decoded string value.
+    ///
+    /// This allocates a `String` in all cases. For performance reasons it might be a better idea to
+    /// instead use one of:
+    ///
+    /// * [`unescaped_value()`], as it doesn't allocate when no escape sequences are used.
+    /// * [`Reader::decode()`], as it only allocates when the decoding can't be performed otherwise.
+    ///
+    /// [`unescaped_value()`]: #method.unescaped_value
+    /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
+    #[cfg(not(feature = "encoding_rs"))]
+    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
+        self.unescaped_value()
+            .and_then(|e| reader.decode(&*e).map(|s| s.to_owned()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,9 +102,16 @@
 //! let expected = r#"<my_elem k1="v1" k2="v2" my-key="some value"><child>text</child></my_elem>"#;
 //! assert_eq!(result, expected.as_bytes());
 //! ```
+//!
+//! # Features
+//!
+//! quick-xml supports 2 additional features, non activated by default:
+//! - `encoding`: support non utf8 xmls
+//! - `use-failure`: support for failure chainable error
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 
+#[cfg(feature = "encoding_rs")]
 extern crate encoding_rs;
 #[cfg(feature = "failure")]
 #[macro_use]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -925,13 +925,12 @@ fn read_elem_until<R: BufRead>(r: &mut R, end_byte: u8, buf: &mut Vec<u8>) -> Re
                 Err(e) => return Err(Error::Io(e)),
             };
 
-            let mut bytes = available.iter().enumerate();
-
+            let mut memiter = memchr::memchr3_iter(end_byte, b'\'', b'"', available);
             let used: usize;
             loop {
-                match bytes.next() {
-                    Some((i, &b)) => {
-                        state = match (state, b) {
+                match memiter.next() {
+                    Some(i) => {
+                        state = match (state, available[i]) {
                             (ElemReadState::Elem, b) if b == end_byte => {
                                 // only allowed to match `end_byte` while we are in state `Elem`
                                 buf.extend_from_slice(&available[..i]);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -325,6 +325,7 @@ fn test_default_ns_shadowing_expanded() {
 }
 
 #[test]
+#[cfg(feature = "encoding_rs")]
 fn test_koi8_r_encoding() {
     let src: &[u8] = include_bytes!("documents/opennews_all.rss");
     let mut r = Reader::from_reader(src as &[u8]);


### PR DESCRIPTION
Following [Raph Levien's post](https://raphlinus.github.io/rust/2019/08/21/rust-bloat.html) regarding bloat, allow quick-xml user to opt in for bloats..
* allow NOT using encoding_rs when we know input xml to be UTF8
* disable both failure and encoding_rs per default, use features `use-failure` and `encoding` to revert them back (**BREAKING CHANGE**)
* speed up reader even further leveraging on memchr3 iterator (about 18% better on quick-xml benches)