### PR TITLE
Serialize basic type as attributes when using serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ memchr = "2.3.3"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
+regex = "1"
 
 [lib]
 bench = false

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -295,7 +295,7 @@ impl<'a> Iterator for Attributes<'a> {
                 .consumed
                 .iter()
                 .filter(|r| r.len() == end_key - start_key)
-                .find(|r| &self.bytes[(*r).clone()] == &self.bytes[start_key..end_key])
+                .find(|r| self.bytes[(*r).clone()] == self.bytes[start_key..end_key])
                 .map(|ref r| r.start)
             {
                 err!(Error::DuplicatedAttribute(start_key, start));

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -45,7 +45,7 @@ impl<'a> BytesStart<'a> {
     pub fn borrowed(content: &'a [u8], name_len: usize) -> Self {
         BytesStart {
             buf: Cow::Borrowed(content),
-            name_len: name_len,
+            name_len,
         }
     }
 
@@ -66,7 +66,7 @@ impl<'a> BytesStart<'a> {
     pub fn owned<C: Into<Vec<u8>>>(content: C, name_len: usize) -> BytesStart<'static> {
         BytesStart {
             buf: Cow::Owned(content.into()),
-            name_len: name_len,
+            name_len,
         }
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -97,7 +97,7 @@ impl<B: BufRead> Reader<B> {
     /// Creates a `Reader` that reads from a reader implementing `BufRead`.
     pub fn from_reader(reader: B) -> Reader<B> {
         Reader {
-            reader: reader,
+            reader,
             opened_buffer: Vec::new(),
             opened_starts: Vec::new(),
             tag_state: TagState::Closed,
@@ -339,7 +339,7 @@ impl<B: BufRead> Reader<B> {
                         return Err(Error::UnexpectedEof("Comment".to_string()));
                     }
                     Ok(_) => (),
-                    Err(e) => return Err(e.into()),
+                    Err(e) => return Err(e),
                 }
             }
             let len = buf.len();
@@ -394,11 +394,11 @@ impl<B: BufRead> Reader<B> {
                         &buf[buf_start + 8..buf.len()],
                     )))
                 }
-                _ => return Err(Error::UnexpectedBang),
+                _ => Err(Error::UnexpectedBang),
             }
         } else {
             self.buf_position -= buf.len() - buf_start;
-            return Err(Error::UnexpectedBang);
+            Err(Error::UnexpectedBang)
         }
     }
 
@@ -1144,10 +1144,10 @@ impl NamespaceBufferIndex {
                             let start = buffer.len();
                             buffer.extend_from_slice(&*v);
                             self.slices.push(Namespace {
-                                start: start,
+                                start,
                                 prefix_len: 0,
                                 value_len: v.len(),
-                                level: level,
+                                level,
                             });
                         }
                         Some(&b':') => {
@@ -1155,10 +1155,10 @@ impl NamespaceBufferIndex {
                             buffer.extend_from_slice(&k[6..]);
                             buffer.extend_from_slice(&*v);
                             self.slices.push(Namespace {
-                                start: start,
+                                start,
                                 prefix_len: k.len() - 6,
                                 value_len: v.len(),
-                                level: level,
+                                level,
                             });
                         }
                         _ => break,

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -209,8 +209,9 @@ impl<'w, W: Write> ser::Serializer for &'w mut Serializer<W> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, DeError> {
+        // 这里只写入 '<name', 后面在序列化 field 时写入 '>'
         self.writer
-            .write_event(Event::Start(BytesStart::borrowed_name(name.as_bytes())))?;
+            .write(format!("<{}", name).as_bytes());
         Ok(Struct::new(self, name))
     }
 

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -211,7 +211,7 @@ impl<'w, W: Write> ser::Serializer for &'w mut Serializer<W> {
     ) -> Result<Self::SerializeStruct, DeError> {
         // 这里只写入 '<name', 后面在序列化 field 时写入 '>'
         self.writer
-            .write(format!("<{}", name).as_bytes());
+            .write(format!("<{}", name).as_bytes())?;
         Ok(Struct::new(self, name))
     }
 

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -272,7 +272,7 @@ mod tests {
             struct_ser.serialize_field("foo", "bar").unwrap();
             let attrs = std::str::from_utf8(&struct_ser.attrs).unwrap();
             assert_eq!(attrs, " foo=\"bar\"");
-            struct_ser.end().unwrap();
+            let _ = struct_ser.end().unwrap();
         }
 
         let got = String::from_utf8(buffer).unwrap();

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::{serialize::DeError, Error},
-    events::{BytesEnd, BytesStart, Event},
+    events::{BytesEnd, Event},
     se::Serializer,
 };
 use serde::ser::{self, Serialize};
@@ -129,13 +129,13 @@ where
         // 将属性和子节点写入
         self.parent
             .writer
-            .write(&self.attrs);
+            .write(&self.attrs)?;
         self.parent
             .writer
-            .write(">".as_bytes());
+            .write(">".as_bytes())?;
         self.parent
             .writer
-            .write(&self.children);
+            .write(&self.children)?;
         self.parent
             .writer
             .write_event(Event::End(BytesEnd::borrowed(self.name.as_bytes())))?;

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -108,8 +108,9 @@ where
             // 如果是复杂类型，必定以 < 打头
             // 复杂类型当做子节点处理，简单类型当做属性处理
             if self.buffer[0] == b'<' {
-                let key = key.as_bytes();
-                self.children.append(&mut self.buffer);
+                self.children.extend(format!("<{}>", key).bytes());
+                self.children.extend(&self.buffer);
+                self.children.extend(format!("</{}>", key).bytes());
             } else {
                 self.attrs.extend(" ".as_bytes());
                 self.attrs.extend(key.as_bytes());

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -190,7 +190,7 @@ impl Indentation {
     }
 
     fn grow(&mut self) {
-        self.indents_len = self.indents_len + self.indent_size;
+        self.indents_len += self.indent_size;
         if self.indents_len > self.indents.len() {
             self.indents.resize(self.indents_len, self.indent_char);
         }

--- a/tests/serde_attrs.rs
+++ b/tests/serde_attrs.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "serialize")]
+
+extern crate quick_xml;
+extern crate serde;
+extern crate regex;
+
+use quick_xml::se::to_string;
+use serde::Serialize;
+use regex::Regex;
+use std::borrow::Cow;
+
+#[derive(Serialize)]
+#[serde(rename="classroom")]
+struct Classroom {
+    pub students: Vec<Person>,
+    pub number: String,
+    pub adviser: Person
+}
+
+#[derive(Serialize)]
+#[serde(rename="person")]
+struct Person {
+    pub name: String,
+    pub age: u32
+}
+
+#[derive(Serialize)]
+#[serde(rename="empty")]
+struct Empty {}
+
+#[test]
+fn test_nested() {
+    let s1 = Person { name: "sherlock".to_string(), age: 20 };
+    let s2 = Person { name: "harry".to_string(), age: 19 };
+    let t = Person { name: "albus".to_string(), age: 88 };
+    let doc = Classroom { students: vec![s1, s2], number: "3-1".to_string(), adviser: t };
+    let xml = quick_xml::se::to_string(&doc).unwrap();
+
+    let str = r#"<classroom number="3-1">
+                   <students>
+                      <person name="sherlock" age="20"></person>
+                      <person name="harry" age="19"></person>
+                   </students>
+                   <adviser>
+                     <person name="albus" age="88"></person>
+                   </adviser>
+                 </classroom>"#;
+    assert_eq!(xml, inline(str));
+}
+
+fn inline(str: &str) -> Cow<str> {
+    let regex = Regex::new(r">\s+<").unwrap();
+    regex.replace_all(str, "><")
+}
+
+#[test]
+fn test_empty() {
+    let e = Empty {};
+    let xml = to_string(&e).unwrap();
+    assert_eq!(xml, "<empty></empty>");
+}

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -37,6 +37,7 @@ fn basic_struct() {
     assert_eq!(item, should_be);
 
     let reserialized_item = to_string(&item).unwrap();
+    let src = "<Item name=\"Banana\" source=\"Store\"></Item>";
     assert_eq!(src, reserialized_item);
 }
 


### PR DESCRIPTION
As [this issue](https://github.com/tafia/quick-xml/issues/196) said, basic type struct fields should be serialized to attributes.

Rather than check type name, I check the serialization result of the field. When the result is a tag(starting with '<'), I treat it as a child node.

In serialize_field(), I don't serialize the field to final result, but store attrs and child nodes in separate temporary location. After all fields have been collected, in end(), I will write them to final result. So the field order is not important.

I got `test framework quit unexpectedly` while runing test in serde_roundtrip.rs, so I write tests in another project. Here is my tests:

```rust
use serde::*;
use quick_xml::se::to_string;
use regex::Regex;
use std::borrow::Cow;

#[derive(Serialize)]
#[serde(rename="classroom")]
struct Classroom {
    pub students: Vec<Person>,
    pub number: String,
    pub adviser: Person
}

#[derive(Serialize)]
#[serde(rename="person")]
struct Person {
    pub name: String,
    pub age: u32
}

#[derive(Serialize)]
#[serde(rename="empty")]
struct Empty {}

#[test]
fn test_nested() {
    let s1 = Person { name: "sherlock".to_string(), age: 20 };
    let s2 = Person { name: "harry".to_string(), age: 19 };
    let t = Person { name: "albus".to_string(), age: 88 };
    let doc = Classroom { students: vec![s1, s2], number: "3-1".to_string(), adviser: t };
    let xml = quick_xml::se::to_string(&doc).unwrap();

    let str = r#"<classroom number="3-1">
                        <students>
                          <person name="sherlock" age="20"></person>
                          <person name="harry" age="19"></person>
                        </students>
                        <adviser>
                          <person name="albus" age="88"></person>
                        </adviser>
                      </classroom>"#;
    assert_eq!(xml, inline(str));
}

fn inline(str: &str) -> Cow<str> {
    let regex = Regex::new(r">\s+<").unwrap();
    regex.replace_all(str, "><")
}

#[test]
fn test_empty() {
    let e = Empty {};
    let xml = to_string(&e).unwrap();
    assert_eq!(xml, "<empty></empty>");
}
```