### PR TITLE
Enable writing manual identation

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -145,6 +145,28 @@ impl<W: Write> Writer<W> {
         }
         Ok(wrote + self.write(before)? + self.write(value)? + self.write(after)?)
     }
+
+    /// Manually write a newline and indentation at the proper level. 
+    /// 
+    /// This can be used when the heuristic to line break and indent after any [Event] apart 
+    /// from [Text] fails such as when a [Start] occurs directly after [Text].
+    /// This method will do nothing if `Writer` was not constructed with `new_with_indent`.
+    ///
+    /// [Event]: events/enum.Event.html
+    /// [Text]: events/enum.Event.html#variant.Text
+    /// [Start]: events/enum.Event.html#variant.Start
+    pub fn write_indent(&mut self) -> Result<usize> {
+        let mut wrote = 0;
+        if let Some(ref i) = self.indent {
+            wrote = self.writer.write(b"\n").map_err(Error::Io)?
+                + self
+                    .writer
+                    .write(&i.indents[..i.indents_len])
+                    .map_err(Error::Io)?;
+        }
+        Ok(wrote)
+    }
+
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
I came across some cases writing valid indented XML where the heuristic to line-break and indent after any `Event` other than `Text` didn't produce correctly formatted XML.

Here's a simple valid XML example that currently isn't formatted properly:
```
<foo>some text<bar>more text</bar></foo>
```

This will be formatted as:
```
<foo>some text<bar>more text</bar>
</foo>
```

Given that the Writer doesn't have the full context of the document (it cannot know that a `Start` will be written after `Text`) it's not possible to modify the heuristic so that indentation is always correct. 
Projects using the Writer might have this context and should be able to manually indent. This PR enables that. 

Below is the above example along with calls to `write_indent` which fixes the formatting.

```rust
extern crate quick_xml;

use quick_xml::{events::*, Writer};
use std::error::Error;
use std::io::Cursor;

fn main() -> Result<(), Box<dyn Error>> {
    let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 2);

    // <foo>some text
    let l1_name = "foo";
    let l1_start = BytesStart::owned(l1_name, l1_name.len());
    let _ = writer.write_event(Event::Start(l1_start))?;
    let _ = writer.write_indent()?;
    let l1_text = BytesText::from_plain_str("some text");
    let _ = writer.write_event(Event::Text(l1_text))?;
    let _ = writer.write_indent()?;

    // <bar>more text
    let l2_name = "bar";
    let l2_start = BytesStart::owned(l2_name, l2_name.len());
    let _ = writer.write_event(Event::Start(l2_start))?;
    let l2_text = BytesText::from_plain_str("more text");
    let _ = writer.write_event(Event::Text(l2_text))?;

    // </bar>
    let l2_end = BytesEnd::owned(l2_name.as_bytes().into());
    let _ = writer.write_event(Event::End(l2_end))?;

    // </foo>
    let l1_end = BytesEnd::owned(l1_name.as_bytes().into());
    let _ = writer.write_event(Event::End(l1_end))?;

    let expected = "<foo>\n  some text\n  <bar>more text</bar>\n</foo>";
    let result = writer.into_inner().into_inner();
    let actual = std::str::from_utf8(&result)?;
    assert_eq!(expected, actual);

    Ok(())
}
```