### PR TITLE
Fix serialization of structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quick-xml"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "High performance xml reader and writer"
 
@@ -30,6 +30,7 @@ bench = false
 default = []
 encoding = ["encoding_rs"]
 serialize = ["serde"]
+failed_test = []
 
 [package.metadata.docs.rs]
 features = ["serialize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ bench = false
 default = []
 encoding = ["encoding_rs"]
 serialize = ["serde"]
-failed_test = []
 
 [package.metadata.docs.rs]
 features = ["serialize"]

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -27,7 +27,7 @@ struct Nodes {
 
 #[test]
 fn basic_struct() {
-    let src = r#"<Item><name>Banana</name><source>Store</source></Item>"#;
+    let src = r#"<Item name="Banana" source="Store"></Item>"#;
     let should_be = Item {
         name: "Banana".to_string(),
         source: "Store".to_string(),

--- a/tests/serde_structs.rs
+++ b/tests/serde_structs.rs
@@ -1,0 +1,111 @@
+#![cfg(feature = "serialize")]
+
+extern crate quick_xml;
+extern crate serde;
+
+use quick_xml::{
+    de::from_str,
+    se
+};
+use serde::{Deserialize, Serialize};
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_deserialize_struct_complex_outer()
+    {
+        #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+        #[serde(rename = "inner", default)]
+        struct Inner {
+            in_dummy: u32
+        }
+
+        #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+        struct Test1 {
+            dummy1: u32,
+            dummy2: String,
+            inner: Inner,
+        }
+
+        const TEST_XML_1: &str =
+            r#"<Test1 dummy1="10" dummy2="bar"><inner in_dummy="30"></inner></Test1>"#;
+
+        println!{};
+        println!{"original XML {}", TEST_XML_1};
+        println!{};
+
+        let outer: Test1 = match from_str(TEST_XML_1) {
+            Ok(foo) => foo,
+            Err(e) => {
+                println!{"deserialize error {:?}", e};
+                assert!{false};
+                return;
+            }
+        };
+
+        println!{"outer {:?}", &outer};
+        println!{};
+
+        let xml2 = match se::to_string(&outer) {
+            Ok(xml2) => xml2,
+            Err(e) => {
+                println!{"serialize error {:?}", e};
+                assert!{false};
+                return;
+            }
+        };
+        println!{"serialized {:?}", &xml2};
+        println!{};
+
+        assert_eq!(TEST_XML_1, &xml2)
+    }
+
+    #[test]
+    fn test_serialize_deserialize_struct_nested()
+    {
+        #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+        #[serde(rename = "inner", default)]
+        struct Inner {
+            in_dummy: u32
+        }
+
+        #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+        struct Test2 {
+            inner: Inner,
+        }
+        const TEST_XML_2: &str =
+            r#"<Test2><inner in_dummy="30"></inner></Test2>"#;
+
+        println!{};
+        println!{"original XML {}", TEST_XML_2};
+        println!{};
+
+        let outer: Test2 = match from_str(TEST_XML_2) {
+            Ok(foo) => foo,
+            Err(e) => {
+                println!{"deserialize error {:?}", e};
+                assert!{false};
+                return;
+            }
+        };
+
+        println!{"outer {:?}", &outer};
+        println!{};
+
+        let xml2 = match se::to_string(&outer) {
+            Ok(xml2) => xml2,
+            Err(e) => {
+                println!{"serialize error {:?}", e};
+                assert!{false};
+                return;
+            }
+        };
+        println!{"serialized {:?}", &xml2};
+        println!{};
+
+        assert_eq!(TEST_XML_2, &xml2)
+    }
+}

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -238,8 +238,8 @@ fn test_writer_borrow() {
     assert_eq!(result, txt.as_bytes());
 }
 
-#[cfg(feature = "failed_test")]
 #[test]
+#[ignore]
 fn test_writer_indent() {
     let txt = include_str!("../tests/documents/test_writer_indent.xml");
     let mut reader = Reader::from_str(txt);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -238,6 +238,7 @@ fn test_writer_borrow() {
     assert_eq!(result, txt.as_bytes());
 }
 
+#[cfg(feature = "failed_test")]
 #[test]
 fn test_writer_indent() {
     let txt = include_str!("../tests/documents/test_writer_indent.xml");

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -4,8 +4,8 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::{Reader, Result};
 use std::str::from_utf8;
 
-#[cfg(feature = "failed_test")]
 #[test]
+#[ignore]
 fn sample_1_short() {
     test(
         include_bytes!("documents/sample_1.xml"),
@@ -14,8 +14,8 @@ fn sample_1_short() {
     );
 }
 
-#[cfg(feature = "failed_test")]
 #[test]
+#[ignore]
 fn sample_1_full() {
     test(
         include_bytes!("documents/sample_1.xml"),
@@ -24,8 +24,8 @@ fn sample_1_full() {
     );
 }
 
-#[cfg(feature = "failed_test")]
 #[test]
+#[ignore]
 fn sample_2_short() {
     test(
         include_bytes!("documents/sample_2.xml"),
@@ -34,8 +34,8 @@ fn sample_2_short() {
     );
 }
 
-#[cfg(feature = "failed_test")]
 #[test]
+#[ignore]
 fn sample_2_full() {
     test(
         include_bytes!("documents/sample_2.xml"),
@@ -81,8 +81,8 @@ fn sample_2_full() {
 //
 // }
 
-#[cfg(feature = "failed_test")]
 #[test]
+#[ignore]
 fn sample_ns_short() {
     test(
         include_bytes!("documents/sample_ns.xml"),

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -4,6 +4,7 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::{Reader, Result};
 use std::str::from_utf8;
 
+#[cfg(feature = "failed_test")]
 #[test]
 fn sample_1_short() {
     test(
@@ -13,6 +14,7 @@ fn sample_1_short() {
     );
 }
 
+#[cfg(feature = "failed_test")]
 #[test]
 fn sample_1_full() {
     test(
@@ -22,6 +24,7 @@ fn sample_1_full() {
     );
 }
 
+#[cfg(feature = "failed_test")]
 #[test]
 fn sample_2_short() {
     test(
@@ -31,6 +34,7 @@ fn sample_2_short() {
     );
 }
 
+#[cfg(feature = "failed_test")]
 #[test]
 fn sample_2_full() {
     test(
@@ -77,6 +81,7 @@ fn sample_2_full() {
 //
 // }
 
+#[cfg(feature = "failed_test")]
 #[test]
 fn sample_ns_short() {
     test(


### PR DESCRIPTION
Attributes were being created as child elements.

This works correctly if the simple types that should be attributes are
kept at the beginning of the struct and the more complex types that
should be children are after all of the simple types.

To solve this correctly, there should probably be two Vecs, one for the
attributes and one for the children.