### PR TITLE
Add Vec-less reading of events and borrowing deserialization

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -115,35 +115,56 @@ mod var;
 pub use crate::errors::serialize::DeError;
 use crate::{
     events::{BytesStart, BytesText, Event},
-    Reader,
+    Reader, reader::Decoder,
 };
-use serde::de::{self, DeserializeOwned};
+use serde::de::{self, Deserialize, DeserializeOwned};
 use serde::forward_to_deserialize_any;
 use std::io::BufRead;
+use std::borrow::Cow;
 
 const INNER_VALUE: &str = "$value";
 
 /// An xml deserializer
-pub struct Deserializer<R: BufRead> {
-    reader: Reader<R>,
-    peek: Option<Event<'static>>,
+pub struct Deserializer<'de, R: BorrowingReader<'de>> {
+    reader: R,
+    peek: Option<Event<'de>>,
     has_value_field: bool,
 }
 
 /// Deserialize a xml string
-pub fn from_str<T: DeserializeOwned>(s: &str) -> Result<T, DeError> {
-    from_reader(s.as_bytes())
+pub fn from_str<'de, T: Deserialize<'de>>(s: &'de str) -> Result<T, DeError> {
+    from_bytes(s.as_bytes())
+}
+
+/// Deserialize a xml slice of bytes
+pub fn from_bytes<'de, T: Deserialize<'de>>(s: &'de [u8]) -> Result<T, DeError> {
+    let mut reader = Reader::from_bytes(s);
+    reader
+        .expand_empty_elements(true)
+        .check_end_names(true)
+        .trim_text(true);
+    let mut de = Deserializer::from_borrowing_reader(
+        SliceReader { reader }
+    );
+    T::deserialize(&mut de)
 }
 
 /// Deserialize from a reader
 pub fn from_reader<R: BufRead, T: DeserializeOwned>(reader: R) -> Result<T, DeError> {
-    let mut de = Deserializer::from_reader(reader);
+    let mut reader = Reader::from_reader(reader);
+    reader
+        .expand_empty_elements(true)
+        .check_end_names(true)
+        .trim_text(true);
+    let mut de = Deserializer::from_borrowing_reader(
+        IoReader { reader, buf: Vec::new() }
+    );
     T::deserialize(&mut de)
 }
 
-impl<R: BufRead> Deserializer<R> {
+impl<'de, R: BorrowingReader<'de>> Deserializer<'de, R> {
     /// Get a new deserializer
-    pub fn new(reader: Reader<R>) -> Self {
+    pub fn new(reader: R) -> Self {
         Deserializer {
             reader,
             peek: None,
@@ -152,56 +173,43 @@ impl<R: BufRead> Deserializer<R> {
     }
 
     /// Get a new deserializer from a regular BufRead
-    pub fn from_reader(reader: R) -> Self {
-        let mut reader = Reader::from_reader(reader);
-        reader
-            .expand_empty_elements(true)
-            .check_end_names(true)
-            .trim_text(true);
+    pub fn from_borrowing_reader(reader: R) -> Self {
         Self::new(reader)
     }
 
-    fn peek(&mut self) -> Result<Option<&Event<'static>>, DeError> {
+    fn peek(&mut self) -> Result<Option<&Event<'de>>, DeError> {
         if self.peek.is_none() {
-            self.peek = Some(self.next(&mut Vec::new())?);
+            self.peek = Some(self.next()?);
         }
         Ok(self.peek.as_ref())
     }
 
-    fn next<'a>(&mut self, buf: &'a mut Vec<u8>) -> Result<Event<'static>, DeError> {
+    fn next(&mut self) -> Result<Event<'de>, DeError> {
         if let Some(e) = self.peek.take() {
             return Ok(e);
         }
-        loop {
-            let e = self.reader.read_event(buf)?;
-            match e {
-                Event::Start(_) | Event::End(_) | Event::Text(_) | Event::Eof | Event::CData(_) => {
-                    return Ok(e.into_owned())
-                }
-                _ => buf.clear(),
-            }
-        }
+        self.reader.next()
     }
 
-    fn next_start(&mut self, buf: &mut Vec<u8>) -> Result<Option<BytesStart<'static>>, DeError> {
+    fn next_start(&mut self) -> Result<Option<BytesStart<'de>>, DeError> {
         loop {
-            let e = self.next(buf)?;
+            let e = self.next()?;
             match e {
                 Event::Start(e) => return Ok(Some(e)),
                 Event::End(_) => return Err(DeError::End),
                 Event::Eof => return Ok(None),
-                _ => buf.clear(), // ignore texts
+                _ => (), // ignore texts
             }
         }
     }
 
-    fn next_text<'a>(&mut self) -> Result<BytesText<'static>, DeError> {
-        match self.next(&mut Vec::new())? {
+    fn next_text(&mut self) -> Result<BytesText<'de>, DeError> {
+        match self.next()? {
             Event::Text(e) | Event::CData(e) => Ok(e),
             Event::Eof => Err(DeError::Eof),
             Event::Start(e) => {
                 // allow one nested level
-                let inner = self.next(&mut Vec::new())?;
+                let inner = self.next()?;
                 let t = match inner {
                     Event::Text(t) | Event::CData(t) => t,
                     Event::Start(_) => return Err(DeError::Start),
@@ -224,13 +232,13 @@ impl<R: BufRead> Deserializer<R> {
     }
 
     fn read_to_end(&mut self, name: &[u8]) -> Result<(), DeError> {
-        let mut buf = Vec::new();
-        match self.next(&mut buf)? {
-            Event::Start(e) => self.reader.read_to_end(e.name(), &mut Vec::new())?,
+        // First one might be in self.peek
+        match self.next()? {
+            Event::Start(e) => self.reader.read_to_end(e.name())?,
             Event::End(e) if e.name() == name => return Ok(()),
-            _ => buf.clear(),
+            _ => (),
         }
-        Ok(self.reader.read_to_end(name, &mut buf)?)
+        self.reader.read_to_end(name)
     }
 }
 
@@ -240,17 +248,17 @@ macro_rules! deserialize_type {
             let txt = self.next_text()?;
 
             #[cfg(not(feature = "encoding"))]
-            let value = self.reader.decode(&*txt)?.parse()?;
+            let value = self.reader.decoder().decode(&*txt)?.parse()?;
 
             #[cfg(feature = "encoding")]
-            let value = self.reader.decode(&*txt).parse()?;
+            let value = self.reader.decoder().decode(&*txt).parse()?;
 
             visitor.$visit(value)
         }
     }
 }
 
-impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
+impl<'de, 'a, R: BorrowingReader<'de>> de::Deserializer<'de> for &'a mut Deserializer<'de, R> {
     type Error = DeError;
 
     forward_to_deserialize_any! { newtype_struct identifier }
@@ -261,7 +269,7 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
         fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, DeError> {
-        if let Some(e) = self.next_start(&mut Vec::new())? {
+        if let Some(e) = self.next_start()? {
             let name = e.name().to_vec();
             self.has_value_field = fields.contains(&INNER_VALUE);
             let map = map::MapAccess::new(self, e)?;
@@ -313,14 +321,19 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
                 b"false" | b"0" | b"False" | b"FALSE" | b"f" | b"No" | b"NO" | b"no" | b"n" => {
                     visitor.visit_bool(false)
                 }
-                e => Err(DeError::InvalidBoolean(self.reader.decode(e)?.into())),
+                e => Err(DeError::InvalidBoolean(
+                    self.reader.decoder().decode(e)?.into()
+                )),
             }
         }
     }
 
     fn deserialize_string<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
-        let value = self.next_text()?.unescape_and_decode(&self.reader)?;
-        visitor.visit_string(value)
+        let text = self.next_text()?;
+        let unescaped = text.unescaped()?;
+        let decoded = self.reader.decoder().decode(&unescaped)?;
+
+        visitor.visit_string(decoded.to_string())
     }
 
     fn deserialize_char<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
@@ -328,7 +341,23 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 
     fn deserialize_str<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
-        self.deserialize_string(visitor)
+        let text = self.next_text()?;
+        let unescaped = text.into_unescaped()?;
+
+        match unescaped {
+            Cow::Borrowed(unescaped) => {
+                // FIXME: Encoding has Cow instead
+                let decoded = self.reader.decoder().decode(unescaped)?;
+
+                visitor.visit_borrowed_str(decoded)
+            },
+            Cow::Owned(unescaped) => {
+                // FIXME: Encoding has Cow instead
+                let decoded = self.reader.decoder().decode_owned(unescaped)?;
+
+                visitor.visit_string(decoded)
+            },
+        }
     }
 
     fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
@@ -340,8 +369,7 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 
     fn deserialize_unit<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
-        let mut buf = Vec::new();
-        match self.next(&mut buf)? {
+        match self.next()? {
             Event::Start(s) => {
                 self.read_to_end(s.name())?;
                 visitor.visit_unit()
@@ -402,7 +430,7 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 
     fn deserialize_ignored_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
-        match self.next(&mut Vec::new())? {
+        match self.next()? {
             Event::Start(e) => self.read_to_end(e.name())?,
             Event::End(_) => return Err(DeError::End),
             _ => (),
@@ -419,10 +447,179 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 }
 
+/// A trait that borrows an XML reader that borrows from the input. For a &[u8]
+/// input the events will borrow from that input, whereas with a BufRead input
+/// all events will be converted to 'static, allocating whenever necessary.
+pub trait BorrowingReader<'i> where Self: 'i {
+    /// Return an input-borrowing event.
+    fn next(&mut self) -> Result<Event<'i>, DeError>;
+
+    /// Skips until end element is found. Unlike `next()` it will not allocate
+    /// when it cannot satisfy the lifetime.
+    fn read_to_end(&mut self, name: &[u8]) -> Result<(), DeError>;
+
+    /// A copy of the reader's decoder used to decode strings.
+    fn decoder(&self) -> Decoder {
+        Decoder
+    }
+}
+
+struct IoReader<R: BufRead> {
+    reader: Reader<R>,
+    buf: Vec<u8>,
+}
+
+impl<'i, R: BufRead + 'i> BorrowingReader<'i> for IoReader<R> {
+    fn next(&mut self) -> Result<Event<'static>, DeError> {
+        let event = loop {
+            let e = self.reader.read_event(&mut self.buf)?;
+            match e {
+                Event::Start(_) | Event::End(_) | Event::Text(_) | Event::Eof | Event::CData(_) => {
+                    break Ok(e.into_owned())
+                }
+                _ => self.buf.clear(),
+            }
+        };
+
+        self.buf.clear();
+
+        event
+    }
+
+    fn read_to_end(&mut self, name: &[u8]) -> Result<(), DeError> {
+        Ok(self.reader.read_to_end(name, &mut self.buf)?)
+    }
+}
+
+struct SliceReader<'de> {
+    reader: Reader<&'de [u8]>,
+}
+
+impl<'de> BorrowingReader<'de> for SliceReader<'de> {
+    fn next(&mut self) -> Result<Event<'de>, DeError> {
+        loop {
+            let e = self.reader.read_event_unbuffered()?;
+            match e {
+                Event::Start(_) | Event::End(_) | Event::Text(_) | Event::Eof | Event::CData(_) => {
+                    break Ok(e)
+                }
+                _ => (),
+            }
+        }
+    }
+
+    fn read_to_end(&mut self, name: &[u8]) -> Result<(), DeError> {
+        Ok(self.reader.read_to_end_unbuffered(name)?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde::Deserialize;
+
+    #[test]
+    fn borrowing_reader_parity() {
+        let s = r##"
+            <item name="hello" source="world.rs">Some text</item>
+            <item2/>
+            <item3 value="world" />
+    	"##.as_bytes();
+
+        let mut reader1 = IoReader {
+            reader: Reader::from_reader(s),
+            buf: Vec::new()
+        };
+        let mut reader2 = SliceReader {
+            reader: Reader::from_bytes(s),
+        };
+
+        loop {
+            let event1 = reader1.next().unwrap();
+            let event2 = reader2.next().unwrap();
+
+            if let (Event::Eof, Event::Eof) = (&event1, &event2) {
+                break;
+            }
+
+            assert_eq!(format!("{:?}", event1), format!("{:?}", event2));
+        }
+    }
+
+    #[test]
+    fn borrowing_reader_events() {
+        let s = r##"
+            <item name="hello" source="world.rs">Some text</item>
+            <item2></item2>
+            <item3/>
+            <item4 value="world" />
+        "##.as_bytes();
+
+        let mut reader = SliceReader {
+            reader: Reader::from_bytes(s),
+        };
+
+        reader.reader
+            .trim_text(true)
+            .expand_empty_elements(true)
+            .check_end_names(true);
+
+        let mut events = Vec::new();
+
+        loop {
+            let event = reader.next().unwrap();
+            if let Event::Eof = event {
+                break;
+            }
+            events.push(event);
+        }
+
+        use crate::events::{BytesStart, BytesText, BytesEnd, Event::*};
+
+        assert_eq!(events, vec![
+            Start(BytesStart::borrowed(br#"item name="hello" source="world.rs""#, 4)),
+            Text(BytesText::from_escaped(b"Some text".as_ref())),
+            End(BytesEnd::borrowed(b"item")),
+            Start(BytesStart::borrowed(b"item2", 5)),
+            End(BytesEnd::borrowed(b"item2")),
+            Start(BytesStart::borrowed(b"item3", 5)),
+            End(BytesEnd::borrowed(b"item3")),
+            Start(BytesStart::borrowed(br#"item4 value="world" "#, 5)),
+            End(BytesEnd::borrowed(b"item4")),
+        ])
+    }
+
+    #[test]
+    fn borrowing_read_to_end() {
+        let s = " <item /> ";
+        let mut reader = SliceReader {
+            reader: Reader::from_str(s),
+        };
+
+        reader.reader
+            .trim_text(true)
+            .expand_empty_elements(true)
+            .check_end_names(true);
+
+        assert_eq!(reader.next().unwrap(), Event::Start(BytesStart::borrowed(b"item ", 4)));
+        reader.read_to_end(b"item").unwrap();
+        assert_eq!(reader.next().unwrap(), Event::Eof);
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct BorrowedText<'a> {
+        #[serde(rename = "$value")]
+        text: &'a str,
+    }
+
+    #[test]
+    fn string_borrow() {
+        let s = "<text>Hello world</text>";
+
+        let borrowed_item: BorrowedText = from_str(s).unwrap();
+
+        assert_eq!(borrowed_item.text, "Hello world");
+    }
 
     #[derive(Debug, Deserialize, PartialEq)]
     struct Item {
@@ -436,7 +633,7 @@ mod tests {
 	    <item name="hello" source="world.rs" />
 	"##;
 
-        let item: Item = from_str(s).unwrap();
+        let item: Item = from_reader(s.as_bytes()).unwrap();
 
         assert_eq!(
             item,

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -27,7 +27,7 @@ use memchr;
 /// [`local_name`]: #method.local_name
 /// [`unescaped`]: #method.unescaped
 /// [`attributes`]: #method.attributes
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesStart<'a> {
     /// content of the element, before any utf8 conversion
     buf: Cow<'a, [u8]>,
@@ -132,7 +132,7 @@ impl<'a> BytesStart<'a> {
 
     /// Returns an iterator over the attributes of this tag.
     pub fn attributes(&self) -> Attributes {
-        Attributes::new(self, self.name_len)
+        Attributes::new(&self.buf, self.name_len)
     }
 
     /// Returns an iterator over the HTML-like attributes of this tag (no mandatory quotes or `=`).
@@ -242,7 +242,7 @@ impl<'a> std::fmt::Debug for BytesStart<'a> {
 /// An XML declaration (`Event::Decl`).
 ///
 /// [W3C XML 1.1 Prolog and Document Type Declaration](http://w3.org/TR/xml11/#sec-prolog-dtd)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BytesDecl<'a> {
     element: BytesStart<'a>,
 }
@@ -364,7 +364,7 @@ impl<'a> BytesDecl<'a> {
 }
 
 /// A struct to manage `Event::End` events
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesEnd<'a> {
     name: Cow<'a, [u8]>,
 }
@@ -423,7 +423,7 @@ impl<'a> std::fmt::Debug for BytesEnd<'a> {
 }
 
 /// Data from various events (most notably, `Event::Text`).
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesText<'a> {
     // Invariant: The content is always escaped.
     content: Cow<'a, [u8]>,
@@ -478,6 +478,23 @@ impl<'a> BytesText<'a> {
     /// returns Malformed error with index within element if '&' is not followed by ';'
     pub fn unescaped(&self) -> Result<Cow<[u8]>> {
         unescape(self).map_err(Error::EscapeError)
+    }
+
+    /// gets escaped content
+    ///
+    /// Same as `unescaped()`, but will reuse the internal buffer when possible.
+    pub fn into_unescaped(self) -> Result<Cow<'a, [u8]>> {
+        match self.content {
+            Cow::Owned(bytes) => {
+                // TODO: Make unescape accept a Cow and reuse the owned string
+                unescape(&bytes)
+                    .map(|b| b.into_owned().into())
+                    .map_err(Error::EscapeError)
+            },
+            Cow::Borrowed(bytes) => {
+                unescape(bytes).map_err(Error::EscapeError)
+            }
+        }
     }
 
     /// helper method to unescape then decode self using the reader encoding
@@ -559,7 +576,7 @@ impl<'a> std::fmt::Debug for BytesText<'a> {
 /// Event emitted by [`Reader::read_event`].
 ///
 /// [`Reader::read_event`]: ../reader/struct.Reader.html#method.read_event
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Event<'a> {
     /// Start tag (with attributes) `<tag attr="value">`.
     Start(BytesStart<'a>),

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -241,6 +241,10 @@ fn test_writer_borrow() {
 #[test]
 fn test_writer_indent() {
     let txt = include_str!("../tests/documents/test_writer_indent.xml");
+    // Normalize newlines on Windows to just \n, which is what the reader and
+    // writer use.
+    let normalized_txt = txt.replace("\r\n", "\n");
+    let txt = normalized_txt.as_str();
     let mut reader = Reader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -7,8 +7,8 @@ use std::str::from_utf8;
 #[test]
 fn sample_1_short() {
     test(
-        include_bytes!("documents/sample_1.xml"),
-        include_bytes!("documents/sample_1_short.txt"),
+        include_str!("documents/sample_1.xml"),
+        include_str!("documents/sample_1_short.txt"),
         true,
     );
 }
@@ -16,8 +16,8 @@ fn sample_1_short() {
 #[test]
 fn sample_1_full() {
     test(
-        include_bytes!("documents/sample_1.xml"),
-        include_bytes!("documents/sample_1_full.txt"),
+        include_str!("documents/sample_1.xml"),
+        include_str!("documents/sample_1_full.txt"),
         false,
     );
 }
@@ -25,8 +25,8 @@ fn sample_1_full() {
 #[test]
 fn sample_2_short() {
     test(
-        include_bytes!("documents/sample_2.xml"),
-        include_bytes!("documents/sample_2_short.txt"),
+        include_str!("documents/sample_2.xml"),
+        include_str!("documents/sample_2_short.txt"),
         true,
     );
 }
@@ -34,8 +34,8 @@ fn sample_2_short() {
 #[test]
 fn sample_2_full() {
     test(
-        include_bytes!("documents/sample_2.xml"),
-        include_bytes!("documents/sample_2_full.txt"),
+        include_str!("documents/sample_2.xml"),
+        include_str!("documents/sample_2_full.txt"),
         false,
     );
 }
@@ -43,8 +43,8 @@ fn sample_2_full() {
 // #[test]
 // fn sample_3_short() {
 //     test(
-//         include_bytes!("documents/sample_3.xml"),
-//         include_bytes!("documents/sample_3_short.txt"),
+//         include_str!("documents/sample_3.xml"),
+//         include_str!("documents/sample_3_short.txt"),
 //         true
 //     );
 // }
@@ -52,8 +52,8 @@ fn sample_2_full() {
 // #[test]
 // fn sample_3_full() {
 //     test(
-//         include_bytes!("documents/sample_3.xml"),
-//         include_bytes!("documents/sample_3_full.txt"),
+//         include_str!("documents/sample_3.xml"),
+//         include_str!("documents/sample_3_full.txt"),
 //         false
 //     );
 // }
@@ -61,8 +61,8 @@ fn sample_2_full() {
 // #[test]
 // fn sample_4_short() {
 //     test(
-//         include_bytes!("documents/sample_4.xml"),
-//         include_bytes!("documents/sample_4_short.txt"),
+//         include_str!("documents/sample_4.xml"),
+//         include_str!("documents/sample_4_short.txt"),
 //         true
 //     );
 // }
@@ -70,8 +70,8 @@ fn sample_2_full() {
 // #[test]
 // fn sample_4_full() {
 //     test(
-//         include_bytes!("documents/sample_4.xml"),
-//         include_bytes!("documents/sample_4_full.txt"),
+//         include_str!("documents/sample_4.xml"),
+//         include_str!("documents/sample_4_full.txt"),
 //         false
 //     );
 //
@@ -80,8 +80,8 @@ fn sample_2_full() {
 #[test]
 fn sample_ns_short() {
     test(
-        include_bytes!("documents/sample_ns.xml"),
-        include_bytes!("documents/sample_ns_short.txt"),
+        include_str!("documents/sample_ns.xml"),
+        include_str!("documents/sample_ns_short.txt"),
         true,
     );
 }
@@ -89,8 +89,8 @@ fn sample_ns_short() {
 #[test]
 fn eof_1() {
     test(
-        br#"<?xml"#,
-        br#"Error: Unexpected EOF during reading XmlDecl."#,
+        r#"<?xml"#,
+        r#"Error: Unexpected EOF during reading XmlDecl."#,
         true,
     );
 }
@@ -98,8 +98,8 @@ fn eof_1() {
 #[test]
 fn bad_1() {
     test(
-        br#"<?xml&.,"#,
-        br#"1:6 Error: Unexpected EOF during reading XmlDecl."#,
+        r#"<?xml&.,"#,
+        r#"1:6 Error: Unexpected EOF during reading XmlDecl."#,
         true,
     );
 }
@@ -107,16 +107,16 @@ fn bad_1() {
 #[test]
 fn dashes_in_comments() {
     test(
-        br#"<!-- comment -- --><hello/>"#,
-        br#"
+        r#"<!-- comment -- --><hello/>"#,
+        r#"
         |Error: Unexpected token '--'
         "#,
         true,
     );
 
     test(
-        br#"<!-- comment ---><hello/>"#,
-        br#"
+        r#"<!-- comment ---><hello/>"#,
+        r#"
         |Error: Unexpected token '--'
         "#,
         true,
@@ -126,8 +126,8 @@ fn dashes_in_comments() {
 #[test]
 fn tabs_1() {
     test(
-        b"\t<a>\t<b/></a>",
-        br#"
+        "\t<a>\t<b/></a>",
+        r#"
             StartElement(a)
             EmptyElement(b)
             EndElement(a)
@@ -142,8 +142,8 @@ fn issue_83_duplicate_attributes() {
     // Error when parsing attributes won't stop main event reader
     // as it is a lazy operation => add ending events
     test(
-        br#"<hello><some-tag a='10' a="20"/></hello>"#,
-        b"
+        r#"<hello><some-tag a='10' a="20"/></hello>"#,
+        "
             |StartElement(hello)
             |1:30 EmptyElement(some-tag, attr-error: error while parsing \
                   attribute at position 16: Duplicate attribute at position 9 and 16)
@@ -157,14 +157,13 @@ fn issue_83_duplicate_attributes() {
 #[test]
 fn issue_93_large_characters_in_entity_references() {
     test(
-        r#"<hello>&𤶼;</hello>"#.as_bytes(),
+        r#"<hello>&𤶼;</hello>"#,
         r#"
             |StartElement(hello)
             |1:10 Error while escaping character at range 1..5: Unrecognized escape symbol: Ok("𤶼")
             |EndElement(hello)
             |EndDocument
-        "#
-        .as_bytes(),
+        "#,
         true,
     )
 }
@@ -172,8 +171,8 @@ fn issue_93_large_characters_in_entity_references() {
 #[test]
 fn issue_98_cdata_ending_with_right_bracket() {
     test(
-        br#"<hello><![CDATA[Foo [Bar]]]></hello>"#,
-        br#"
+        r#"<hello><![CDATA[Foo [Bar]]]></hello>"#,
+        r#"
             |StartElement(hello)
             |Characters()
             |CData(Foo [Bar])
@@ -188,8 +187,8 @@ fn issue_98_cdata_ending_with_right_bracket() {
 #[test]
 fn issue_105_unexpected_double_dash() {
     test(
-        br#"<hello>-- </hello>"#,
-        br#"
+        r#"<hello>-- </hello>"#,
+        r#"
             |StartElement(hello)
             |Characters(-- )
             |EndElement(hello)
@@ -199,8 +198,8 @@ fn issue_105_unexpected_double_dash() {
     );
 
     test(
-        br#"<hello>--</hello>"#,
-        br#"
+        r#"<hello>--</hello>"#,
+        r#"
             |StartElement(hello)
             |Characters(--)
             |EndElement(hello)
@@ -210,8 +209,8 @@ fn issue_105_unexpected_double_dash() {
     );
 
     test(
-        br#"<hello>--></hello>"#,
-        br#"
+        r#"<hello>--></hello>"#,
+        r#"
             |StartElement(hello)
             |Characters(-->)
             |EndElement(hello)
@@ -221,8 +220,8 @@ fn issue_105_unexpected_double_dash() {
     );
 
     test(
-        br#"<hello><![CDATA[--]]></hello>"#,
-        br#"
+        r#"<hello><![CDATA[--]]></hello>"#,
+        r#"
             |StartElement(hello)
             |Characters()
             |CData(--)
@@ -239,8 +238,8 @@ fn issue_attributes_have_no_default_namespace() {
     // At the moment, the 'test' method doesn't render namespaces for attribute names.
     // This test only checks whether the default namespace got applied to the EmptyElement.
     test(
-        br#"<hello xmlns="urn:foo" x="y"/>"#,
-        br#"
+        r#"<hello xmlns="urn:foo" x="y"/>"#,
+        r#"
              |EmptyElement({urn:foo}hello [x="y"])
              |EndDocument
          "#,
@@ -252,8 +251,8 @@ fn issue_attributes_have_no_default_namespace() {
 fn issue_default_namespace_on_outermost_element() {
     // Regression test
     test(
-        br#"<hello xmlns="urn:foo"/>"#,
-        br#"
+        r#"<hello xmlns="urn:foo"/>"#,
+        r#"
                 |EmptyElement({urn:foo}hello)
                 |EndDocument
             "#,
@@ -264,10 +263,10 @@ fn issue_default_namespace_on_outermost_element() {
 #[test]
 fn default_namespace_applies_to_end_elem() {
     test(
-        br#"<hello xmlns="urn:foo" x="y">
+        r#"<hello xmlns="urn:foo" x="y">
               <inner/>
             </hello>"#,
-        br#"
+        r#"
             |StartElement({urn:foo}hello [x="y"])
             |EmptyElement({urn:foo}inner)
             |EndElement({urn:foo}hello)
@@ -277,7 +276,13 @@ fn default_namespace_applies_to_end_elem() {
     );
 }
 
-fn test(input: &[u8], output: &[u8], is_short: bool) {
+fn test(input: &str, output: &str, is_short: bool) {
+    // Normalize newlines on Windows to just \n, which is what the reader and
+    // writer use.
+    let input = input.replace("\r\n", "\n");
+    let input = input.as_bytes();
+    let output = output.replace("\r\n", "\n");
+    let output = output.as_bytes();
     let mut reader = Reader::from_reader(input);
     reader
         .trim_text(is_short)


### PR DESCRIPTION
Add a new `reader.read_event_unbuffered()` method that does not require a user-given Vec buffer, and borrows from the input, implemented if the input is a `&[u8]`.

Still needs more polishing, and it needs the buf_position branch to be pushed first, since it is based on those changes. I had to move all of the input-reading methods into a trait, and make them return a reference to the text that was read. Because of that, there's now a new requirement of at most 1 input-reading method being called per `read_event()`, so I had to rework whitespace skipping, and to move all of the bang element processing into yet another `read_until`-like function which doesn't return until it has all of the text.

Next up is making a deserializer that can use this to remove the `DeserializedOwned` restriction and allow user structs to borrow from the input when possible, allowing for truly zero-copy parsing and deserialization.

The only user-facing change is the 1 new method, the rest is completely hidden. I'm not fond of the new method's name, so I'd appreciate any help with figuring out a better name for it.

Bikeshedding for the rest of the names would be appreciated too.