### PR TITLE
Add BytesStart::attributes_raw() to access raw tag attributes

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -140,6 +140,13 @@ impl<'a> BytesStart<'a> {
         Attributes::html(self, self.name_len)
     }
 
+    /// Gets the undecoded raw string with the attributes of this tag as a `&[u8]`,
+    /// including the whitespace after the tag name if there is any.
+    #[inline]
+    pub fn attributes_raw(&self) -> &[u8] {
+        &self.buf[self.name_len..]
+    }
+
     /// Add additional attributes to this tag using an iterator.
     ///
     /// The yielded items must be convertible to [`Attribute`] using `Into`.
@@ -660,8 +667,10 @@ mod test {
         let mut b = BytesStart::owned_name("test");
         assert_eq!(b.len(), 4);
         assert_eq!(b.name(), b"test");
+        assert_eq!(b.attributes_raw(), b"");
         b.push_attribute(("x", "a"));
         assert_eq!(b.len(), 10);
+        assert_eq!(b.attributes_raw(), b" x=\"a\"");
         b.set_name(b"g");
         assert_eq!(b.len(), 7);
         assert_eq!(b.name(), b"g");


### PR DESCRIPTION
I use quick-xml to parse XML files with a defined format. When profiling my application, I found that `<quick_xml::events::attributes::Attributes as core::iter::traits::iterator::Iterator>::next` takes up almost 8% of execution time. It is also responsible for the majority of temporary allocations even with `with_checks(false)`. All I need is to find opening tags with a known key=value, and for this particular task iterating over `Attributes` is superfluous. Unfortunately I couldn't find a way to extract tag attributes without parsing them (save for reading the input buffer based on `Reader::buffer_position`, but that's a bit too low-level for my taste).

`BytesStart::attributes_raw()` solves my use case and doesn't add a lot of code. I'd love to see this upstreamed :)