### PR TITLE
implement std::error::Error and remove failure dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
 encoding_rs = { version = "0.8.17", optional = true }
-failure = { version = "0.1.5", optional = true }
 memchr = "2.2.1"
 
 [lib]
@@ -26,4 +25,3 @@ bench = false
 [features]
 default = []
 encoding = ["encoding_rs"]
-use-failure = ["failure"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,12 @@
 //! Error management module
 
 /// The error type used by this crate.
-#[cfg_attr(feature = "failure", derive(Fail))]
 #[derive(Debug)]
 pub enum Error {
     /// IO error
-    Io(#[cfg_attr(feature = "failure", cause)] ::std::io::Error),
+    Io(::std::io::Error),
     /// Utf8 error
-    Utf8(#[cfg_attr(feature = "failure", cause)] ::std::str::Utf8Error),
+    Utf8(::std::str::Utf8Error),
     /// Unexpected End of File
     UnexpectedEof(String),
     /// End event mismatch
@@ -34,7 +33,7 @@ pub enum Error {
     /// Duplicate attribute
     DuplicatedAttribute(usize, usize),
     /// Escape error
-    EscapeError(#[cfg_attr(feature = "failure", cause)] ::escape::EscapeError),
+    EscapeError(::escape::EscapeError),
 }
 
 impl From<::std::io::Error> for Error {
@@ -103,6 +102,17 @@ impl std::fmt::Display for Error {
                 pos1, pos2
             ),
             Error::EscapeError(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            Error::Utf8(e) => Some(e),
+            Error::EscapeError(e) => Some(e),
+            _ => None,
         }
     }
 }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -3,7 +3,6 @@
 use memchr;
 use std::borrow::Cow;
 
-#[cfg_attr(feature = "failure", derive(Fail))]
 #[derive(Debug)]
 pub enum EscapeError {
     /// Entity with Null character
@@ -52,6 +51,8 @@ impl std::fmt::Display for EscapeError {
         }
     }
 }
+
+impl std::error::Error for EscapeError {}
 
 // UTF-8 ranges and tags for encoding characters
 const TAG_CONT: u8 = 0b1000_0000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,9 +113,6 @@
 
 #[cfg(feature = "encoding_rs")]
 extern crate encoding_rs;
-#[cfg(feature = "failure")]
-#[macro_use]
-extern crate failure;
 extern crate memchr;
 
 mod errors;


### PR DESCRIPTION
Failure derives `Fail` from `std::error::Error` anyway. 