### PR TITLE
Fix minor formatting issues Travis has been complaining about

### DIFF
--- a/src/de/escape.rs
+++ b/src/de/escape.rs
@@ -50,7 +50,7 @@ macro_rules! deserialize_num {
 
             visitor.$visit(value)
         }
-    }
+    };
 }
 
 impl<'de> serde::Deserializer<'de> for EscapedDeserializer {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -247,7 +247,7 @@ macro_rules! deserialize_type {
 
             visitor.$visit(value)
         }
-    }
+    };
 }
 
 impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -146,9 +146,9 @@ impl<W: Write> Writer<W> {
         Ok(wrote + self.write(before)? + self.write(value)? + self.write(after)?)
     }
 
-    /// Manually write a newline and indentation at the proper level. 
-    /// 
-    /// This can be used when the heuristic to line break and indent after any [Event] apart 
+    /// Manually write a newline and indentation at the proper level.
+    ///
+    /// This can be used when the heuristic to line break and indent after any [Event] apart
     /// from [Text] fails such as when a [Start] occurs directly after [Text].
     /// This method will do nothing if `Writer` was not constructed with `new_with_indent`.
     ///
@@ -166,7 +166,6 @@ impl<W: Write> Writer<W> {
         }
         Ok(wrote)
     }
-
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Like the title says, Travis builds appear to have been failing for a little while - but only due to `cargo fmt` objecting to some very minor things.

I have taken the liberty of running `cargo fmt` locally and pushing the end result into a branch, making the build go green again.