### PR TITLE
Make escape module public apart from EscapeError

### DIFF
--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -63,9 +63,8 @@ const MAX_ONE_B: u32 = 0x80;
 const MAX_TWO_B: u32 = 0x800;
 const MAX_THREE_B: u32 = 0x10000;
 
-/// helper function to escape a `&[u8]` and replace all
-/// xml special characters (<, >, &, ', ") with their corresponding
-/// xml escaped value.
+/// Escapes a `&[u8]` and replaces all xml special characters (<, >, &, ', ") with their
+/// corresponding xml escaped value.
 pub fn escape(raw: &[u8]) -> Cow<[u8]> {
     fn to_escape(b: u8) -> bool {
         match b {
@@ -105,8 +104,8 @@ pub fn escape(raw: &[u8]) -> Cow<[u8]> {
     }
 }
 
-/// helper function to unescape a `&[u8]` and replace all
-/// xml escaped characters ('&...;') into their corresponding value
+/// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
+/// value
 pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
     let mut unescaped = None;
     let mut last_end = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,12 @@ extern crate serde;
 #[cfg(feature = "serialize")]
 pub mod de;
 mod errors;
-mod escape;
+mod escapei;
+pub mod escape {
+    //! Manage xml character escapes
+    pub(crate) use escapei::EscapeError;
+    pub use escapei::{escape, unescape};
+}
 pub mod events;
 mod reader;
 #[cfg(feature = "serialize")]


### PR DESCRIPTION
I think these functions should be public. My own usage of unescape is:

1. Search for particular two markers in a text node
2. If they are present, use them as delimiters to make a slice which is passed to unescape
3. Otherwise, don't use unescape.

This way a user can only unescape the text they need.