### PR TITLE
Deserialize bytes

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -332,11 +332,15 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 
     fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
-        self.deserialize_string(visitor)
+        let text = self.next_text()?;
+        let value = text.escaped();
+        visitor.visit_bytes(value)
     }
 
     fn deserialize_byte_buf<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {
-        self.deserialize_string(visitor)
+        let text = self.next_text()?;
+        let value = text.into_inner().into_owned();
+        visitor.visit_byte_buf(value)
     }
 
     fn deserialize_unit<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, DeError> {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -472,6 +472,12 @@ impl<'a> BytesText<'a> {
         }
     }
 
+    /// Extracts the inner `Cow` from the `BytesText` event container.
+    #[inline]
+    pub(crate) fn into_inner(self) -> Cow<'a, [u8]> {
+        self.content
+    }
+
     /// gets escaped content
     ///
     /// Searches for '&' into content and try to escape the coded character if possible

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -473,6 +473,7 @@ impl<'a> BytesText<'a> {
     }
 
     /// Extracts the inner `Cow` from the `BytesText` event container.
+    #[cfg(feature = "serialize")]
     #[inline]
     pub(crate) fn into_inner(self) -> Cow<'a, [u8]> {
         self.content


### PR DESCRIPTION
This PR ensures that there is a path for deserializing raw bytes.
There is a real use case for this type of deserialization (see for example the VTK XML file format using raw unencoded binary data).

A new internal method on BytesText is added to potentially make use of an owned byte Vec.

A test is added to demonstrate how this feature can be used.