### PR TITLE
Nested Struct and Enum Serialization

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -121,7 +121,7 @@ use serde::de::{self, DeserializeOwned};
 use serde::forward_to_deserialize_any;
 use std::io::BufRead;
 
-const INNER_VALUE: &str = "$value";
+pub(crate) const INNER_VALUE: &str = "$value";
 
 /// An xml deserializer
 pub struct Deserializer<R: BufRead> {

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -146,17 +146,12 @@ impl<'w, W: Write> ser::Serializer for &'w mut Serializer<W> {
 
     fn serialize_unit_variant(
         self,
-        name: &'static str,
+        _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, DeError> {
-        let name = name.as_bytes();
         self.writer
-            .write_event(Event::Start(BytesStart::borrowed_name(name)))?;
-        self.writer
-            .write_event(Event::Text(BytesText::from_plain_str(variant)))?;
-        self.writer
-            .write_event(Event::End(BytesEnd::borrowed(name)))?;
+            .write_event(Event::Empty(BytesStart::borrowed_name(variant.as_bytes())))?;
         Ok(())
     }
 
@@ -180,6 +175,7 @@ impl<'w, W: Write> ser::Serializer for &'w mut Serializer<W> {
         let mut this = self;
         this.nesting += 1;
         value.serialize(&mut *this)?;
+        this.nesting = this.nesting.saturating_sub(1);
         this.writer
             .write_event(Event::End(BytesEnd::borrowed(variant.as_bytes())))?;
         Ok(())

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -96,14 +96,19 @@ where
         key: &'static str,
         value: &T,
     ) -> Result<(), DeError> {
+        let wrap_inner = key != crate::de::INNER_VALUE;
         let key = key.as_bytes();
-        self.parent
-            .writer
-            .write_event(Event::Start(BytesStart::borrowed_name(key)))?;
+        if wrap_inner {
+            self.parent
+                .writer
+                .write_event(Event::Start(BytesStart::borrowed_name(key)))?;
+        }
         value.serialize(&mut *self.parent)?;
-        self.parent
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(key)))?;
+        if wrap_inner {
+            self.parent
+                .writer
+                .write_event(Event::End(BytesEnd::borrowed(key)))?;
+        }
         Ok(())
     }
 

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -108,9 +108,13 @@ where
     }
 
     fn end(self) -> Result<Self::Ok, DeError> {
-        self.parent
-            .writer
-            .write_event(Event::End(BytesEnd::borrowed(self.name.as_bytes())))?;
+        let mut this = self;
+        this.parent.nesting = this.parent.nesting.saturating_sub(1);
+        if this.parent.nesting == 0 {
+            this.parent
+                .writer
+                .write_event(Event::End(BytesEnd::borrowed(this.name.as_bytes())))?;
+        }
         Ok(())
     }
 }

--- a/tests/serde_rename_roundtrip.rs
+++ b/tests/serde_rename_roundtrip.rs
@@ -1,0 +1,113 @@
+#![cfg(feature = "serialize")]
+
+extern crate quick_xml;
+extern crate serde;
+
+use quick_xml::{de::from_str, se::to_string};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Nested {
+    #[serde(rename="A")]
+    a: ItemA,
+    #[serde(rename="B")]
+    b: ItemB,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+enum Wrapper {
+    #[serde(rename="ItA")]
+    A(ItemA),
+    #[serde(rename="ItB")]
+    B(ItemB),
+    #[serde(rename="Nd")]
+    Node(Node),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct ItemA {
+    #[serde(rename="Nm")]
+    name: String,
+    #[serde(rename="Src")]
+    source: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct ItemB {
+    #[serde(rename="Cnt")]
+    cnt: usize,
+    #[serde(rename="Nodes")]
+    nodes: Nodes,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+enum Node {
+    Boolean(bool),
+    Identifier { value: String, index: u32 },
+    EOF,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Nodes {
+    #[serde(rename = "$value")]
+    items: Vec<Node>,
+}
+
+#[test]
+fn basic_struct() {
+    let src = r#"<ItemA><Nm>Banana</Nm><Src>Store</Src></ItemA>"#;
+    let should_be = ItemA {
+        name: "Banana".to_string(),
+        source: "Store".to_string(),
+    };
+
+    let v: ItemA = from_str(src).unwrap();
+    assert_eq!(v, should_be);
+
+    let reserialized_item = to_string(&v).unwrap();
+    assert_eq!(src, reserialized_item);
+}
+
+#[test]
+fn nested_struct() {
+    let src = r#"<Nested><A><Nm>Banana</Nm><Src>Store</Src></A><B><Cnt>2</Cnt><Nodes></Nodes></Nested>"#;
+    let should_be = Nested {
+        a: ItemA {
+            name: "Banana".to_string(),
+            source: "Store".to_string(),
+        },
+        b: ItemB {
+            cnt: 2,
+            nodes: Nodes {
+                items: vec![
+                    Node::Boolean(false),
+                    Node::EOF,
+                ]
+            }
+        }
+    };
+
+    let ser_item = to_string(&should_be).unwrap();
+    println!("Serialized: {}", ser_item);
+
+    let v: Nested = from_str(src).unwrap();
+    assert_eq!(v, should_be);
+
+    let reserialized_item = to_string(&v).unwrap();
+    assert_eq!(src, reserialized_item);
+}
+
+#[test]
+fn wrapped_struct() {
+    let src = r#"<ItA><Nm>Banana</Nm><Src>Store</Src></ItA>"#;
+    let should_be = Wrapper::A(ItemA {
+        name: "Banana".to_string(),
+        source: "Store".to_string(),
+    });
+
+    let v: Wrapper = from_str(src).unwrap();
+    assert_eq!(v, should_be);
+
+    let reserialized_item = to_string(&v).unwrap();
+    assert_eq!(src, reserialized_item);
+}

--- a/tests/serde_rename_roundtrip.rs
+++ b/tests/serde_rename_roundtrip.rs
@@ -70,7 +70,7 @@ fn basic_struct() {
 
 #[test]
 fn nested_struct() {
-    let src = r#"<Nested><A><Nm>Banana</Nm><Src>Store</Src></A><B><Cnt>2</Cnt><Nodes></Nodes></Nested>"#;
+    let src = r#"<Nested><A><Nm>Banana</Nm><Src>Store</Src></A><B><Cnt>2</Cnt><Nodes><Boolean>false</Boolean><EOF /></Nodes></Nested>"#;
     let should_be = Nested {
         a: ItemA {
             name: "Banana".to_string(),


### PR DESCRIPTION
This PR fixes issues with nested struct and enum serialization, where the struct name will be serialized multiple times, or enum name will serialized. Unit variant enums are supported as well.