### PR TITLE
Allow using tokio's AsyncBufRead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "tafia/quick-xml" }
 [dependencies]
 async-recursion = { version = "0.3.2", optional = true }
 encoding_rs = { version = "0.8.26", optional = true }
-tokio = { version = "0.2.22", features = ["fs", "io-util"], optional = true }
+tokio = { version = "1.4.0", features = ["fs", "io-util"], optional = true }
 serde = { version = "1.0", optional = true }
 memchr = "2.3.4"
 
@@ -26,7 +26,7 @@ memchr = "2.3.4"
 serde = { version = "1.0", features = ["derive"] }
 serde-value = "0.7"
 regex = "1"
-tokio = { version = "0.2.22", features = ["macros", "rt-threaded"] }
+tokio = { version = "1.4.0", features = ["macros", "rt-multi-thread"] }
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "quick-xml"
 version = "0.22.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "High performance xml reader and writer"
+edition = "2018"
 
 documentation = "https://docs.rs/quick-xml"
 repository = "https://github.com/tafia/quick-xml"
@@ -15,7 +16,9 @@ license = "MIT"
 travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
+async-recursion = { version = "0.3.2", optional = true }
 encoding_rs = { version = "0.8.26", optional = true }
+tokio = { version = "0.2.22", features = ["fs", "io-util"], optional = true }
 serde = { version = "1.0", optional = true }
 memchr = "2.3.4"
 
@@ -23,6 +26,7 @@ memchr = "2.3.4"
 serde = { version = "1.0", features = ["derive"] }
 serde-value = "0.7"
 regex = "1"
+tokio = { version = "0.2.22", features = ["macros", "rt-threaded"] }
 
 [lib]
 bench = false
@@ -32,6 +36,7 @@ default = []
 encoding = ["encoding_rs"]
 serialize = ["serde"]
 escape-html = []
+asynchronous = ["tokio", "async-recursion"]
 
 [package.metadata.docs.rs]
 features = ["serialize"]

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ fn crates_io() -> Result<Html, DeError> {
 
 ### Credits
 
-This has largely been inspired by [serde-xml-rs](https://github.com/RReverser/serde-xml-rs). 
-quick-xml follows its convention for deserialization, including the 
+This has largely been inspired by [serde-xml-rs](https://github.com/RReverser/serde-xml-rs).
+quick-xml follows its convention for deserialization, including the
 [`$value`](https://github.com/RReverser/serde-xml-rs#parsing-the-value-of-a-tag) special name.
 
 ### Parsing the "value" of a tag
@@ -234,6 +234,7 @@ Note that despite not focusing on performance (there are several unecessary copi
 
 - `encoding`: support non utf8 xmls
 - `serialize`: support serde `Serialize`/`Deserialize`
+- `asynchronous`: support for `AsyncRead`s in `tokio`
 
 ## Performance
 

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -11,6 +11,8 @@ extern crate quick_xml;
 extern crate regex;
 
 use quick_xml::events::Event;
+#[cfg(feature = "asynchronous")]
+use quick_xml::AsyncReader;
 use quick_xml::Reader;
 use regex::bytes::Regex;
 use std::collections::HashMap;
@@ -27,22 +29,15 @@ const DATA: &str = r#"
 
 "#;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut reader = Reader::from_str(DATA);
+fn custom_entities(data: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut reader = Reader::from_str(data);
     reader.trim_text(true);
 
     let mut buf = Vec::new();
     let mut custom_entities = HashMap::new();
     let entity_re = Regex::new(r#"<!ENTITY\s+([^ \t\r\n]+)\s+"([^"]*)"\s*>"#)?;
 
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
-
     loop {
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { reader.read_event(&mut buf).await });
-
-        #[cfg(not(feature = "asynchronous"))]
         let event = reader.read_event(&mut buf);
 
         match event {
@@ -78,5 +73,63 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             _ => (),
         }
     }
+    Ok(())
+}
+
+#[cfg(feature = "asynchronous")]
+async fn custom_entities_async(data: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut reader = AsyncReader::from_str(data);
+    reader.trim_text(true);
+
+    let mut buf = Vec::new();
+    let mut custom_entities = HashMap::new();
+    let entity_re = Regex::new(r#"<!ENTITY\s+([^ \t\r\n]+)\s+"([^"]*)"\s*>"#)?;
+
+    loop {
+        match reader.read_event(&mut buf).await {
+            Ok(Event::DocType(ref e)) => {
+                for cap in entity_re.captures_iter(&e) {
+                    custom_entities.insert(cap[1].to_vec(), cap[2].to_vec());
+                }
+            }
+            Ok(Event::Start(ref e)) => match e.name() {
+                b"test" => println!(
+                    "attributes values: {:?}",
+                    e.attributes()
+                        .map(|a| a
+                            .unwrap()
+                            .unescape_and_decode_value_with_custom_entities(
+                                &reader,
+                                &custom_entities
+                            )
+                            .unwrap())
+                        .collect::<Vec<_>>()
+                ),
+                _ => (),
+            },
+            Ok(Event::Text(ref e)) => {
+                println!(
+                    "text value: {}",
+                    e.unescape_and_decode_with_custom_entities(&reader, &custom_entities)
+                        .unwrap()
+                );
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            _ => (),
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    custom_entities(DATA)?;
+
+    #[cfg(feature = "asynchronous")]
+    let runtime = Runtime::new().expect("Runtime cannot be initialized");
+
+    #[cfg(feature = "asynchronous")]
+    runtime.block_on(async { custom_entities_async(DATA).await })?;
+
     Ok(())
 }

--- a/examples/read_texts.rs
+++ b/examples/read_texts.rs
@@ -1,40 +1,48 @@
+use quick_xml::events::Event;
+#[cfg(feature = "asynchronous")]
+use quick_xml::AsyncReader;
+use quick_xml::Reader;
 #[cfg(feature = "asynchronous")]
 use tokio::runtime::Runtime;
 
-fn main() {
-    use quick_xml::events::Event;
-    use quick_xml::Reader;
+#[cfg(feature = "asynchronous")]
+async fn read_text_async(xml: &str) {
+    let mut reader = AsyncReader::from_str(xml);
+    reader.trim_text(true);
 
-    let xml = "<tag1>text1</tag1><tag1>text2</tag1>\
-               <tag1>text3</tag1><tag1><tag2>text4</tag2></tag1>";
+    let mut txt = Vec::new();
+    let mut buf = Vec::new();
 
+    loop {
+        match reader.read_event(&mut buf).await {
+            Ok(Event::Start(ref e)) if e.name() == b"tag2" => {
+                #[cfg(feature = "asynchronous")]
+                let text = reader
+                    .read_text(b"tag2", &mut Vec::new())
+                    .await
+                    .expect("Cannot decode text value");
+
+                txt.push(text);
+                println!("{:?}", txt);
+            }
+            Ok(Event::Eof) => break, // exits the loop when reaching end of file
+            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            _ => (), // There are several other `Event`s we do not consider here
+        }
+        buf.clear();
+    }
+}
+
+fn read_text(xml: &str) {
     let mut reader = Reader::from_str(xml);
     reader.trim_text(true);
 
     let mut txt = Vec::new();
     let mut buf = Vec::new();
 
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
-
     loop {
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { reader.read_event(&mut buf).await });
-
-        #[cfg(not(feature = "asynchronous"))]
-        let event = reader.read_event(&mut buf);
-
-        match event {
+        match reader.read_event(&mut buf) {
             Ok(Event::Start(ref e)) if e.name() == b"tag2" => {
-                #[cfg(feature = "asynchronous")]
-                let text = runtime.block_on(async {
-                    reader
-                        .read_text(b"tag2", &mut Vec::new())
-                        .await
-                        .expect("Cannot decode text value")
-                });
-
-                #[cfg(not(feature = "asynchronous"))]
                 let text = reader
                     .read_text(b"tag2", &mut Vec::new())
                     .expect("Cannot decode text value");
@@ -48,4 +56,17 @@ fn main() {
         }
         buf.clear();
     }
+}
+
+fn main() {
+    let xml = "<tag1>text1</tag1><tag1>text2</tag1>\
+               <tag1>text3</tag1><tag1><tag2>text4</tag2></tag1>";
+
+    read_text(xml);
+
+    #[cfg(feature = "asynchronous")]
+    let runtime = Runtime::new().expect("Runtime cannot be initialized");
+
+    #[cfg(feature = "asynchronous")]
+    runtime.block_on(async { read_text_async(xml).await });
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -115,6 +115,7 @@ mod var;
 pub use crate::errors::serialize::DeError;
 use crate::{
     events::{BytesStart, BytesText, Event},
+    reader::Decode,
     Reader,
 };
 use serde::de::{self, DeserializeOwned};

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,7 +33,7 @@ pub enum Error {
     /// Duplicate attribute
     DuplicatedAttribute(usize, usize),
     /// Escape error
-    EscapeError(::escape::EscapeError),
+    Escape(crate::escape::EscapeError),
 }
 
 impl From<::std::io::Error> for Error {
@@ -101,7 +101,7 @@ impl std::fmt::Display for Error {
                  Duplicate attribute at position {1} and {0}",
                 pos1, pos2
             ),
-            Error::EscapeError(e) => write!(f, "{}", e),
+            Error::Escape(e) => write!(f, "{}", e),
         }
     }
 }
@@ -111,7 +111,7 @@ impl std::error::Error for Error {
         match self {
             Error::Io(e) => Some(e),
             Error::Utf8(e) => Some(e),
-            Error::EscapeError(e) => Some(e),
+            Error::Escape(e) => Some(e),
             _ => None,
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,7 +33,7 @@ pub enum Error {
     /// Duplicate attribute
     DuplicatedAttribute(usize, usize),
     /// Escape error
-    Escape(crate::escape::EscapeError),
+    EscapeError(crate::escape::EscapeError),
 }
 
 impl From<::std::io::Error> for Error {
@@ -101,7 +101,7 @@ impl std::fmt::Display for Error {
                  Duplicate attribute at position {1} and {0}",
                 pos1, pos2
             ),
-            Error::Escape(e) => write!(f, "{}", e),
+            Error::EscapeError(e) => write!(f, "{}", e),
         }
     }
 }
@@ -111,7 +111,7 @@ impl std::error::Error for Error {
         match self {
             Error::Io(e) => Some(e),
             Error::Utf8(e) => Some(e),
-            Error::Escape(e) => Some(e),
+            Error::EscapeError(e) => Some(e),
             _ => None,
         }
     }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,0 +1,4 @@
+//! Pub escape module.
+
+pub(crate) use crate::escapei::{do_unescape, EscapeError};
+pub use crate::escapei::{escape, unescape, unescape_with};

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -119,7 +119,7 @@ pub fn unescape_with<'a>(
 }
 
 /// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
-/// value, using an optional dictionnary of custom entities.
+/// value, using an optional dictionary of custom entities.
 ///
 /// # Pre-condition
 ///

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -1,6 +1,5 @@
 //! Manage xml character escapes
 
-use memchr;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Range;
@@ -181,7 +180,7 @@ const fn named_entity(name: &[u8]) -> Option<&str> {
         b"amp" => "&",
         b"apos" => "'",
         b"quot" => "\"",
-        _ => return None
+        _ => return None,
     };
     Some(s)
 }
@@ -820,11 +819,9 @@ const fn named_entity(name: &[u8]) -> Option<&str> {
         b"mid" | b"VerticalBar" | b"smid" | b"shortmid" => "\u{2223}",
         b"nmid" | b"NotVerticalBar" | b"nsmid" | b"nshortmid" => "\u{2224}",
         b"par" | b"parallel" | b"DoubleVerticalBar" | b"spar" | b"shortparallel" => "\u{2225}",
-        b"npar"
-        | b"nparallel"
-        | b"NotDoubleVerticalBar"
-        | b"nspar"
-        | b"nshortparallel" => "\u{2226}",
+        b"npar" | b"nparallel" | b"NotDoubleVerticalBar" | b"nspar" | b"nshortparallel" => {
+            "\u{2226}"
+        }
         b"and" | b"wedge" => "\u{2227}",
         b"or" | b"vee" => "\u{2228}",
         b"cap" => "\u{2229}",
@@ -1645,13 +1642,13 @@ const fn named_entity(name: &[u8]) -> Option<&str> {
         b"xopf" => "\u{1D56}",
         b"yopf" => "\u{1D56}",
         b"zopf" => "\u{1D56}",
-        _ => return None
+        _ => return None,
     };
     Some(s)
 }
 
 fn push_utf8(out: &mut Vec<u8>, code: char) {
-    let mut buf = [0u8; 4];
+    let mut buf = [0_u8; 4];
     out.extend_from_slice(code.encode_utf8(&mut buf).as_bytes());
 }
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -122,7 +122,7 @@ impl<'a> Attribute<'a> {
         &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<[u8]>> {
-        do_unescape(&*self.value, custom_entities).map_err(Error::Escape)
+        do_unescape(&*self.value, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Decode then unescapes the value
@@ -169,8 +169,7 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -181,7 +180,7 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value)?;
-        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::Escape)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -256,8 +255,7 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -268,7 +266,7 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value)?;
-        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::Escape)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 }
@@ -349,7 +347,7 @@ impl<'a> Iterator for Attributes<'a> {
                 return Some(Ok(Attribute {
                     key: &self.bytes[$key],
                     value: Cow::Borrowed(&self.bytes[$val]),
-                }));
+                }))
             };
         }
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -2,12 +2,11 @@
 //!
 //! Provides an iterator over attributes key/value pairs
 
-use errors::{Error, Result};
-use escape::{do_unescape, escape};
-use reader::{is_whitespace, Reader};
+use crate::errors::{Error, Result};
+use crate::escape::{do_unescape, escape};
+use crate::reader::{is_whitespace, Decode};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::io::BufRead;
 use std::ops::Range;
 
 /// Iterator over XML attributes.
@@ -123,7 +122,7 @@ impl<'a> Attribute<'a> {
         &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<[u8]>> {
-        do_unescape(&*self.value, custom_entities).map_err(Error::EscapeError)
+        do_unescape(&*self.value, custom_entities).map_err(Error::Escape)
     }
 
     /// Decode then unescapes the value
@@ -136,7 +135,7 @@ impl<'a> Attribute<'a> {
     ///
     /// [`unescaped_value()`]: #method.unescaped_value
     /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
-    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
+    pub fn unescape_and_decode_value(&self, reader: &impl Decode) -> Result<String> {
         self.do_unescape_and_decode_value(reader, None)
     }
 
@@ -154,9 +153,9 @@ impl<'a> Attribute<'a> {
     /// # Pre-condition
     ///
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
-    pub fn unescape_and_decode_value_with_custom_entities<B: BufRead>(
+    pub fn unescape_and_decode_value_with_custom_entities(
         &self,
-        reader: &Reader<B>,
+        reader: &impl Decode,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<String> {
         self.do_unescape_and_decode_value(reader, Some(custom_entities))
@@ -164,9 +163,9 @@ impl<'a> Attribute<'a> {
 
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(feature = "encoding")]
-    fn do_unescape_and_decode_value<B: BufRead>(
+    fn do_unescape_and_decode_value(
         &self,
-        reader: &Reader<B>,
+        reader: &impl Decode,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value);
@@ -176,14 +175,13 @@ impl<'a> Attribute<'a> {
     }
 
     #[cfg(not(feature = "encoding"))]
-    fn do_unescape_and_decode_value<B: BufRead>(
+    fn do_unescape_and_decode_value(
         &self,
-        reader: &Reader<B>,
+        reader: &impl Decode,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::Escape)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -195,10 +193,7 @@ impl<'a> Attribute<'a> {
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
     #[cfg(feature = "encoding")]
-    pub fn unescape_and_decode_without_bom<B: BufRead>(
-        &self,
-        reader: &mut Reader<B>,
-    ) -> Result<String> {
+    pub fn unescape_and_decode_without_bom(&self, reader: &mut impl Decode) -> Result<String> {
         self.do_unescape_and_decode_without_bom(reader, None)
     }
 
@@ -210,10 +205,7 @@ impl<'a> Attribute<'a> {
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
     #[cfg(not(feature = "encoding"))]
-    pub fn unescape_and_decode_without_bom<B: BufRead>(
-        &self,
-        reader: &Reader<B>,
-    ) -> Result<String> {
+    pub fn unescape_and_decode_without_bom(&self, reader: &impl Decode) -> Result<String> {
         self.do_unescape_and_decode_without_bom(reader, None)
     }
 
@@ -229,9 +221,9 @@ impl<'a> Attribute<'a> {
     ///
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(feature = "encoding")]
-    pub fn unescape_and_decode_without_bom_with_custom_entities<B: BufRead>(
+    pub fn unescape_and_decode_without_bom_with_custom_entities(
         &self,
-        reader: &mut Reader<B>,
+        reader: &mut impl Decode,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<String> {
         self.do_unescape_and_decode_without_bom(reader, Some(custom_entities))
@@ -249,18 +241,18 @@ impl<'a> Attribute<'a> {
     ///
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(not(feature = "encoding"))]
-    pub fn unescape_and_decode_without_bom_with_custom_entities<B: BufRead>(
+    pub fn unescape_and_decode_without_bom_with_custom_entities(
         &self,
-        reader: &Reader<B>,
+        reader: &impl Decode,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<String> {
         self.do_unescape_and_decode_without_bom(reader, Some(custom_entities))
     }
 
     #[cfg(feature = "encoding")]
-    fn do_unescape_and_decode_without_bom<B: BufRead>(
+    fn do_unescape_and_decode_without_bom(
         &self,
-        reader: &mut Reader<B>,
+        reader: &mut impl Decode,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value);
@@ -270,14 +262,13 @@ impl<'a> Attribute<'a> {
     }
 
     #[cfg(not(feature = "encoding"))]
-    fn do_unescape_and_decode_without_bom<B: BufRead>(
+    fn do_unescape_and_decode_without_bom(
         &self,
-        reader: &Reader<B>,
+        reader: &impl Decode,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::Escape)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 }
@@ -351,9 +342,8 @@ impl<'a> Iterator for Attributes<'a> {
                 self.position = len;
                 if self.html {
                     attr!($key, 0..0)
-                } else {
-                    return None;
-                };
+                }
+                return None;
             }};
             ($key:expr, $val:expr) => {
                 return Some(Ok(Attribute {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -187,7 +187,7 @@ impl<'a> BytesStart<'a> {
         &'s self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
-        do_unescape(&*self.buf, custom_entities).map_err(Error::Escape)
+        do_unescape(&*self.buf, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Returns an iterator over the attributes of this tag.
@@ -269,8 +269,7 @@ impl<'a> BytesStart<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -282,7 +281,7 @@ impl<'a> BytesStart<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self)?;
-        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::Escape)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -598,7 +597,7 @@ impl<'a> BytesText<'a> {
         &'s self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
-        do_unescape(self, custom_entities).map_err(Error::Escape)
+        do_unescape(self, custom_entities).map_err(Error::EscapeError)
     }
 
     /// helper method to unescape then decode self using the reader encoding
@@ -672,8 +671,7 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -684,7 +682,7 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self)?;
-        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::Escape)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -723,8 +721,7 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -735,7 +732,7 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self)?;
-        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::Escape)?;
+        let unescaped = do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -856,8 +853,6 @@ impl<'a> AsRef<Event<'a>> for Event<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(feature = "asynchronous")]
-    use tokio::runtime::Runtime;
 
     #[test]
     fn local_name() {
@@ -872,19 +867,54 @@ mod test {
         let mut buf = Vec::new();
         let mut parsed_local_names = Vec::new();
 
-        #[cfg(feature = "asynchronous")]
-        let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
+        loop {
+            let event = rdr.read_event(&mut buf).expect("unable to read xml event");
+
+            match event {
+                Event::Start(ref e) => parsed_local_names.push(
+                    from_utf8(e.local_name())
+                        .expect("unable to build str from local_name")
+                        .to_string(),
+                ),
+                Event::End(ref e) => parsed_local_names.push(
+                    from_utf8(e.local_name())
+                        .expect("unable to build str from local_name")
+                        .to_string(),
+                ),
+                Event::Eof => break,
+                _ => {}
+            }
+        }
+
+        assert_eq!(parsed_local_names[0], "bus".to_string());
+        assert_eq!(parsed_local_names[1], "bus".to_string());
+        assert_eq!(parsed_local_names[2], "".to_string());
+        assert_eq!(parsed_local_names[3], "".to_string());
+        assert_eq!(parsed_local_names[4], "foo".to_string());
+        assert_eq!(parsed_local_names[5], "foo".to_string());
+        assert_eq!(parsed_local_names[6], "bus:baz".to_string());
+        assert_eq!(parsed_local_names[7], "bus:baz".to_string());
+    }
+
+    #[cfg(feature = "asynchronous")]
+    #[tokio::test]
+    async fn local_name_async() {
+        use std::str::from_utf8;
+        let xml = r#"
+            <foo:bus attr='bar'>foobusbar</foo:bus>
+            <foo: attr='bar'>foobusbar</foo:>
+            <:foo attr='bar'>foobusbar</:foo>
+            <foo:bus:baz attr='bar'>foobusbar</foo:bus:baz>
+            "#;
+        let mut rdr = crate::AsyncReader::from_str(xml);
+        let mut buf = Vec::new();
+        let mut parsed_local_names = Vec::new();
 
         loop {
-            #[cfg(feature = "asynchronous")]
-            let event = runtime.block_on(async {
-                rdr.read_event(&mut buf)
-                    .await
-                    .expect("unable to read xml event")
-            });
-
-            #[cfg(not(feature = "asynchronous"))]
-            let event = rdr.read_event(&mut buf).expect("unable to read xml event");
+            let event = rdr
+                .read_event(&mut buf)
+                .await
+                .expect("unable to read xml event");
 
             match event {
                 Event::Start(ref e) => parsed_local_names.push(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ### Reader
 //!
-//! ```ignore
+//! ```rust
 //! use quick_xml::Reader;
 //! use quick_xml::events::Event;
 //!
@@ -24,8 +24,8 @@
 //! reader.trim_text(true);
 //!
 //! let mut count = 0;
-//! let mut txt: Vec<String> = Vec::new();
-//! let mut buf: Vec<u8> = Vec::new();
+//! let mut txt = Vec::new();
+//! let mut buf = Vec::new();
 //!
 //! // The `Reader` does not implement `Iterator` because it outputs borrowed data (`Cow`s)
 //! loop {
@@ -57,7 +57,7 @@
 //!
 //! ### Writer
 //!
-//! ```ignore
+//! ```rust
 //! use quick_xml::Writer;
 //! use quick_xml::events::{Event, BytesEnd, BytesStart};
 //! use quick_xml::Reader;
@@ -68,7 +68,7 @@
 //! let mut reader = Reader::from_str(xml);
 //! reader.trim_text(true);
 //! let mut writer = Writer::new(Cursor::new(Vec::new()));
-//! let mut buf: Vec<u8> = Vec::new();
+//! let mut buf = Vec::new();
 //! loop {
 //!     match reader.read_event(&mut buf) {
 //!         Ok(Event::Start(ref e)) if e.name() == b"this_tag" => {
@@ -132,7 +132,6 @@ pub mod reader;
 pub use errors::serialize::DeError;
 pub use errors::{Error, Result};
 #[cfg(feature = "asynchronous")]
-pub use reader::asynchronous::Reader;
-#[cfg(not(feature = "asynchronous"))]
+pub use reader::asynchronous::AsyncReader;
 pub use reader::sync::Reader;
 pub use writer::Writer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ### Reader
 //!
-//! ```rust
+//! ```ignore
 //! use quick_xml::Reader;
 //! use quick_xml::events::Event;
 //!
@@ -24,8 +24,8 @@
 //! reader.trim_text(true);
 //!
 //! let mut count = 0;
-//! let mut txt = Vec::new();
-//! let mut buf = Vec::new();
+//! let mut txt: Vec<String> = Vec::new();
+//! let mut buf: Vec<u8> = Vec::new();
 //!
 //! // The `Reader` does not implement `Iterator` because it outputs borrowed data (`Cow`s)
 //! loop {
@@ -57,7 +57,7 @@
 //!
 //! ### Writer
 //!
-//! ```rust
+//! ```ignore
 //! use quick_xml::Writer;
 //! use quick_xml::events::{Event, BytesEnd, BytesStart};
 //! use quick_xml::Reader;
@@ -68,7 +68,7 @@
 //! let mut reader = Reader::from_str(xml);
 //! reader.trim_text(true);
 //! let mut writer = Writer::new(Cursor::new(Vec::new()));
-//! let mut buf = Vec::new();
+//! let mut buf: Vec<u8> = Vec::new();
 //! loop {
 //!     match reader.read_event(&mut buf) {
 //!         Ok(Event::Start(ref e)) if e.name() == b"this_tag" => {
@@ -105,40 +105,34 @@
 //!
 //! # Features
 //!
-//! quick-xml supports 2 additional features, non activated by default:
+//! quick-xml supports 3 additional features, non activated by default:
 //! - `encoding`: support non utf8 xmls
 //! - `serialize`: support serde `Serialize`/`Deserialize`
+//! - `asynchronous`: support async reading
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 
-#[cfg(feature = "encoding_rs")]
-extern crate encoding_rs;
-extern crate memchr;
-#[cfg(feature = "serialize")]
-extern crate serde;
-#[cfg(all(test, feature = "serialize"))]
-extern crate serde_value;
-
 #[cfg(feature = "serialize")]
 pub mod de;
-mod errors;
-mod escapei;
-pub mod escape {
-    //! Manage xml character escapes
-    pub(crate) use escapei::{do_unescape, EscapeError};
-    pub use escapei::{escape, unescape, unescape_with};
-}
-pub mod events;
-mod reader;
 #[cfg(feature = "serialize")]
 pub mod se;
+
+mod errors;
+mod escapei;
 mod utils;
 mod writer;
+
+pub mod escape;
+pub mod events;
+pub mod reader;
 
 // reexports
 #[cfg(feature = "serialize")]
 pub use errors::serialize::DeError;
 pub use errors::{Error, Result};
-pub use reader::Reader;
+#[cfg(feature = "asynchronous")]
+pub use reader::asynchronous::Reader;
+#[cfg(not(feature = "asynchronous"))]
+pub use reader::sync::Reader;
 pub use writer::Writer;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,9 +1,10 @@
 //! A module to handle `Reader`
 
-use crate::events::{attributes::Attribute, BytesStart};
-
 #[cfg(not(feature = "encoding"))]
-use crate::errors::{Error, Result};
+use crate::errors::Error;
+#[cfg(not(feature = "encoding"))]
+use crate::errors::Result;
+use crate::events::{attributes::Attribute, BytesStart};
 #[cfg(not(feature = "encoding"))]
 use std::str::from_utf8;
 
@@ -14,7 +15,6 @@ use std::borrow::Cow;
 
 #[cfg(feature = "asynchronous")]
 pub mod asynchronous;
-#[cfg(not(feature = "asynchronous"))]
 pub mod sync;
 
 /// Trait for decoding, which is shared by the sync and async `Reader`

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,0 +1,323 @@
+//! A module to handle `Reader`
+
+use crate::events::{attributes::Attribute, BytesStart};
+
+#[cfg(not(feature = "encoding"))]
+use crate::errors::{Error, Result};
+#[cfg(not(feature = "encoding"))]
+use std::str::from_utf8;
+
+#[cfg(feature = "encoding")]
+use encoding_rs::{Encoding, UTF_16BE, UTF_16LE};
+#[cfg(feature = "encoding")]
+use std::borrow::Cow;
+
+#[cfg(feature = "asynchronous")]
+pub mod asynchronous;
+#[cfg(not(feature = "asynchronous"))]
+pub mod sync;
+
+/// Trait for decoding, which is shared by the sync and async `Reader`
+pub trait Decode {
+    /// Decodes a slice using the encoding specified in the XML declaration.
+    ///
+    /// Decode `bytes` with BOM sniffing and with malformed sequences replaced with the
+    /// `U+FFFD REPLACEMENT CHARACTER`.
+    ///
+    /// If no encoding is specified, defaults to UTF-8.
+    #[inline]
+    #[cfg(feature = "encoding")]
+    fn decode<'b, 'c>(&'b self, bytes: &'c [u8]) -> Cow<'c, str> {
+        self.read_encoding().decode(bytes).0
+    }
+
+    /// Decodes a UTF8 slice regardless of XML declaration.
+    ///
+    /// Decode `bytes` with BOM sniffing and with malformed sequences replaced with the
+    /// `U+FFFD REPLACEMENT CHARACTER`.
+    ///
+    /// # Note
+    ///
+    /// If you instead want to use XML declared encoding, use the `encoding` feature
+    #[inline]
+    #[cfg(not(feature = "encoding"))]
+    fn decode<'c>(&self, bytes: &'c [u8]) -> Result<&'c str> {
+        from_utf8(bytes).map_err(Error::Utf8)
+    }
+
+    /// Decodes a UTF8 slice without BOM (Byte order mark) regardless of XML declaration.
+    ///
+    /// Decode `bytes` without BOM and with malformed sequences replaced with the
+    /// `U+FFFD REPLACEMENT CHARACTER`.
+    ///
+    /// # Note
+    ///
+    /// If you instead want to use XML declared encoding, use the `encoding` feature
+    #[inline]
+    #[cfg(not(feature = "encoding"))]
+    fn decode_without_bom<'c>(&self, bytes: &'c [u8]) -> Result<&'c str> {
+        if bytes.starts_with(b"\xEF\xBB\xBF") {
+            from_utf8(&bytes[3..]).map_err(Error::Utf8)
+        } else {
+            from_utf8(bytes).map_err(Error::Utf8)
+        }
+    }
+
+    /// Decodes a slice using without BOM (Byte order mark) the encoding specified in the XML declaration.
+    ///
+    /// Decode `bytes` without BOM and with malformed sequences replaced with the
+    /// `U+FFFD REPLACEMENT CHARACTER`.
+    ///
+    /// If no encoding is specified, defaults to UTF-8.
+    #[inline]
+    #[cfg(feature = "encoding")]
+    fn decode_without_bom<'b, 'c>(&'b mut self, mut bytes: &'c [u8]) -> Cow<'c, str> {
+        if self.read_is_encoding_set() {
+            return self.read_encoding().decode_with_bom_removal(bytes).0;
+        }
+        if bytes.starts_with(b"\xEF\xBB\xBF") {
+            self.write_is_encoding_set(true);
+            bytes = &bytes[3..];
+        } else if bytes.starts_with(b"\xFF\xFE") {
+            self.write_is_encoding_set(true);
+            self.write_encoding(UTF_16LE);
+            bytes = &bytes[2..];
+        } else if bytes.starts_with(b"\xFE\xFF") {
+            self.write_is_encoding_set(true);
+            self.write_encoding(UTF_16BE);
+            bytes = &bytes[3..];
+        };
+        self.read_encoding().decode_without_bom_handling(bytes).0
+    }
+
+    #[cfg(feature = "encoding")]
+    /// Returns the encoding specified in the xml, defaults to utf8
+    fn read_encoding(&self) -> &'static Encoding;
+
+    #[cfg(feature = "encoding")]
+    /// check if quick-rs could find out the encoding
+    fn read_is_encoding_set(&self) -> bool;
+
+    #[cfg(feature = "encoding")]
+    /// Returns the encoding specified in the xml, defaults to utf8
+    fn write_encoding(&mut self, val: &'static Encoding);
+
+    #[cfg(feature = "encoding")]
+    /// check if quick-rs could find out the encoding
+    fn write_is_encoding_set(&mut self, val: bool);
+}
+
+#[derive(Clone, Debug)]
+enum TagState {
+    Opened,
+    Closed,
+    Empty,
+    /// Either Eof or Errored
+    Exit,
+}
+
+/// A function to check whether the byte is a whitespace (blank, new line, carriage return or tab)
+#[inline]
+pub(crate) fn is_whitespace(b: u8) -> bool {
+    match b {
+        b' ' | b'\r' | b'\n' | b'\t' => true,
+        _ => false,
+    }
+}
+
+/// A namespace declaration. Can either bind a namespace to a prefix or define the current default
+/// namespace.
+#[derive(Clone, Debug)]
+struct Namespace {
+    /// Index of the namespace in the buffer
+    start: usize,
+    /// Length of the prefix
+    /// * if bigger than start, then binds this namespace to the corresponding slice.
+    /// * else defines the current default namespace.
+    prefix_len: usize,
+    /// The namespace name (the URI) of this namespace declaration.
+    ///
+    /// The XML standard specifies that an empty namespace value 'removes' a namespace declaration
+    /// for the extent of its scope. For prefix declarations that's not very interesting, but it is
+    /// vital for default namespace declarations. With `xmlns=""` you can revert back to the default
+    /// behaviour of leaving unqualified element names unqualified.
+    value_len: usize,
+    /// Level of nesting at which this namespace was declared. The declaring element is included,
+    /// i.e., a declaration on the document root has `level = 1`.
+    /// This is used to pop the namespace when the element gets closed.
+    level: i32,
+}
+
+impl Namespace {
+    /// Gets the value slice out of namespace buffer
+    ///
+    /// Returns `None` if `value_len == 0`
+    #[inline]
+    fn opt_value<'a, 'b>(&'a self, ns_buffer: &'b [u8]) -> Option<&'b [u8]> {
+        if self.value_len == 0 {
+            None
+        } else {
+            let start = self.start + self.prefix_len;
+            Some(&ns_buffer[start..start + self.value_len])
+        }
+    }
+
+    /// Check if the namespace matches the potentially qualified name
+    #[inline]
+    fn is_match(&self, ns_buffer: &[u8], qname: &[u8]) -> bool {
+        if self.prefix_len == 0 {
+            !qname.contains(&b':')
+        } else {
+            qname.get(self.prefix_len).map_or(false, |n| *n == b':')
+                && qname.starts_with(&ns_buffer[self.start..self.start + self.prefix_len])
+        }
+    }
+}
+
+/// A namespace management buffer.
+///
+/// Holds all internal logic to push/pop namespaces with their levels.
+#[derive(Clone, Debug, Default)]
+struct NamespaceBufferIndex {
+    /// a buffer of namespace ranges
+    slices: Vec<Namespace>,
+    /// The number of open tags at the moment. We need to keep track of this to know which namespace
+    /// declarations to remove when we encounter an `End` event.
+    nesting_level: i32,
+    /// For `Empty` events keep the 'scope' of the element on the stack artificially. That way, the
+    /// consumer has a chance to use `resolve` in the context of the empty element. We perform the
+    /// pop as the first operation in the next `next()` call.
+    pending_pop: bool,
+}
+
+impl NamespaceBufferIndex {
+    #[inline]
+    fn find_namespace_value<'a, 'b, 'c>(
+        &'a self,
+        element_name: &'b [u8],
+        buffer: &'c [u8],
+    ) -> Option<&'c [u8]> {
+        self.slices
+            .iter()
+            .rfind(|n| n.is_match(buffer, element_name))
+            .and_then(|n| n.opt_value(buffer))
+    }
+
+    fn pop_empty_namespaces(&mut self, buffer: &mut Vec<u8>) {
+        if !self.pending_pop {
+            return;
+        }
+        self.pending_pop = false;
+        self.nesting_level -= 1;
+        let current_level = self.nesting_level;
+        // from the back (most deeply nested scope), look for the first scope that is still valid
+        match self.slices.iter().rposition(|n| n.level <= current_level) {
+            // none of the namespaces are valid, remove all of them
+            None => {
+                buffer.clear();
+                self.slices.clear();
+            }
+            // drop all namespaces past the last valid namespace
+            Some(last_valid_pos) => {
+                if let Some(len) = self.slices.get(last_valid_pos + 1).map(|n| n.start) {
+                    buffer.truncate(len);
+                    self.slices.truncate(last_valid_pos + 1);
+                }
+            }
+        }
+    }
+
+    fn push_new_namespaces(&mut self, e: &BytesStart, buffer: &mut Vec<u8>) {
+        self.nesting_level += 1;
+        let level = self.nesting_level;
+        // adds new namespaces for attributes starting with 'xmlns:' and for the 'xmlns'
+        // (default namespace) attribute.
+        for a in e.attributes().with_checks(false) {
+            if let Ok(Attribute { key: k, value: v }) = a {
+                if k.starts_with(b"xmlns") {
+                    match k.get(5) {
+                        None => {
+                            let start = buffer.len();
+                            buffer.extend_from_slice(&*v);
+                            self.slices.push(Namespace {
+                                start,
+                                prefix_len: 0,
+                                value_len: v.len(),
+                                level,
+                            });
+                        }
+                        Some(&b':') => {
+                            let start = buffer.len();
+                            buffer.extend_from_slice(&k[6..]);
+                            buffer.extend_from_slice(&*v);
+                            self.slices.push(Namespace {
+                                start,
+                                prefix_len: k.len() - 6,
+                                value_len: v.len(),
+                                level,
+                            });
+                        }
+                        _ => break,
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Resolves a potentially qualified **attribute name** into (namespace name, local name).
+    ///
+    /// *Qualified* attribute names have the form `prefix:local-name` where the`prefix` is defined
+    /// on any containing XML element via `xmlns:prefix="the:namespace:uri"`. The namespace prefix
+    /// can be defined on the same element as the attribute in question.
+    ///
+    /// *Unqualified* attribute names do *not* inherit the current *default namespace*.
+    #[inline]
+    fn resolve_namespace<'a, 'b, 'c>(
+        &'a self,
+        qname: &'b [u8],
+        buffer: &'c [u8],
+        use_default: bool,
+    ) -> (Option<&'c [u8]>, &'b [u8]) {
+        self.slices
+            .iter()
+            .rfind(|n| n.is_match(buffer, qname))
+            .map_or((None, qname), |n| {
+                let len = n.prefix_len;
+                if len > 0 {
+                    (n.opt_value(buffer), &qname[len + 1..])
+                } else if use_default {
+                    (n.opt_value(buffer), qname)
+                } else {
+                    (None, qname)
+                }
+            })
+    }
+}
+
+/// Utf8 Decoder
+#[cfg(not(feature = "encoding"))]
+#[derive(Clone, Copy)]
+pub struct Decoder;
+
+/// Utf8 Decoder
+#[cfg(feature = "encoding")]
+#[derive(Clone, Copy)]
+pub struct Decoder {
+    encoding: &'static Encoding,
+}
+
+impl Decoder {
+    /// Decode a slice of u8 into a UTF8 str
+    #[cfg(not(feature = "encoding"))]
+    pub fn decode<'c>(&self, bytes: &'c [u8]) -> Result<&'c str> {
+        from_utf8(bytes).map_err(Error::Utf8)
+    }
+
+    /// Decode a slice of u8 into a Cow str
+    #[cfg(feature = "encoding")]
+    pub fn decode<'c>(&self, bytes: &'c [u8]) -> Cow<'c, str> {
+        self.encoding.decode(bytes).0
+    }
+}

--- a/src/reader/sync.rs
+++ b/src/reader/sync.rs
@@ -1,0 +1,987 @@
+//! A module to handle sync `Reader`
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
+use std::str::from_utf8;
+
+#[cfg(feature = "encoding")]
+use encoding_rs::Encoding;
+
+use crate::errors::{Error, Result};
+use crate::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+
+use super::{is_whitespace, Decode, Decoder, NamespaceBufferIndex, TagState};
+
+impl<B: BufRead> Decode for Reader<B> {
+    #[cfg(feature = "encoding")]
+    fn read_encoding(&self) -> &'static Encoding {
+        self.encoding
+    }
+
+    #[cfg(feature = "encoding")]
+    fn read_is_encoding_set(&self) -> bool {
+        self.is_encoding_set
+    }
+
+    #[cfg(feature = "encoding")]
+    fn write_encoding(&mut self, val: &'static Encoding) {
+        self.encoding = val;
+    }
+
+    #[cfg(feature = "encoding")]
+    fn write_is_encoding_set(&mut self, val: bool) {
+        self.is_encoding_set = val;
+    }
+}
+
+/// A low level encoding-agnostic XML event reader.
+///
+/// Consumes a `BufRead` and streams XML `Event`s.
+///
+/// # Examples
+///
+/// ```
+/// use quick_xml::Reader;
+/// use quick_xml::events::Event;
+///
+/// let xml = r#"<tag1 att1 = "test">
+///                 <tag2><!--Test comment-->Test</tag2>
+///                 <tag2>Test 2</tag2>
+///             </tag1>"#;
+/// let mut reader = Reader::from_str(xml);
+/// reader.trim_text(true);
+/// let mut count = 0;
+/// let mut txt = Vec::new();
+/// let mut buf = Vec::new();
+/// loop {
+///     match reader.read_event(&mut buf) {
+///         Ok(Event::Start(ref e)) => {
+///             match e.name() {
+///                 b"tag1" => println!("attributes values: {:?}",
+///                                     e.attributes().map(|a| a.unwrap().value)
+///                                     .collect::<Vec<_>>()),
+///                 b"tag2" => count += 1,
+///                 _ => (),
+///             }
+///         },
+///         Ok(Event::Text(e)) => txt.push(e.unescape_and_decode(&reader).unwrap()),
+///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+///         Ok(Event::Eof) => break,
+///         _ => (),
+///     }
+///     buf.clear();
+/// }
+/// ```
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone)]
+pub struct Reader<B: BufRead> {
+    /// reader
+    reader: B,
+    /// current buffer position, useful for debuging errors
+    buf_position: usize,
+    /// current state Open/Close
+    tag_state: TagState,
+    /// expand empty element into an opening and closing element
+    expand_empty_elements: bool,
+    /// trims leading whitespace in Text events, skip the element if text is empty
+    trim_text_start: bool,
+    /// trims trailing whitespace in Text events.
+    trim_text_end: bool,
+    /// trims trailing whitespaces from markup names in closing tags `</a >`
+    trim_markup_names_in_closing_tags: bool,
+    /// check if End nodes match last Start node
+    check_end_names: bool,
+    /// check if comments contains `--` (false per default)
+    check_comments: bool,
+    /// all currently Started elements which didn't have a matching
+    /// End element yet
+    opened_buffer: Vec<u8>,
+    /// opened name start indexes
+    opened_starts: Vec<usize>,
+    /// a buffer to manage namespaces
+    ns_buffer: NamespaceBufferIndex,
+    #[cfg(feature = "encoding")]
+    /// the encoding specified in the xml, defaults to utf8
+    encoding: &'static Encoding,
+    #[cfg(feature = "encoding")]
+    /// check if quick-rs could find out the encoding
+    is_encoding_set: bool,
+}
+
+impl<B: BufRead> Reader<B> {
+    /// Creates a `Reader` that reads from a reader implementing `BufRead`.
+    pub fn from_reader(reader: B) -> Reader<B> {
+        Reader {
+            reader,
+            opened_buffer: Vec::new(),
+            opened_starts: Vec::new(),
+            tag_state: TagState::Closed,
+            expand_empty_elements: false,
+            trim_text_start: false,
+            trim_text_end: false,
+            trim_markup_names_in_closing_tags: true,
+            check_end_names: true,
+            buf_position: 0,
+            check_comments: false,
+            ns_buffer: NamespaceBufferIndex::default(),
+            #[cfg(feature = "encoding")]
+            encoding: ::encoding_rs::UTF_8,
+            #[cfg(feature = "encoding")]
+            is_encoding_set: false,
+        }
+    }
+
+    /// Changes whether empty elements should be split into an `Open` and a `Close` event.
+    ///
+    /// When set to `true`, all [`Empty`] events produced by a self-closing tag like `<tag/>` are
+    /// expanded into a [`Start`] event followed by a [`End`] event. When set to `false` (the
+    /// default), those tags are represented by an [`Empty`] event instead.
+    ///
+    /// (`false` by default)
+    ///
+    /// [`Empty`]: events/enum.Event.html#variant.Empty
+    /// [`Start`]: events/enum.Event.html#variant.Start
+    /// [`End`]: events/enum.Event.html#variant.End
+    pub fn expand_empty_elements(&mut self, val: bool) -> &mut Reader<B> {
+        self.expand_empty_elements = val;
+        self
+    }
+
+    /// Changes whether whitespace before and after character data should be removed.
+    ///
+    /// When set to `true`, all [`Text`] events are trimmed. If they are empty, no event will be
+    /// pushed.
+    ///
+    /// (`false` by default)
+    ///
+    /// [`Text`]: events/enum.Event.html#variant.Text
+    pub fn trim_text(&mut self, val: bool) -> &mut Reader<B> {
+        self.trim_text_start = val;
+        self.trim_text_end = val;
+        self
+    }
+
+    /// Changes whether whitespace after character data should be removed.
+    ///
+    /// When set to `true`, trailing whitespace is trimmed in [`Text`] events.
+    ///
+    /// (`false` by default)
+    ///
+    /// [`Text`]: events/enum.Event.html#variant.Text
+    pub fn trim_text_end(&mut self, val: bool) -> &mut Reader<B> {
+        self.trim_text_end = val;
+        self
+    }
+
+    /// Changes whether trailing whitespaces after the markup name are trimmed in closing tags
+    /// `</a >`.
+    ///
+    /// If true the emitted [`End`] event is stripped of trailing whitespace after the markup name.
+    ///
+    /// Note that if set to `false` and `check_end_names` is true the comparison of markup names is
+    /// going to fail erronously if a closing tag contains trailing whitespaces.
+    ///
+    /// (`true` by default)
+    ///
+    /// [`End`]: events/enum.Event.html#variant.End
+    pub fn trim_markup_names_in_closing_tags(&mut self, val: bool) -> &mut Reader<B> {
+        self.trim_markup_names_in_closing_tags = val;
+        self
+    }
+
+    /// Changes whether mismatched closing tag names should be detected.
+    ///
+    /// When set to `false`, it won't check if a closing tag matches the corresponding opening tag.
+    /// For example, `<mytag></different_tag>` will be permitted.
+    ///
+    /// If the XML is known to be sane (already processed, etc.) this saves extra time.
+    ///
+    /// Note that the emitted [`End`] event will not be modified if this is disabled, ie. it will
+    /// contain the data of the mismatched end tag.
+    ///
+    /// (`true` by default)
+    ///
+    /// [`End`]: events/enum.Event.html#variant.End
+    pub fn check_end_names(&mut self, val: bool) -> &mut Reader<B> {
+        self.check_end_names = val;
+        self
+    }
+
+    /// Changes whether comments should be validated.
+    ///
+    /// When set to `true`, every [`Comment`] event will be checked for not containing `--`, which
+    /// is not allowed in XML comments. Most of the time we don't want comments at all so we don't
+    /// really care about comment correctness, thus the default value is `false` to improve
+    /// performance.
+    ///
+    /// (`false` by default)
+    ///
+    /// [`Comment`]: events/enum.Event.html#variant.Comment
+    pub fn check_comments(&mut self, val: bool) -> &mut Reader<B> {
+        self.check_comments = val;
+        self
+    }
+
+    /// Gets the current byte position in the input data.
+    ///
+    /// Useful when debugging errors.
+    pub fn buffer_position(&self) -> usize {
+        // when internal state is Opened, we have actually read until '<',
+        // which we don't want to show
+        if let TagState::Opened = self.tag_state {
+            self.buf_position - 1
+        } else {
+            self.buf_position
+        }
+    }
+
+    /// private function to read until '<' is found
+    /// return a `Text` event
+    fn read_until_open<'a, 'b>(&'a mut self, buf: &'b mut Vec<u8>) -> Result<Event<'b>> {
+        self.tag_state = TagState::Opened;
+        let buf_start = buf.len();
+
+        match read_until(&mut self.reader, b'<', buf, &mut self.buf_position) {
+            Ok(0) => Ok(Event::Eof),
+            Ok(_) => {
+                let (start, len) = (
+                    buf_start
+                        + if self.trim_text_start {
+                            match buf.iter().skip(buf_start).position(|&b| !is_whitespace(b)) {
+                                Some(start) => start,
+                                None => return self.read_event(buf),
+                            }
+                        } else {
+                            0
+                        },
+                    if self.trim_text_end {
+                        buf.iter()
+                            .rposition(|&b| !is_whitespace(b))
+                            .map_or_else(|| buf.len(), |p| p + 1)
+                    } else {
+                        buf.len()
+                    },
+                );
+                Ok(Event::Text(BytesText::from_escaped(&buf[start..len])))
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// private function to read until '>' is found
+    fn read_until_close<'a, 'b>(&'a mut self, buf: &'b mut Vec<u8>) -> Result<Event<'b>> {
+        self.tag_state = TagState::Closed;
+
+        // need to read 1 character to decide whether pay special attention to attribute values
+        let buf_start = buf.len();
+        let start = loop {
+            match self.reader.fill_buf() {
+                Ok(n) if n.is_empty() => return Ok(Event::Eof),
+                Ok(n) => {
+                    // We intentionally don't `consume()` the byte, otherwise we would have to
+                    // handle things like '<>' here already.
+                    break n[0];
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(Error::Io(e)),
+            }
+        };
+
+        if start != b'/' && start != b'!' && start != b'?' {
+            match read_elem_until(&mut self.reader, b'>', buf, &mut self.buf_position) {
+                Ok(0) => Ok(Event::Eof),
+                Ok(_) => {
+                    // we already *know* that we are in this case
+                    self.read_start(&buf[buf_start..])
+                }
+                Err(e) => Err(e),
+            }
+        } else {
+            match read_until(&mut self.reader, b'>', buf, &mut self.buf_position) {
+                Ok(0) => Ok(Event::Eof),
+                Ok(_) => match start {
+                    b'/' => self.read_end(&buf[buf_start..]),
+                    b'!' => self.read_bang(buf_start, buf),
+                    b'?' => self.read_question_mark(&buf[buf_start..]),
+                    _ => unreachable!(
+                        "We checked that `start` must be one of [/!?], was {:?} \
+                                 instead.",
+                        start
+                    ),
+                },
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    /// reads `BytesElement` starting with a `/`,
+    /// if `self.check_end_names`, checks that element matches last opened element
+    /// return `End` event
+    fn read_end<'a, 'b>(&'a mut self, buf: &'b [u8]) -> Result<Event<'b>> {
+        // XML standard permits whitespaces after the markup name in closing tags.
+        // Let's strip them from the buffer before comparing tag names.
+        let name = if self.trim_markup_names_in_closing_tags {
+            if let Some(pos_end_name) = buf[1..].iter().rposition(|&b| !b.is_ascii_whitespace()) {
+                let (name, _) = buf[1..].split_at(pos_end_name + 1);
+                name
+            } else {
+                &buf[1..]
+            }
+        } else {
+            &buf[1..]
+        };
+        if self.check_end_names {
+            let mismatch_err = |expected: &[u8], found: &[u8], buf_position: &mut usize| {
+                *buf_position -= buf.len();
+                Err(Error::EndEventMismatch {
+                    expected: from_utf8(expected).unwrap_or("").to_owned(),
+                    found: from_utf8(found).unwrap_or("").to_owned(),
+                })
+            };
+            match self.opened_starts.pop() {
+                Some(start) => {
+                    if name == &self.opened_buffer[start..] {
+                        self.opened_buffer.truncate(start);
+                        Ok(Event::End(BytesEnd::borrowed(name)))
+                    } else {
+                        let expected = &self.opened_buffer[start..];
+                        mismatch_err(expected, name, &mut self.buf_position)
+                    }
+                }
+                None => mismatch_err(b"", &buf[1..], &mut self.buf_position),
+            }
+        } else {
+            Ok(Event::End(BytesEnd::borrowed(name)))
+        }
+    }
+
+    /// reads `BytesElement` starting with a `!`,
+    /// return `Comment`, `CData` or `DocType` event
+    ///
+    /// Note: depending on the start of the Event, we may need to read more
+    /// data, thus we need a mutable buffer
+    fn read_bang<'a, 'b>(
+        &'a mut self,
+        buf_start: usize,
+        buf: &'b mut Vec<u8>,
+    ) -> Result<Event<'b>> {
+        if buf[buf_start..].starts_with(b"!--") {
+            while buf.len() < buf_start + 5 || !buf.ends_with(b"--") {
+                buf.push(b'>');
+                match read_until(&mut self.reader, b'>', buf, &mut self.buf_position) {
+                    Ok(0) => {
+                        self.buf_position -= buf.len() - buf_start;
+                        return Err(Error::UnexpectedEof("Comment".to_string()));
+                    }
+                    Ok(_) => (),
+                    Err(e) => return Err(e),
+                }
+            }
+            let len = buf.len();
+            if self.check_comments {
+                // search if '--' not in comments
+                if let Some(p) = memchr::memchr_iter(b'-', &buf[buf_start + 3..len - 2])
+                    .position(|p| buf[buf_start + 3 + p + 1] == b'-')
+                {
+                    self.buf_position -= buf.len() - buf_start + p;
+                    return Err(Error::UnexpectedToken("--".to_string()));
+                }
+            }
+            Ok(Event::Comment(BytesText::from_escaped(
+                &buf[buf_start + 3..len - 2],
+            )))
+        } else if buf.len() >= buf_start + 8 {
+            match &buf[buf_start + 1..buf_start + 8] {
+                b"[CDATA[" => {
+                    while buf.len() < 10 || !buf.ends_with(b"]]") {
+                        buf.push(b'>');
+                        match read_until(&mut self.reader, b'>', buf, &mut self.buf_position) {
+                            Ok(0) => {
+                                self.buf_position -= buf.len() - buf_start;
+                                return Err(Error::UnexpectedEof("CData".to_string()));
+                            }
+                            Ok(_) => (),
+                            Err(e) => return Err(e),
+                        }
+                    }
+                    Ok(Event::CData(BytesText::from_plain(
+                        &buf[buf_start + 8..buf.len() - 2],
+                    )))
+                }
+                x if x.eq_ignore_ascii_case(b"DOCTYPE") => {
+                    let mut count = buf.iter().skip(buf_start).filter(|&&b| b == b'<').count();
+                    while count > 0 {
+                        buf.push(b'>');
+                        match read_until(&mut self.reader, b'>', buf, &mut self.buf_position) {
+                            Ok(0) => {
+                                self.buf_position -= buf.len() - buf_start;
+                                return Err(Error::UnexpectedEof("DOCTYPE".to_string()));
+                            }
+                            Ok(n) => {
+                                let start = buf.len() - n;
+                                count += buf.iter().skip(start).filter(|&&b| b == b'<').count();
+                                count -= 1;
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    }
+                    Ok(Event::DocType(BytesText::from_escaped(
+                        &buf[buf_start + 8..buf.len()],
+                    )))
+                }
+                _ => Err(Error::UnexpectedBang),
+            }
+        } else {
+            self.buf_position -= buf.len() - buf_start;
+            Err(Error::UnexpectedBang)
+        }
+    }
+
+    /// reads `BytesElement` starting with a `?`,
+    /// return `Decl` or `PI` event
+    #[cfg(feature = "encoding")]
+    fn read_question_mark<'a, 'b>(&'a mut self, buf: &'b [u8]) -> Result<Event<'b>> {
+        let len = buf.len();
+        if len > 2 && buf[len - 1] == b'?' {
+            if len > 5 && &buf[1..4] == b"xml" && is_whitespace(buf[4]) {
+                let event = BytesDecl::from_start(BytesStart::borrowed(&buf[1..len - 1], 3));
+                // Try getting encoding from the declaration event
+                if let Some(enc) = event.encoder() {
+                    self.encoding = enc;
+                    self.is_encoding_set = true;
+                }
+                Ok(Event::Decl(event))
+            } else {
+                Ok(Event::PI(BytesText::from_escaped(&buf[1..len - 1])))
+            }
+        } else {
+            self.buf_position -= len;
+            Err(Error::UnexpectedEof("XmlDecl".to_string()))
+        }
+    }
+
+    /// reads `BytesElement` starting with a `?`,
+    /// return `Decl` or `PI` event
+    #[cfg(not(feature = "encoding"))]
+    fn read_question_mark<'a, 'b>(&'a mut self, buf: &'b [u8]) -> Result<Event<'b>> {
+        let len = buf.len();
+        if len > 2 && buf[len - 1] == b'?' {
+            if len > 5 && &buf[1..4] == b"xml" && is_whitespace(buf[4]) {
+                let event = BytesDecl::from_start(BytesStart::borrowed(&buf[1..len - 1], 3));
+                Ok(Event::Decl(event))
+            } else {
+                Ok(Event::PI(BytesText::from_escaped(&buf[1..len - 1])))
+            }
+        } else {
+            self.buf_position -= len;
+            Err(Error::UnexpectedEof("XmlDecl".to_string()))
+        }
+    }
+
+    #[inline]
+    fn close_expanded_empty(&mut self) -> Result<Event<'static>> {
+        self.tag_state = TagState::Closed;
+        let name = self
+            .opened_buffer
+            .split_off(self.opened_starts.pop().unwrap());
+        Ok(Event::End(BytesEnd::owned(name)))
+    }
+
+    /// reads `BytesElement` starting with any character except `/`, `!` or ``?`
+    /// return `Start` or `Empty` event
+    fn read_start<'a, 'b>(&'a mut self, buf: &'b [u8]) -> Result<Event<'b>> {
+        // TODO: do this directly when reading bufreader ...
+        let len = buf.len();
+        let name_end = buf.iter().position(|&b| is_whitespace(b)).unwrap_or(len);
+
+        if let Some(&b'/') = buf.last() {
+            let end = if name_end < len { name_end } else { len - 1 };
+            if self.expand_empty_elements {
+                self.tag_state = TagState::Empty;
+                self.opened_starts.push(self.opened_buffer.len());
+                self.opened_buffer.extend(&buf[..end]);
+                Ok(Event::Start(BytesStart::borrowed(&buf[..len - 1], end)))
+            } else {
+                Ok(Event::Empty(BytesStart::borrowed(&buf[..len - 1], end)))
+            }
+        } else {
+            if self.check_end_names {
+                self.opened_starts.push(self.opened_buffer.len());
+                self.opened_buffer.extend(&buf[..name_end]);
+            }
+            Ok(Event::Start(BytesStart::borrowed(buf, name_end)))
+        }
+    }
+
+    /// Reads the next `Event`.
+    ///
+    /// This is the main entry point for reading XML `Event`s.
+    ///
+    /// `Event`s borrow `buf` and can be converted to own their data if needed (uses `Cow`
+    /// internally).
+    ///
+    /// Having the possibility to control the internal buffers gives you some additional benefits
+    /// such as:
+    ///
+    /// - Reduce the number of allocations by reusing the same buffer. For constrained systems,
+    ///   you can call `buf.clear()` once you are done with processing the event (typically at the
+    ///   end of your loop).
+    /// - Reserve the buffer length if you know the file size (using `Vec::with_capacity`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quick_xml::Reader;
+    /// use quick_xml::events::Event;
+    ///
+    /// let xml = r#"<tag1 att1 = "test">
+    ///                 <tag2><!--Test comment-->Test</tag2>
+    ///                 <tag2>Test 2</tag2>
+    ///             </tag1>"#;
+    /// let mut reader = Reader::from_str(xml);
+    /// reader.trim_text(true);
+    /// let mut count = 0;
+    /// let mut buf = Vec::new();
+    /// let mut txt = Vec::new();
+    /// loop {
+    ///     match reader.read_event(&mut buf) {
+    ///         Ok(Event::Start(ref e)) => count += 1,
+    ///         Ok(Event::Text(e)) => txt.push(e.unescape_and_decode(&reader).expect("Error!")),
+    ///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+    ///         Ok(Event::Eof) => break,
+    ///         _ => (),
+    ///     }
+    ///     buf.clear();
+    /// }
+    /// println!("Found {} start events", count);
+    /// println!("Text events: {:?}", txt);
+    /// ```
+    pub fn read_event<'a, 'b>(&'a mut self, buf: &'b mut Vec<u8>) -> Result<Event<'b>> {
+        let event = match self.tag_state {
+            TagState::Opened => self.read_until_close(buf),
+            TagState::Closed => self.read_until_open(buf),
+            TagState::Empty => self.close_expanded_empty(),
+            TagState::Exit => return Ok(Event::Eof),
+        };
+        match event {
+            Err(_) | Ok(Event::Eof) => self.tag_state = TagState::Exit,
+            _ => {}
+        }
+        event
+    }
+
+    /// Resolves a potentially qualified **event name** into (namespace name, local name).
+    ///
+    /// *Qualified* attribute names have the form `prefix:local-name` where the`prefix` is defined
+    /// on any containing XML element via `xmlns:prefix="the:namespace:uri"`. The namespace prefix
+    /// can be defined on the same element as the attribute in question.
+    ///
+    /// *Unqualified* event inherits the current *default namespace*.
+    #[inline]
+    pub fn event_namespace<'a, 'b, 'c>(
+        &'a self,
+        qname: &'b [u8],
+        namespace_buffer: &'c [u8],
+    ) -> (Option<&'c [u8]>, &'b [u8]) {
+        self.ns_buffer
+            .resolve_namespace(qname, namespace_buffer, true)
+    }
+
+    /// Resolves a potentially qualified **attribute name** into (namespace name, local name).
+    ///
+    /// *Qualified* attribute names have the form `prefix:local-name` where the`prefix` is defined
+    /// on any containing XML element via `xmlns:prefix="the:namespace:uri"`. The namespace prefix
+    /// can be defined on the same element as the attribute in question.
+    ///
+    /// *Unqualified* attribute names do *not* inherit the current *default namespace*.
+    #[inline]
+    pub fn attribute_namespace<'a, 'b, 'c>(
+        &'a self,
+        qname: &'b [u8],
+        namespace_buffer: &'c [u8],
+    ) -> (Option<&'c [u8]>, &'b [u8]) {
+        self.ns_buffer
+            .resolve_namespace(qname, namespace_buffer, false)
+    }
+
+    /// Reads the next event and resolves its namespace (if applicable).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::from_utf8;
+    /// use quick_xml::Reader;
+    /// use quick_xml::events::Event;
+    ///
+    /// let xml = r#"<x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
+    ///                 <y:tag2><!--Test comment-->Test</y:tag2>
+    ///                 <y:tag2>Test 2</y:tag2>
+    ///             </x:tag1>"#;
+    /// let mut reader = Reader::from_str(xml);
+    /// reader.trim_text(true);
+    /// let mut count = 0;
+    /// let mut buf = Vec::new();
+    /// let mut ns_buf = Vec::new();
+    /// let mut txt = Vec::new();
+    /// loop {
+    ///     match reader.read_namespaced_event(&mut buf, &mut ns_buf) {
+    ///         Ok((ref ns, Event::Start(ref e))) => {
+    ///             count += 1;
+    ///             match (*ns, e.local_name()) {
+    ///                 (Some(b"www.xxxx"), b"tag1") => (),
+    ///                 (Some(b"www.yyyy"), b"tag2") => (),
+    ///                 (ns, n) => panic!("Namespace and local name mismatch"),
+    ///             }
+    ///             println!("Resolved namespace: {:?}", ns.and_then(|ns| from_utf8(ns).ok()));
+    ///         }
+    ///         Ok((_, Event::Text(e))) => {
+    ///             txt.push(e.unescape_and_decode(&reader).expect("Error!"))
+    ///         },
+    ///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+    ///         Ok((_, Event::Eof)) => break,
+    ///         _ => (),
+    ///     }
+    ///     buf.clear();
+    /// }
+    /// println!("Found {} start events", count);
+    /// println!("Text events: {:?}", txt);
+    /// ```
+    pub fn read_namespaced_event<'a, 'b, 'c>(
+        &'a mut self,
+        buf: &'b mut Vec<u8>,
+        namespace_buffer: &'c mut Vec<u8>,
+    ) -> Result<(Option<&'c [u8]>, Event<'b>)> {
+        self.ns_buffer.pop_empty_namespaces(namespace_buffer);
+        match self.read_event(buf) {
+            Ok(Event::Eof) => Ok((None, Event::Eof)),
+            Ok(Event::Start(e)) => {
+                self.ns_buffer.push_new_namespaces(&e, namespace_buffer);
+                Ok((
+                    self.ns_buffer
+                        .find_namespace_value(e.name(), &**namespace_buffer),
+                    Event::Start(e),
+                ))
+            }
+            Ok(Event::Empty(e)) => {
+                // For empty elements we need to 'artificially' keep the namespace scope on the
+                // stack until the next `next()` call occurs.
+                // Otherwise the caller has no chance to use `resolve` in the context of the
+                // namespace declarations that are 'in scope' for the empty element alone.
+                // Ex: <img rdf:nodeID="abc" xmlns:rdf="urn:the-rdf-uri" />
+                self.ns_buffer.push_new_namespaces(&e, namespace_buffer);
+                // notify next `read_namespaced_event()` invocation that it needs to pop this
+                // namespace scope
+                self.ns_buffer.pending_pop = true;
+                Ok((
+                    self.ns_buffer
+                        .find_namespace_value(e.name(), &**namespace_buffer),
+                    Event::Empty(e),
+                ))
+            }
+            Ok(Event::End(e)) => {
+                // notify next `read_namespaced_event()` invocation that it needs to pop this
+                // namespace scope
+                self.ns_buffer.pending_pop = true;
+                Ok((
+                    self.ns_buffer
+                        .find_namespace_value(e.name(), &**namespace_buffer),
+                    Event::End(e),
+                ))
+            }
+            Ok(e) => Ok((None, e)),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Returns the `Reader`s encoding.
+    ///
+    /// The used encoding may change after parsing the XML declaration.
+    ///
+    /// This encoding will be used by [`decode`].
+    ///
+    /// [`decode`]: #method.decode
+    #[cfg(feature = "encoding")]
+    pub fn encoding(&self) -> &'static Encoding {
+        self.encoding
+    }
+
+    /// Get utf8 decoder
+    #[cfg(feature = "encoding")]
+    pub fn decoder(&self) -> Decoder {
+        Decoder {
+            encoding: self.encoding,
+        }
+    }
+
+    /// Get utf8 decoder
+    #[cfg(not(feature = "encoding"))]
+    pub fn decoder(&self) -> Decoder {
+        Decoder
+    }
+
+    /// Reads until end element is found
+    ///
+    /// Manages nested cases where parent and child elements have the same name
+    pub fn read_to_end<K: AsRef<[u8]>>(&mut self, end: K, buf: &mut Vec<u8>) -> Result<()> {
+        let mut depth = 0;
+        let end = end.as_ref();
+        loop {
+            match self.read_event(buf) {
+                Ok(Event::End(ref e)) if e.name() == end => {
+                    if depth == 0 {
+                        return Ok(());
+                    }
+                    depth -= 1;
+                }
+                Ok(Event::Start(ref e)) if e.name() == end => depth += 1,
+                Err(e) => return Err(e),
+                Ok(Event::Eof) => {
+                    return Err(Error::UnexpectedEof(format!("</{:?}>", from_utf8(end))));
+                }
+                _ => (),
+            }
+            buf.clear();
+        }
+    }
+
+    /// Reads optional text between start and end tags.
+    ///
+    /// If the next event is a [`Text`] event, returns the decoded and unescaped content as a
+    /// `String`. If the next event is an [`End`] event, returns the empty string. In all other
+    /// cases, returns an error.
+    ///
+    /// Any text will be decoded using the XML encoding specified in the XML declaration (or UTF-8
+    /// if none is specified).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quick_xml::Reader;
+    /// use quick_xml::events::Event;
+    ///
+    /// let mut xml = Reader::from_reader(b"
+    ///     <a>&lt;b&gt;</a>
+    ///     <a></a>
+    /// " as &[u8]);
+    /// xml.trim_text(true);
+    ///
+    /// let expected = ["<b>", ""];
+    /// for &content in expected.iter() {
+    ///     match xml.read_event(&mut Vec::new()) {
+    ///         Ok(Event::Start(ref e)) => {
+    ///             assert_eq!(&xml.read_text(e.name(), &mut Vec::new()).unwrap(), content);
+    ///         },
+    ///         e => panic!("Expecting Start event, found {:?}", e),
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [`Text`]: events/enum.Event.html#variant.Text
+    /// [`End`]: events/enum.Event.html#variant.End
+    pub fn read_text<K: AsRef<[u8]>>(&mut self, end: K, buf: &mut Vec<u8>) -> Result<String> {
+        let s = match self.read_event(buf) {
+            Ok(Event::Text(e)) => e.unescape_and_decode(self),
+            Ok(Event::End(ref e)) if e.name() == end.as_ref() => return Ok("".to_string()),
+            Err(e) => return Err(e),
+            Ok(Event::Eof) => return Err(Error::UnexpectedEof("Text".to_string())),
+            _ => return Err(Error::TextNotFound),
+        };
+        self.read_to_end(end, buf)?;
+        s
+    }
+
+    /// Consumes `Reader` returning the underlying reader
+    ///
+    /// Can be used to compute line and column of a parsing error position
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::{str, io::Cursor};
+    /// use quick_xml::Reader;
+    /// use quick_xml::events::Event;
+    ///
+    /// let xml = r#"<tag1 att1 = "test">
+    ///                 <tag2><!--Test comment-->Test</tag2>
+    ///                 <tag3>Test 2</tag3>
+    ///             </tag1>"#;
+    /// let mut reader = Reader::from_reader(Cursor::new(xml.as_bytes()));
+    /// let mut buf = Vec::new();
+    ///
+    /// fn into_line_and_column(reader: Reader<Cursor<&[u8]>>) -> (usize, usize) {
+    ///     let end_pos = reader.buffer_position();
+    ///     let mut cursor = reader.into_underlying_reader();
+    ///     let s = String::from_utf8(cursor.into_inner()[0..end_pos].to_owned())
+    ///         .expect("can't make a string");
+    ///     let mut line = 1;
+    ///     let mut column = 0;
+    ///     for c in s.chars() {
+    ///         if c == '\n' {
+    ///             line += 1;
+    ///             column = 0;
+    ///         } else {
+    ///             column += 1;
+    ///         }
+    ///     }
+    ///     (line, column)
+    /// }
+    ///
+    /// loop {
+    ///     match reader.read_event(&mut buf) {
+    ///         Ok(Event::Start(ref e)) => match e.name() {
+    ///             b"tag1" | b"tag2" => (),
+    ///             tag => {
+    ///                 assert_eq!(b"tag3", tag);
+    ///                 assert_eq!((3, 22), into_line_and_column(reader));
+    ///                 break;
+    ///             }
+    ///         },
+    ///         Ok(Event::Eof) => unreachable!(),
+    ///         _ => (),
+    ///     }
+    ///     buf.clear();
+    /// }
+    /// ```
+    pub fn into_underlying_reader(self) -> B {
+        self.reader
+    }
+}
+
+impl Reader<BufReader<File>> {
+    /// Creates an XML reader from a file path.
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Reader<BufReader<File>>> {
+        let file = File::open(path).map_err(Error::Io)?;
+        let reader = BufReader::new(file);
+        Ok(Reader::from_reader(reader))
+    }
+}
+
+impl<'a> Reader<&'a [u8]> {
+    /// Creates an XML reader from a string slice.
+    pub fn from_str(s: &'a str) -> Reader<&'a [u8]> {
+        Reader::from_reader(s.as_bytes())
+    }
+}
+
+/// read until `byte` is found or end of file
+/// return the position of byte
+#[inline]
+fn read_until<R: BufRead>(
+    r: &mut R,
+    byte: u8,
+    buf: &mut Vec<u8>,
+    position: &mut usize,
+) -> Result<usize> {
+    let mut read = 0;
+    let mut done = false;
+    while !done {
+        let used = {
+            let available = match r.fill_buf() {
+                Ok(n) if n.is_empty() => break,
+                Ok(n) => n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    *position += read;
+                    return Err(Error::Io(e));
+                }
+            };
+
+            match memchr::memchr(byte, available) {
+                Some(i) => {
+                    buf.extend_from_slice(&available[..i]);
+                    done = true;
+                    i + 1
+                }
+                None => {
+                    buf.extend_from_slice(available);
+                    available.len()
+                }
+            }
+        };
+        r.consume(used);
+        read += used;
+    }
+    *position += read;
+    Ok(read)
+}
+
+/// Derived from `read_until`, but modified to handle XML attributes using a minimal state machine.
+/// [W3C Extensible Markup Language (XML) 1.1 (2006)](https://www.w3.org/TR/xml11)
+///
+/// Attribute values are defined as follows:
+/// ```plain
+/// AttValue := '"' (([^<&"]) | Reference)* '"'
+///           | "'" (([^<&']) | Reference)* "'"
+/// ```
+/// (`Reference` is something like `&quot;`, but we don't care about escaped characters at this
+/// level)
+#[inline]
+fn read_elem_until<R: BufRead>(
+    r: &mut R,
+    end_byte: u8,
+    buf: &mut Vec<u8>,
+    position: &mut usize,
+) -> Result<usize> {
+    #[derive(Clone, Copy)]
+    enum State {
+        /// The initial state (inside element, but outside of attribute value)
+        Elem,
+        /// Inside a single-quoted attribute value
+        SingleQ,
+        /// Inside a double-quoted attribute value
+        DoubleQ,
+    }
+    let mut state = State::Elem;
+    let mut read = 0;
+    let mut done = false;
+    while !done {
+        let used = {
+            let available = match r.fill_buf() {
+                Ok(n) if n.is_empty() => return Ok(read),
+                Ok(n) => n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    *position += read;
+                    return Err(Error::Io(e));
+                }
+            };
+
+            let mut memiter = memchr::memchr3_iter(end_byte, b'\'', b'"', available);
+            let used: usize;
+            loop {
+                match memiter.next() {
+                    Some(i) => {
+                        state = match (state, available[i]) {
+                            (State::Elem, b) if b == end_byte => {
+                                // only allowed to match `end_byte` while we are in state `Elem`
+                                buf.extend_from_slice(&available[..i]);
+                                done = true;
+                                used = i + 1;
+                                break;
+                            }
+                            (State::Elem, b'\'') => State::SingleQ,
+                            (State::Elem, b'\"') => State::DoubleQ,
+
+                            // the only end_byte that gets us out if the same character
+                            (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
+
+                            // all other bytes: no state change
+                            _ => state,
+                        };
+                    }
+                    None => {
+                        buf.extend_from_slice(available);
+                        used = available.len();
+                        break;
+                    }
+                }
+            }
+            used
+        };
+        r.consume(used);
+        read += used;
+    }
+    *position += read;
+    Ok(read)
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,7 +11,7 @@ use crate::events::Event;
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```rust
 /// extern crate quick_xml;
 /// fn main() {
 /// use quick_xml::{Reader, Writer};

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,8 +2,8 @@
 
 use std::io::Write;
 
-use errors::{Error, Result};
-use events::Event;
+use crate::errors::{Error, Result};
+use crate::events::Event;
 
 /// XML writer.
 ///
@@ -11,9 +11,9 @@ use events::Event;
 ///
 /// # Examples
 ///
-/// ```rust
-/// # extern crate quick_xml;
-/// # fn main() {
+/// ```ignore
+/// extern crate quick_xml;
+/// fn main() {
 /// use quick_xml::{Reader, Writer};
 /// use quick_xml::events::{Event, BytesEnd, BytesStart};
 /// use std::io::Cursor;
@@ -27,7 +27,7 @@ use events::Event;
 ///     match reader.read_event(&mut buf) {
 ///         Ok(Event::Start(ref e)) if e.name() == b"this_tag" => {
 ///
-///             // crates a new element ... alternatively we could reuse `e` by calling
+///             // creates a new element ... alternatively we could reuse `e` by calling
 ///             // `e.into_owned()`
 ///             let mut elem = BytesStart::owned(b"my_elem".to_vec(), "my_elem".len());
 ///
@@ -54,7 +54,7 @@ use events::Event;
 /// let result = writer.into_inner().into_inner();
 /// let expected = r#"<my_elem k1="v1" k2="v2" my-key="some value"><child>text</child></my_elem>"#;
 /// assert_eq!(result, expected.as_bytes());
-/// # }
+/// }
 /// ```
 #[derive(Clone)]
 pub struct Writer<W: Write> {
@@ -210,7 +210,7 @@ impl Indentation {
 #[cfg(test)]
 mod indentation {
     use super::*;
-    use events::*;
+    use crate::events::*;
 
     #[test]
     fn self_closed() {

--- a/tests/documents/html5.txt
+++ b/tests/documents/html5.txt
@@ -4,5 +4,7 @@ Characters(
 StartElement(a, attr-error: error while parsing attribute at position 7: Attribute value must start with a quote.)
 Characters(Hey)
 EndElement(a)
-InvalidUtf8([10, 38, 110, 98, 115, 112, 59, 10]; invalid utf-8 sequence of 1 bytes from index 1)
+Characters(
+ 
+)
 EndDocument

--- a/tests/serde-migrated.rs
+++ b/tests/serde-migrated.rs
@@ -953,12 +953,12 @@ fn futile2() {
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
     struct Object {
         field: Option<Null>,
-    };
+    }
 
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
     struct Stuff {
         stuff_field: Option<Object>,
-    };
+    }
 
     test_parse_ok(&[
         (

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,8 +5,6 @@ use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::io::Cursor;
-#[cfg(feature = "asynchronous")]
-use tokio::runtime::Runtime;
 
 #[test]
 fn test_sample() {
@@ -15,17 +13,8 @@ fn test_sample() {
     let mut r = Reader::from_reader(src);
     let mut count = 0;
 
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
-
     loop {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_event(&mut buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { r.read_event(&mut buf).await });
-
-        match event.unwrap() {
+        match r.read_event(&mut buf).unwrap() {
             Start(_) => count += 1,
             Decl(e) => println!("{:?}", e.version()),
             Eof => break,
@@ -42,17 +31,9 @@ fn test_sample_async() {
     let mut buf = Vec::new();
     let mut r = Reader::from_reader(src);
     let mut count = 0;
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     loop {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_event(&mut buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { r.read_event(&mut buf).await });
-
-        match event.unwrap() {
+        match r.read_event(&mut buf).unwrap() {
             Start(_) => count += 1,
             Decl(e) => println!("{:?}", e.version()),
             Eof => break,
@@ -69,16 +50,8 @@ fn test_attributes_empty() {
     let mut r = Reader::from_reader(src as &[u8]);
     r.trim_text(true).expand_empty_elements(false);
     let mut buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_event(&mut buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_event(&mut buf).await });
-
-    match event {
+    match r.read_event(&mut buf) {
         Ok(Empty(e)) => {
             let mut atts = e.attributes();
             match atts.next() {
@@ -104,23 +77,14 @@ fn test_attributes_empty() {
     }
 }
 
-#[cfg(not(feature = "asynchronous"))]
 #[test]
 fn test_attribute_equal() {
     let src = b"<a att1=\"a=b\"/>";
     let mut r = Reader::from_reader(src as &[u8]);
     r.trim_text(true).expand_empty_elements(false);
     let mut buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_event(&mut buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_event(&mut buf).await });
-
-    match event {
+    match r.read_event(&mut buf) {
         Ok(Empty(e)) => {
             let mut atts = e.attributes();
             match atts.next() {
@@ -139,24 +103,15 @@ fn test_attribute_equal() {
     }
 }
 
-#[cfg(not(feature = "asynchronous"))]
 #[test]
 fn test_comment_starting_with_gt() {
     let src = b"<a /><!-->-->";
     let mut r = Reader::from_reader(src as &[u8]);
     r.trim_text(true).expand_empty_elements(false);
     let mut buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     loop {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_event(&mut buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { r.read_event(&mut buf).await });
-
-        match event {
+        match r.read_event(&mut buf) {
             Ok(Comment(ref e)) if &**e == b">" => break,
             Ok(Eof) => panic!("Expecting Comment"),
             _ => (),
@@ -175,16 +130,8 @@ fn test_attributes_empty_ns() {
     r.trim_text(true).expand_empty_elements(false);
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    let e = match event {
+    let e = match r.read_namespaced_event(&mut buf, &mut ns_buf) {
         Ok((None, Empty(e))) => e,
         e => panic!("Expecting Empty event, got {:?}", e),
     };
@@ -220,7 +167,6 @@ fn test_attributes_empty_ns() {
 /// Single empty element with qualified attributes.
 /// Empty element expansion: enabled
 /// The code path for namespace handling is slightly different for `Empty` vs. `Start+End`.
-#[cfg(not(feature = "asynchronous"))]
 #[test]
 fn test_attributes_empty_ns_expanded() {
     let src = b"<a att1='a' r:att2='b' xmlns:r='urn:example:r' />";
@@ -229,18 +175,9 @@ fn test_attributes_empty_ns_expanded() {
     r.trim_text(true).expand_empty_elements(true);
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event =
-            runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-        let e = match event {
+        let e = match r.read_namespaced_event(&mut buf, &mut ns_buf) {
             Ok((None, Start(e))) => e,
             e => panic!("Expecting Empty event, got {:?}", e),
         };
@@ -273,13 +210,7 @@ fn test_attributes_empty_ns_expanded() {
         }
     }
 
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    match event {
+    match r.read_namespaced_event(&mut buf, &mut ns_buf) {
         Ok((None, End(e))) => assert_eq!(b"a", e.name()),
         e => panic!("Expecting End event, got {:?}", e),
     }
@@ -293,19 +224,10 @@ fn test_default_ns_shadowing_empty() {
     r.trim_text(true).expand_empty_elements(false);
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     // <outer xmlns='urn:example:o'>
     {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event =
-            runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-        match event {
+        match r.read_namespaced_event(&mut buf, &mut ns_buf) {
             Ok((Some(ns), Start(e))) => {
                 assert_eq!(&ns[..], b"urn:example:o");
                 assert_eq!(e.name(), b"e");
@@ -316,14 +238,7 @@ fn test_default_ns_shadowing_empty() {
 
     // <inner att1='a' xmlns='urn:example:i' />
     {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event =
-            runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-        let e = match event {
+        let e = match r.read_namespaced_event(&mut buf, &mut ns_buf) {
             Ok((Some(ns), Empty(e))) => {
                 assert_eq!(::std::str::from_utf8(ns).unwrap(), "urn:example:i");
                 assert_eq!(e.name(), b"e");
@@ -354,14 +269,7 @@ fn test_default_ns_shadowing_empty() {
     }
 
     // </outer>
-
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    match event {
+    match r.read_namespaced_event(&mut buf, &mut ns_buf) {
         Ok((Some(ns), End(e))) => {
             assert_eq!(&ns[..], b"urn:example:o");
             assert_eq!(e.name(), b"e");
@@ -370,7 +278,6 @@ fn test_default_ns_shadowing_empty() {
     }
 }
 
-#[cfg(not(feature = "asynchronous"))]
 #[test]
 fn test_default_ns_shadowing_expanded() {
     let src = b"<e xmlns='urn:example:o'><e att1='a' xmlns='urn:example:i' /></e>";
@@ -379,19 +286,10 @@ fn test_default_ns_shadowing_expanded() {
     r.trim_text(true).expand_empty_elements(true);
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     // <outer xmlns='urn:example:o'>
     {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event =
-            runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-        match event {
+        match r.read_namespaced_event(&mut buf, &mut ns_buf) {
             Ok((Some(ns), Start(e))) => {
                 assert_eq!(&ns[..], b"urn:example:o");
                 assert_eq!(e.name(), b"e");
@@ -403,14 +301,7 @@ fn test_default_ns_shadowing_expanded() {
 
     // <inner att1='a' xmlns='urn:example:i' />
     {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event =
-            runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-        let e = match event {
+        let e = match r.read_namespaced_event(&mut buf, &mut ns_buf) {
             Ok((Some(ns), Start(e))) => {
                 assert_eq!(&ns[..], b"urn:example:i");
                 assert_eq!(e.name(), b"e");
@@ -440,13 +331,7 @@ fn test_default_ns_shadowing_expanded() {
     }
 
     // virtual </inner>
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    match event {
+    match r.read_namespaced_event(&mut buf, &mut ns_buf) {
         Ok((Some(ns), End(e))) => {
             assert_eq!(&ns[..], b"urn:example:i");
             assert_eq!(e.name(), b"e");
@@ -455,13 +340,7 @@ fn test_default_ns_shadowing_expanded() {
     }
 
     // </outer>
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    match event {
+    match r.read_namespaced_event(&mut buf, &mut ns_buf) {
         Ok((Some(ns), End(e))) => {
             assert_eq!(&ns[..], b"urn:example:o");
             assert_eq!(e.name(), b"e");
@@ -477,17 +356,9 @@ fn test_koi8_r_encoding() {
     let mut r = Reader::from_reader(src as &[u8]);
     r.trim_text(true).expand_empty_elements(false);
     let mut buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     loop {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_event(&mut buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { r.read_event(&mut buf).await });
-
-        match event {
+        match r.read_event(&mut buf) {
             Ok(Text(e)) => {
                 e.unescape_and_decode(&r).unwrap();
             }
@@ -505,24 +376,15 @@ fn fuzz_53() {
     let cursor = Cursor::new(data);
     let mut reader = Reader::from_reader(cursor);
     let mut buf = vec![];
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     loop {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = reader.read_event(&mut buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { reader.read_event(&mut buf).await });
-
-        match event {
+        match reader.read_event(&mut buf) {
             Ok(quick_xml::events::Event::Eof) | Err(..) => break,
             _ => buf.clear(),
         }
     }
 }
 
-#[cfg(not(feature = "asynchronous"))]
 #[test]
 fn test_issue94() {
     let data = br#"<Run>
@@ -531,17 +393,9 @@ fn test_issue94() {
     let mut reader = Reader::from_reader(&data[..]);
     reader.trim_text(true);
     let mut buf = vec![];
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     loop {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = reader.read_event(&mut buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { reader.read_event(&mut buf).await });
-
-        match event {
+        match reader.read_event(&mut buf) {
             Ok(quick_xml::events::Event::Eof) | Err(..) => break,
             _ => buf.clear(),
         }
@@ -557,17 +411,9 @@ fn fuzz_101() {
     let cursor = Cursor::new(data);
     let mut reader = Reader::from_reader(cursor);
     let mut buf = vec![];
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
     loop {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = reader.read_event(&mut buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event = runtime.block_on(async { reader.read_event(&mut buf).await });
-
-        match event {
+        match reader.read_event(&mut buf) {
             Ok(Start(ref e)) | Ok(Empty(ref e)) => {
                 if e.unescaped().is_err() {
                     break;
@@ -598,30 +444,15 @@ fn test_default_namespace() {
     // <a>
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
-    #[cfg(feature = "asynchronous")]
-    let mut runtime = Runtime::new().expect("Runtime cannot be initialized");
 
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    if let Ok((None, Start(_))) = event {
+    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
         panic!("expecting outer start element with no namespace");
     }
 
     // <b>
     {
-        #[cfg(not(feature = "asynchronous"))]
-        let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-        #[cfg(feature = "asynchronous")]
-        let event =
-            runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-        let event = match event {
+        let event = match r.read_namespaced_event(&mut buf, &mut ns_buf) {
             Ok((Some(b"www1"), Start(event))) => event,
             Ok((Some(_), Start(_))) => panic!("expecting namespace to resolve to 'www1'"),
             _ => panic!("expecting namespace resolution"),
@@ -639,13 +470,7 @@ fn test_default_namespace() {
     }
 
     // </b>
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    match event {
+    match r.read_namespaced_event(&mut buf, &mut ns_buf) {
         Ok((Some(b"www1"), End(_))) => (),
         Ok((Some(_), End(_))) => panic!("expecting namespace to resolve to 'www1'"),
         _ => panic!("expecting namespace resolution"),
@@ -653,14 +478,7 @@ fn test_default_namespace() {
 
     // </a> very important: a should not be in any namespace. The default namespace only applies to
     // the sub-document it is defined on.
-
-    #[cfg(not(feature = "asynchronous"))]
-    let event = r.read_namespaced_event(&mut buf, &mut ns_buf);
-
-    #[cfg(feature = "asynchronous")]
-    let event = runtime.block_on(async { r.read_namespaced_event(&mut buf, &mut ns_buf).await });
-
-    if let Ok((None, End(_))) = event {
+    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
     } else {
         panic!("expecting outer end element with no namespace");
     }

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -1,0 +1,1187 @@
+#[cfg(feature = "asynchronous")]
+use quick_xml::events::attributes::Attribute;
+#[cfg(feature = "asynchronous")]
+use quick_xml::events::Event::*;
+#[cfg(feature = "asynchronous")]
+use quick_xml::AsyncReader;
+#[cfg(feature = "asynchronous")]
+use std::borrow::Cow;
+#[cfg(feature = "asynchronous")]
+use std::io::Cursor;
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_sample() {
+    let src: &[u8] = include_bytes!("sample_rss.xml");
+    let mut buf = Vec::new();
+    let mut r = AsyncReader::from_reader(src);
+    let mut count = 0;
+
+    loop {
+        match r.read_event(&mut buf).await.unwrap() {
+            Start(_) => count += 1,
+            Decl(e) => println!("{:?}", e.version()),
+            Eof => break,
+            _ => (),
+        }
+        buf.clear();
+    }
+    println!("{}", count);
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_sample_async() {
+    let src: &[u8] = include_bytes!("sample_rss.xml");
+    let mut buf = Vec::new();
+    let mut r = AsyncReader::from_reader(src);
+    let mut count = 0;
+
+    loop {
+        match r.read_event(&mut buf).await.unwrap() {
+            Start(_) => count += 1,
+            Decl(e) => println!("{:?}", e.version()),
+            Eof => break,
+            _ => (),
+        }
+        buf.clear();
+    }
+    println!("{}", count);
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_attributes_empty() {
+    let src = b"<a att1='a' att2='b'/>";
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(false);
+    let mut buf = Vec::new();
+
+    match r.read_event(&mut buf).await {
+        Ok(Empty(e)) => {
+            let mut atts = e.attributes();
+            match atts.next() {
+                Some(Ok(Attribute {
+                    key: b"att1",
+                    value: Cow::Borrowed(b"a"),
+                })) => (),
+                e => panic!("Expecting att1='a' attribute, found {:?}", e),
+            }
+            match atts.next() {
+                Some(Ok(Attribute {
+                    key: b"att2",
+                    value: Cow::Borrowed(b"b"),
+                })) => (),
+                e => panic!("Expecting att2='b' attribute, found {:?}", e),
+            }
+            match atts.next() {
+                None => (),
+                e => panic!("Expecting None, found {:?}", e),
+            }
+        }
+        e => panic!("Expecting Empty event, got {:?}", e),
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_attribute_equal() {
+    let src = b"<a att1=\"a=b\"/>";
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(false);
+    let mut buf = Vec::new();
+
+    match r.read_event(&mut buf).await {
+        Ok(Empty(e)) => {
+            let mut atts = e.attributes();
+            match atts.next() {
+                Some(Ok(Attribute {
+                    key: b"att1",
+                    value: Cow::Borrowed(b"a=b"),
+                })) => (),
+                e => panic!("Expecting att1=\"a=b\" attribute, found {:?}", e),
+            }
+            match atts.next() {
+                None => (),
+                e => panic!("Expecting None, found {:?}", e),
+            }
+        }
+        e => panic!("Expecting Empty event, got {:?}", e),
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_comment_starting_with_gt() {
+    let src = b"<a /><!-->-->";
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(false);
+    let mut buf = Vec::new();
+
+    loop {
+        match r.read_event(&mut buf).await {
+            Ok(Comment(ref e)) if &**e == b">" => break,
+            Ok(Eof) => panic!("Expecting Comment"),
+            _ => (),
+        }
+    }
+}
+
+/// Single empty element with qualified attributes.
+/// Empty element expansion: disabled
+/// The code path for namespace handling is slightly different for `Empty` vs. `Start+End`.
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_attributes_empty_ns() {
+    let src = b"<a att1='a' r:att2='b' xmlns:r='urn:example:r' />";
+
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(false);
+    let mut buf = Vec::new();
+    let mut ns_buf = Vec::new();
+
+    let e = match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+        Ok((None, Empty(e))) => e,
+        e => panic!("Expecting Empty event, got {:?}", e),
+    };
+
+    let mut atts = e
+        .attributes()
+        .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
+        // we don't care about xmlns attributes for this test
+        .filter(|kv| !kv.key.starts_with(b"xmlns"))
+        .map(|Attribute { key: name, value }| {
+            let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+            (opt_ns, local_name, value)
+        });
+    match atts.next() {
+        Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
+        e => panic!("Expecting att1='a' attribute, found {:?}", e),
+    }
+    match atts.next() {
+        Some((Some(ns), b"att2", Cow::Borrowed(b"b"))) => {
+            assert_eq!(&ns[..], b"urn:example:r");
+        }
+        e => panic!(
+            "Expecting {{urn:example:r}}att2='b' attribute, found {:?}",
+            e
+        ),
+    }
+    match atts.next() {
+        None => (),
+        e => panic!("Expecting None, found {:?}", e),
+    }
+}
+
+/// Single empty element with qualified attributes.
+/// Empty element expansion: enabled
+/// The code path for namespace handling is slightly different for `Empty` vs. `Start+End`.
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_attributes_empty_ns_expanded() {
+    let src = b"<a att1='a' r:att2='b' xmlns:r='urn:example:r' />";
+
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(true);
+    let mut buf = Vec::new();
+    let mut ns_buf = Vec::new();
+
+    {
+        let e = match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+            Ok((None, Start(e))) => e,
+            e => panic!("Expecting Empty event, got {:?}", e),
+        };
+
+        let mut atts = e
+            .attributes()
+            .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
+            // we don't care about xmlns attributes for this test
+            .filter(|kv| !kv.key.starts_with(b"xmlns"))
+            .map(|Attribute { key: name, value }| {
+                let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+                (opt_ns, local_name, value)
+            });
+        match atts.next() {
+            Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
+            e => panic!("Expecting att1='a' attribute, found {:?}", e),
+        }
+        match atts.next() {
+            Some((Some(ns), b"att2", Cow::Borrowed(b"b"))) => {
+                assert_eq!(&ns[..], b"urn:example:r");
+            }
+            e => panic!(
+                "Expecting {{urn:example:r}}att2='b' attribute, found {:?}",
+                e
+            ),
+        }
+        match atts.next() {
+            None => (),
+            e => panic!("Expecting None, found {:?}", e),
+        }
+    }
+
+    match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+        Ok((None, End(e))) => assert_eq!(b"a", e.name()),
+        e => panic!("Expecting End event, got {:?}", e),
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_default_ns_shadowing_empty() {
+    let src = b"<e xmlns='urn:example:o'><e att1='a' xmlns='urn:example:i' /></e>";
+
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(false);
+    let mut buf = Vec::new();
+    let mut ns_buf = Vec::new();
+
+    // <outer xmlns='urn:example:o'>
+    {
+        match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+            Ok((Some(ns), Start(e))) => {
+                assert_eq!(&ns[..], b"urn:example:o");
+                assert_eq!(e.name(), b"e");
+            }
+            e => panic!("Expected Start event (<outer>), got {:?}", e),
+        }
+    }
+
+    // <inner att1='a' xmlns='urn:example:i' />
+    {
+        let e = match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+            Ok((Some(ns), Empty(e))) => {
+                assert_eq!(::std::str::from_utf8(ns).unwrap(), "urn:example:i");
+                assert_eq!(e.name(), b"e");
+                e
+            }
+            e => panic!("Expecting Empty event, got {:?}", e),
+        };
+
+        let mut atts = e
+            .attributes()
+            .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
+            // we don't care about xmlns attributes for this test
+            .filter(|kv| !kv.key.starts_with(b"xmlns"))
+            .map(|Attribute { key: name, value }| {
+                let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+                (opt_ns, local_name, value)
+            });
+        // the attribute should _not_ have a namespace name. The default namespace does not
+        // apply to attributes.
+        match atts.next() {
+            Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
+            e => panic!("Expecting att1='a' attribute, found {:?}", e),
+        }
+        match atts.next() {
+            None => (),
+            e => panic!("Expecting None, found {:?}", e),
+        }
+    }
+
+    // </outer>
+    match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+        Ok((Some(ns), End(e))) => {
+            assert_eq!(&ns[..], b"urn:example:o");
+            assert_eq!(e.name(), b"e");
+        }
+        e => panic!("Expected End event (<outer>), got {:?}", e),
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_default_ns_shadowing_expanded() {
+    let src = b"<e xmlns='urn:example:o'><e att1='a' xmlns='urn:example:i' /></e>";
+
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(true);
+    let mut buf = Vec::new();
+    let mut ns_buf = Vec::new();
+
+    // <outer xmlns='urn:example:o'>
+    {
+        match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+            Ok((Some(ns), Start(e))) => {
+                assert_eq!(&ns[..], b"urn:example:o");
+                assert_eq!(e.name(), b"e");
+            }
+            e => panic!("Expected Start event (<outer>), got {:?}", e),
+        }
+    }
+    buf.clear();
+
+    // <inner att1='a' xmlns='urn:example:i' />
+    {
+        let e = match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+            Ok((Some(ns), Start(e))) => {
+                assert_eq!(&ns[..], b"urn:example:i");
+                assert_eq!(e.name(), b"e");
+                e
+            }
+            e => panic!("Expecting Start event (<inner>), got {:?}", e),
+        };
+        let mut atts = e
+            .attributes()
+            .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
+            // we don't care about xmlns attributes for this test
+            .filter(|kv| !kv.key.starts_with(b"xmlns"))
+            .map(|Attribute { key: name, value }| {
+                let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+                (opt_ns, local_name, value)
+            });
+        // the attribute should _not_ have a namespace name. The default namespace does not
+        // apply to attributes.
+        match atts.next() {
+            Some((None, b"att1", Cow::Borrowed(b"a"))) => (),
+            e => panic!("Expecting att1='a' attribute, found {:?}", e),
+        }
+        match atts.next() {
+            None => (),
+            e => panic!("Expecting None, found {:?}", e),
+        }
+    }
+
+    // virtual </inner>
+    match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+        Ok((Some(ns), End(e))) => {
+            assert_eq!(&ns[..], b"urn:example:i");
+            assert_eq!(e.name(), b"e");
+        }
+        e => panic!("Expected End event (</inner>), got {:?}", e),
+    }
+
+    // </outer>
+    match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+        Ok((Some(ns), End(e))) => {
+            assert_eq!(&ns[..], b"urn:example:o");
+            assert_eq!(e.name(), b"e");
+        }
+        e => panic!("Expected End event (</outer>), got {:?}", e),
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+#[cfg(feature = "encoding_rs")]
+async fn test_koi8_r_encoding() {
+    let src: &[u8] = include_bytes!("documents/opennews_all.rss");
+    let mut r = AsyncReader::from_reader(src as &[u8]);
+    r.trim_text(true).expand_empty_elements(false);
+    let mut buf = Vec::new();
+
+    loop {
+        match r.read_event(&mut buf).await {
+            Ok(Text(e)) => {
+                e.unescape_and_decode(&r).unwrap();
+            }
+            Ok(Eof) => break,
+            _ => (),
+        }
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn fuzz_53() {
+    let data: &[u8] = b"\xe9\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x00\n(\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\
+\x00<>\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00<<\x00\x00\x00";
+    let cursor = Cursor::new(data);
+    let mut reader = AsyncReader::from_reader(cursor);
+    let mut buf = vec![];
+
+    loop {
+        match reader.read_event(&mut buf).await {
+            Ok(quick_xml::events::Event::Eof) | Err(..) => break,
+            _ => buf.clear(),
+        }
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_issue94() {
+    let data = br#"<Run>
+<!B>
+</Run>"#;
+    let mut reader = AsyncReader::from_reader(&data[..]);
+    reader.trim_text(true);
+    let mut buf = vec![];
+
+    loop {
+        match reader.read_event(&mut buf).await {
+            Ok(quick_xml::events::Event::Eof) | Err(..) => break,
+            _ => buf.clear(),
+        }
+        buf.clear();
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn fuzz_101() {
+    let data: &[u8] = b"\x00\x00<\x00\x00\x0a>&#44444444401?#\x0a413518\
+                       #\x0a\x0a\x0a;<:<)(<:\x0a\x0a\x0a\x0a;<:\x0a\x0a\
+                       <:\x0a\x0a\x0a\x0a\x0a<\x00*\x00\x00\x00\x00";
+    let cursor = Cursor::new(data);
+    let mut reader = AsyncReader::from_reader(cursor);
+    let mut buf = vec![];
+
+    loop {
+        match reader.read_event(&mut buf).await {
+            Ok(Start(ref e)) | Ok(Empty(ref e)) => {
+                if e.unescaped().is_err() {
+                    break;
+                }
+                for a in e.attributes() {
+                    if a.ok().map_or(true, |a| a.unescaped_value().is_err()) {
+                        break;
+                    }
+                }
+            }
+            Ok(Text(ref e)) => {
+                if e.unescaped().is_err() {
+                    break;
+                }
+            }
+            Ok(Eof) | Err(..) => break,
+            _ => (),
+        }
+        buf.clear();
+    }
+}
+
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_default_namespace() {
+    let mut r = AsyncReader::from_str("<a ><b xmlns=\"www1\"></b></a>");
+    r.trim_text(true);
+
+    // <a>
+    let mut buf = Vec::new();
+    let mut ns_buf = Vec::new();
+
+    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+    } else {
+        panic!("expecting outer start element with no namespace");
+    }
+
+    // <b>
+    {
+        let event = match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+            Ok((Some(b"www1"), Start(event))) => event,
+            Ok((Some(_), Start(_))) => panic!("expecting namespace to resolve to 'www1'"),
+            _ => panic!("expecting namespace resolution"),
+        };
+
+        //We check if the resolve_namespace method also work properly
+        match r.event_namespace(event.name(), &mut ns_buf) {
+            (Some(b"www1"), _) => (),
+            (Some(_), _) => panic!("expecting namespace to resolve to 'www1'"),
+            ns => panic!(
+                "expecting namespace resolution by the resolve_nemespace method {:?}",
+                ns
+            ),
+        }
+    }
+
+    // </b>
+    match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+        Ok((Some(b"www1"), End(_))) => (),
+        Ok((Some(_), End(_))) => panic!("expecting namespace to resolve to 'www1'"),
+        _ => panic!("expecting namespace resolution"),
+    }
+
+    // </a> very important: a should not be in any namespace. The default namespace only applies to
+    // the sub-document it is defined on.
+
+    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
+    } else {
+        panic!("expecting outer end element with no namespace");
+    }
+}
+
+// #[cfg(feature = "asynchronous")]
+// #[cfg(feature = "serialize")]
+// #[tokio::test]
+// async fn line_score() {
+//     #[derive(Debug, PartialEq, Deserialize)]
+//     struct LineScoreData {
+//         game_pk: u32,
+//         game_type: char,
+//         venue: String,
+//         venue_w_chan_loc: String,
+//         venue_id: u32,
+//         time: String,
+//         time_zone: String,
+//         ampm: String,
+//         home_team_id: u32,
+//         home_team_city: String,
+//         home_team_name: String,
+//         home_league_id: u32,
+//         away_team_id: u32,
+//         away_team_city: String,
+//         away_team_name: String,
+//         away_league_id: u32,
+//         #[serde(rename = "linescore", skip_serializing)]
+//         innings: Vec<LineScore>,
+//     }
+//     #[derive(Debug, PartialEq, Deserialize)]
+//     struct LineScore {
+//         #[serde(rename = "away_inning_runs")]
+//         away_runs: u32,
+//         #[serde(rename = "home_inning_runs")]
+//         //needs to be an Option, since home team doesn't always bat.
+//         home_runs: Option<u32>,
+//         // Keeping the inning as a string, since we'll need it to construct URLs later
+//         inning: String,
+//     }
+
+//     let res: LineScoreData = quick_xml::de::from_str(include_str!("linescore.xml")).unwrap();
+
+//     let expected = LineScoreData {
+//         game_pk: 239575,
+//         game_type: 'R',
+//         venue: "Generic".to_owned(),
+//         venue_w_chan_loc: "USNY0996".to_owned(),
+//         venue_id: 401,
+//         time: "Gm 2".to_owned(),
+//         time_zone: "ET".to_owned(),
+//         ampm: "AM".to_owned(),
+//         home_team_id: 611,
+//         home_team_city: "DSL Dodgers".to_owned(),
+//         home_team_name: "DSL Dodgers".to_owned(),
+//         home_league_id: 130,
+//         away_team_id: 604,
+//         away_team_city: "DSL Blue Jays1".to_owned(),
+//         away_team_name: "DSL Blue Jays1".to_owned(),
+//         away_league_id: 130,
+//         innings: vec![
+//             LineScore {
+//                 away_runs: 1,
+//                 home_runs: Some(0),
+//                 inning: "1".to_owned(),
+//             },
+//             LineScore {
+//                 away_runs: 0,
+//                 home_runs: Some(0),
+//                 inning: "2".to_owned(),
+//             },
+//             LineScore {
+//                 away_runs: 1,
+//                 home_runs: Some(1),
+//                 inning: "3".to_owned(),
+//             },
+//             LineScore {
+//                 away_runs: 2,
+//                 home_runs: Some(0),
+//                 inning: "4".to_owned(),
+//             },
+//             LineScore {
+//                 away_runs: 0,
+//                 home_runs: Some(0),
+//                 inning: "5".to_owned(),
+//             },
+//             LineScore {
+//                 away_runs: 0,
+//                 home_runs: Some(0),
+//                 inning: "6".to_owned(),
+//             },
+//             LineScore {
+//                 away_runs: 0,
+//                 home_runs: Some(0),
+//                 inning: "7".to_owned(),
+//             },
+//         ],
+//     };
+//     assert_eq!(res, expected);
+// }
+
+// #[cfg(feature = "serialize")]
+// #[test]
+// fn players() {
+//     #[derive(PartialEq, Deserialize, Serialize, Debug)]
+//     struct Game {
+//         #[serde(rename = "team")]
+//         teams: Vec<Team>,
+//         //umpires: Umpires
+//     }
+
+//     #[derive(PartialEq, Deserialize, Serialize, Debug)]
+//     struct Team {
+//         #[serde(rename = "type")]
+//         home_away: HomeAway,
+//         id: String,
+//         name: String,
+//         #[serde(rename = "player")]
+//         players: Vec<Player>,
+//         #[serde(rename = "coach")]
+//         coaches: Vec<Coach>,
+//     }
+
+//     #[derive(PartialEq, Deserialize, Serialize, Debug)]
+//     enum HomeAway {
+//         #[serde(rename = "home")]
+//         Home,
+//         #[serde(rename = "away")]
+//         Away,
+//     }
+
+//     #[derive(PartialEq, Deserialize, Serialize, Debug, Clone)]
+//     struct Player {
+//         id: u32,
+//         #[serde(rename = "first")]
+//         name_first: String,
+//         #[serde(rename = "last")]
+//         name_last: String,
+//         game_position: Option<String>,
+//         bat_order: Option<u8>,
+//         position: String,
+//     }
+
+//     #[derive(PartialEq, Deserialize, Serialize, Debug)]
+//     struct Coach {
+//         position: String,
+//         #[serde(rename = "first")]
+//         name_first: String,
+//         #[serde(rename = "last")]
+//         name_last: String,
+//         id: u32,
+//     }
+
+//     let res: Game = quick_xml::de::from_str(include_str!("players.xml")).unwrap();
+
+//     let expected = Game {
+//         teams: vec![
+//             Team {
+//                 home_away: HomeAway::Away,
+//                 id: "CIN".to_owned(),
+//                 name: "Cincinnati Reds".to_owned(),
+//                 players: vec![
+//                     Player {
+//                         id: 115135,
+//                         name_first: "Ken".to_owned(),
+//                         name_last: "Griffey".to_owned(),
+//                         game_position: Some("RF".to_owned()),
+//                         bat_order: Some(3),
+//                         position: "RF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 115608,
+//                         name_first: "Scott".to_owned(),
+//                         name_last: "Hatteberg".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "1B".to_owned(),
+//                     },
+//                     Player {
+//                         id: 118967,
+//                         name_first: "Kent".to_owned(),
+//                         name_last: "Mercker".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 136460,
+//                         name_first: "Alex".to_owned(),
+//                         name_last: "Gonzalez".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "SS".to_owned(),
+//                     },
+//                     Player {
+//                         id: 150020,
+//                         name_first: "Jerry".to_owned(),
+//                         name_last: "Hairston".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "SS".to_owned(),
+//                     },
+//                     Player {
+//                         id: 150188,
+//                         name_first: "Francisco".to_owned(),
+//                         name_last: "Cordero".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 150221,
+//                         name_first: "Mike".to_owned(),
+//                         name_last: "Lincoln".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 150319,
+//                         name_first: "Josh".to_owned(),
+//                         name_last: "Fogg".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 150472,
+//                         name_first: "Ryan".to_owned(),
+//                         name_last: "Freel".to_owned(),
+//                         game_position: Some("LF".to_owned()),
+//                         bat_order: Some(2),
+//                         position: "CF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 276520,
+//                         name_first: "Bronson".to_owned(),
+//                         name_last: "Arroyo".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 279571,
+//                         name_first: "Matt".to_owned(),
+//                         name_last: "Belisle".to_owned(),
+//                         game_position: Some("P".to_owned()),
+//                         bat_order: Some(9),
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 279913,
+//                         name_first: "Corey".to_owned(),
+//                         name_last: "Patterson".to_owned(),
+//                         game_position: Some("CF".to_owned()),
+//                         bat_order: Some(1),
+//                         position: "CF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 346793,
+//                         name_first: "Jeremy".to_owned(),
+//                         name_last: "Affeldt".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 408252,
+//                         name_first: "Brandon".to_owned(),
+//                         name_last: "Phillips".to_owned(),
+//                         game_position: Some("2B".to_owned()),
+//                         bat_order: Some(4),
+//                         position: "2B".to_owned(),
+//                     },
+//                     Player {
+//                         id: 421685,
+//                         name_first: "Aaron".to_owned(),
+//                         name_last: "Harang".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 424325,
+//                         name_first: "David".to_owned(),
+//                         name_last: "Ross".to_owned(),
+//                         game_position: Some("C".to_owned()),
+//                         bat_order: Some(8),
+//                         position: "C".to_owned(),
+//                     },
+//                     Player {
+//                         id: 429665,
+//                         name_first: "Edwin".to_owned(),
+//                         name_last: "Encarnacion".to_owned(),
+//                         game_position: Some("3B".to_owned()),
+//                         bat_order: Some(6),
+//                         position: "3B".to_owned(),
+//                     },
+//                     Player {
+//                         id: 433898,
+//                         name_first: "Jeff".to_owned(),
+//                         name_last: "Keppinger".to_owned(),
+//                         game_position: Some("SS".to_owned()),
+//                         bat_order: Some(7),
+//                         position: "SS".to_owned(),
+//                     },
+//                     Player {
+//                         id: 435538,
+//                         name_first: "Bill".to_owned(),
+//                         name_last: "Bray".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 440361,
+//                         name_first: "Norris".to_owned(),
+//                         name_last: "Hopper".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "O".to_owned(),
+//                     },
+//                     Player {
+//                         id: 450172,
+//                         name_first: "Edinson".to_owned(),
+//                         name_last: "Volquez".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 454537,
+//                         name_first: "Jared".to_owned(),
+//                         name_last: "Burton".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 455751,
+//                         name_first: "Bobby".to_owned(),
+//                         name_last: "Livingston".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 456501,
+//                         name_first: "Johnny".to_owned(),
+//                         name_last: "Cueto".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 458015,
+//                         name_first: "Joey".to_owned(),
+//                         name_last: "Votto".to_owned(),
+//                         game_position: Some("1B".to_owned()),
+//                         bat_order: Some(5),
+//                         position: "1B".to_owned(),
+//                     },
+//                 ],
+//                 coaches: vec![
+//                     Coach {
+//                         position: "manager".to_owned(),
+//                         name_first: "Dusty".to_owned(),
+//                         name_last: "Baker".to_owned(),
+//                         id: 110481,
+//                     },
+//                     Coach {
+//                         position: "batting_coach".to_owned(),
+//                         name_first: "Brook".to_owned(),
+//                         name_last: "Jacoby".to_owned(),
+//                         id: 116461,
+//                     },
+//                     Coach {
+//                         position: "pitching_coach".to_owned(),
+//                         name_first: "Dick".to_owned(),
+//                         name_last: "Pole".to_owned(),
+//                         id: 120649,
+//                     },
+//                     Coach {
+//                         position: "first_base_coach".to_owned(),
+//                         name_first: "Billy".to_owned(),
+//                         name_last: "Hatcher".to_owned(),
+//                         id: 115602,
+//                     },
+//                     Coach {
+//                         position: "third_base_coach".to_owned(),
+//                         name_first: "Mark".to_owned(),
+//                         name_last: "Berry".to_owned(),
+//                         id: 427028,
+//                     },
+//                     Coach {
+//                         position: "bench_coach".to_owned(),
+//                         name_first: "Chris".to_owned(),
+//                         name_last: "Speier".to_owned(),
+//                         id: 122573,
+//                     },
+//                     Coach {
+//                         position: "bullpen_coach".to_owned(),
+//                         name_first: "Juan".to_owned(),
+//                         name_last: "Lopez".to_owned(),
+//                         id: 427306,
+//                     },
+//                     Coach {
+//                         position: "bullpen_catcher".to_owned(),
+//                         name_first: "Mike".to_owned(),
+//                         name_last: "Stefanski".to_owned(),
+//                         id: 150464,
+//                     },
+//                 ],
+//             },
+//             Team {
+//                 home_away: HomeAway::Home,
+//                 id: "NYM".to_owned(),
+//                 name: "New York Mets".to_owned(),
+//                 players: vec![
+//                     Player {
+//                         id: 110189,
+//                         name_first: "Moises".to_owned(),
+//                         name_last: "Alou".to_owned(),
+//                         game_position: Some("LF".to_owned()),
+//                         bat_order: Some(6),
+//                         position: "LF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 112116,
+//                         name_first: "Luis".to_owned(),
+//                         name_last: "Castillo".to_owned(),
+//                         game_position: Some("2B".to_owned()),
+//                         bat_order: Some(2),
+//                         position: "2B".to_owned(),
+//                     },
+//                     Player {
+//                         id: 113232,
+//                         name_first: "Carlos".to_owned(),
+//                         name_last: "Delgado".to_owned(),
+//                         game_position: Some("1B".to_owned()),
+//                         bat_order: Some(7),
+//                         position: "1B".to_owned(),
+//                     },
+//                     Player {
+//                         id: 113702,
+//                         name_first: "Damion".to_owned(),
+//                         name_last: "Easley".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "2B".to_owned(),
+//                     },
+//                     Player {
+//                         id: 118377,
+//                         name_first: "Pedro".to_owned(),
+//                         name_last: "Martinez".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 123790,
+//                         name_first: "Billy".to_owned(),
+//                         name_last: "Wagner".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 133340,
+//                         name_first: "Orlando".to_owned(),
+//                         name_last: "Hernandez".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 135783,
+//                         name_first: "Ramon".to_owned(),
+//                         name_last: "Castro".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "C".to_owned(),
+//                     },
+//                     Player {
+//                         id: 136724,
+//                         name_first: "Marlon".to_owned(),
+//                         name_last: "Anderson".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "LF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 136860,
+//                         name_first: "Carlos".to_owned(),
+//                         name_last: "Beltran".to_owned(),
+//                         game_position: Some("CF".to_owned()),
+//                         bat_order: Some(4),
+//                         position: "CF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 150411,
+//                         name_first: "Brian".to_owned(),
+//                         name_last: "Schneider".to_owned(),
+//                         game_position: Some("C".to_owned()),
+//                         bat_order: Some(8),
+//                         position: "C".to_owned(),
+//                     },
+//                     Player {
+//                         id: 276371,
+//                         name_first: "Johan".to_owned(),
+//                         name_last: "Santana".to_owned(),
+//                         game_position: Some("P".to_owned()),
+//                         bat_order: Some(9),
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 277184,
+//                         name_first: "Matt".to_owned(),
+//                         name_last: "Wise".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 346795,
+//                         name_first: "Endy".to_owned(),
+//                         name_last: "Chavez".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "RF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 407901,
+//                         name_first: "Jorge".to_owned(),
+//                         name_last: "Sosa".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 408230,
+//                         name_first: "Pedro".to_owned(),
+//                         name_last: "Feliciano".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 408310,
+//                         name_first: "Aaron".to_owned(),
+//                         name_last: "Heilman".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 408314,
+//                         name_first: "Jose".to_owned(),
+//                         name_last: "Reyes".to_owned(),
+//                         game_position: Some("SS".to_owned()),
+//                         bat_order: Some(1),
+//                         position: "SS".to_owned(),
+//                     },
+//                     Player {
+//                         id: 425508,
+//                         name_first: "Ryan".to_owned(),
+//                         name_last: "Church".to_owned(),
+//                         game_position: Some("RF".to_owned()),
+//                         bat_order: Some(5),
+//                         position: "RF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 429720,
+//                         name_first: "John".to_owned(),
+//                         name_last: "Maine".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 431151,
+//                         name_first: "David".to_owned(),
+//                         name_last: "Wright".to_owned(),
+//                         game_position: Some("3B".to_owned()),
+//                         bat_order: Some(3),
+//                         position: "3B".to_owned(),
+//                     },
+//                     Player {
+//                         id: 434586,
+//                         name_first: "Ambiorix".to_owned(),
+//                         name_last: "Burgos".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 434636,
+//                         name_first: "Angel".to_owned(),
+//                         name_last: "Pagan".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "LF".to_owned(),
+//                     },
+//                     Player {
+//                         id: 450306,
+//                         name_first: "Jason".to_owned(),
+//                         name_last: "Vargas".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                     Player {
+//                         id: 460059,
+//                         name_first: "Mike".to_owned(),
+//                         name_last: "Pelfrey".to_owned(),
+//                         game_position: None,
+//                         bat_order: None,
+//                         position: "P".to_owned(),
+//                     },
+//                 ],
+//                 coaches: vec![
+//                     Coach {
+//                         position: "manager".to_owned(),
+//                         name_first: "Willie".to_owned(),
+//                         name_last: "Randolph".to_owned(),
+//                         id: 120927,
+//                     },
+//                     Coach {
+//                         position: "batting_coach".to_owned(),
+//                         name_first: "Howard".to_owned(),
+//                         name_last: "Johnson".to_owned(),
+//                         id: 116593,
+//                     },
+//                     Coach {
+//                         position: "pitching_coach".to_owned(),
+//                         name_first: "Rick".to_owned(),
+//                         name_last: "Peterson".to_owned(),
+//                         id: 427395,
+//                     },
+//                     Coach {
+//                         position: "first_base_coach".to_owned(),
+//                         name_first: "Tom".to_owned(),
+//                         name_last: "Nieto".to_owned(),
+//                         id: 119796,
+//                     },
+//                     Coach {
+//                         position: "third_base_coach".to_owned(),
+//                         name_first: "Sandy".to_owned(),
+//                         name_last: "Alomar".to_owned(),
+//                         id: 110185,
+//                     },
+//                     Coach {
+//                         position: "bench_coach".to_owned(),
+//                         name_first: "Jerry".to_owned(),
+//                         name_last: "Manuel".to_owned(),
+//                         id: 118262,
+//                     },
+//                     Coach {
+//                         position: "bullpen_coach".to_owned(),
+//                         name_first: "Guy".to_owned(),
+//                         name_last: "Conti".to_owned(),
+//                         id: 434699,
+//                     },
+//                     Coach {
+//                         position: "bullpen_catcher".to_owned(),
+//                         name_first: "Dave".to_owned(),
+//                         name_last: "Racaniello".to_owned(),
+//                         id: 534948,
+//                     },
+//                     Coach {
+//                         position: "coach".to_owned(),
+//                         name_first: "Sandy".to_owned(),
+//                         name_last: "Alomar".to_owned(),
+//                         id: 110184,
+//                     },
+//                     Coach {
+//                         position: "coach".to_owned(),
+//                         name_first: "Juan".to_owned(),
+//                         name_last: "Lopez".to_owned(),
+//                         id: 495390,
+//                     },
+//                 ],
+//             },
+//         ],
+//     };
+
+//     assert_eq!(res, expected);
+// }

--- a/tests/unit_tests_async.rs
+++ b/tests/unit_tests_async.rs
@@ -1,14 +1,20 @@
+#[cfg(feature = "asynchronous")]
 use quick_xml::events::Event::*;
+#[cfg(feature = "asynchronous")]
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
-use quick_xml::{Reader, Result, Writer};
+#[cfg(feature = "asynchronous")]
+use quick_xml::{AsyncReader, Result, Writer};
+#[cfg(feature = "asynchronous")]
 use std::io::Cursor;
+#[cfg(feature = "asynchronous")]
 use std::str::from_utf8;
 
+#[cfg(feature = "asynchronous")]
 macro_rules! next_eq_name {
     ($r:expr, $t:tt, $bytes:expr) => {
         let mut buf = Vec::new();
 
-        match $r.read_event(&mut buf).unwrap() {
+        match $r.read_event(&mut buf).await.unwrap() {
             $t(ref e) if e.name() == $bytes => (),
             e => panic!(
                 "expecting {}({:?}), found {:?}",
@@ -21,11 +27,12 @@ macro_rules! next_eq_name {
     };
 }
 
+#[cfg(feature = "asynchronous")]
 macro_rules! next_eq_content {
     ($r:expr, $t:tt, $bytes:expr) => {
         let mut buf = Vec::new();
 
-        match $r.read_event(&mut buf).unwrap() {
+        match $r.read_event(&mut buf).await.unwrap() {
             $t(ref e) if &**e == $bytes => (),
             e => panic!(
                 "expecting {}({:?}), found {:?}",
@@ -38,6 +45,7 @@ macro_rules! next_eq_content {
     };
 }
 
+#[cfg(feature = "asynchronous")]
 macro_rules! next_eq {
     ($r:expr, Start, $bytes:expr) => (next_eq_name!($r, Start, $bytes););
     ($r:expr, End, $bytes:expr) => (next_eq_name!($r, End, $bytes););
@@ -51,83 +59,94 @@ macro_rules! next_eq {
     };
 }
 
-#[test]
-fn test_start() {
-    let mut r = Reader::from_str("<a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_start() {
+    let mut r = AsyncReader::from_str("<a>");
     r.trim_text(true);
     next_eq!(r, Start, b"a");
 }
 
-#[test]
-fn test_start_end() {
-    let mut r = Reader::from_str("<a></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_start_end() {
+    let mut r = AsyncReader::from_str("<a></a>");
     r.trim_text(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
 
-#[test]
-fn test_start_end_with_ws() {
-    let mut r = Reader::from_str("<a></a >");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_start_end_with_ws() {
+    let mut r = AsyncReader::from_str("<a></a >");
     r.trim_text(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
 
-#[test]
-fn test_start_end_attr() {
-    let mut r = Reader::from_str("<a b=\"test\"></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_start_end_attr() {
+    let mut r = AsyncReader::from_str("<a b=\"test\"></a>");
     r.trim_text(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
 
-#[test]
-fn test_empty() {
-    let mut r = Reader::from_str("<a />");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_empty() {
+    let mut r = AsyncReader::from_str("<a />");
     r.trim_text(true).expand_empty_elements(false);
     next_eq!(r, Empty, b"a");
 }
 
-#[test]
-fn test_empty_can_be_expanded() {
-    let mut r = Reader::from_str("<a />");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_empty_can_be_expanded() {
+    let mut r = AsyncReader::from_str("<a />");
     r.trim_text(true).expand_empty_elements(true);
     next_eq!(r, Start, b"a", End, b"a");
 }
 
-#[test]
-fn test_empty_attr() {
-    let mut r = Reader::from_str("<a b=\"test\" />");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_empty_attr() {
+    let mut r = AsyncReader::from_str("<a b=\"test\" />");
     r.trim_text(true).expand_empty_elements(false);
     next_eq!(r, Empty, b"a");
 }
 
-#[test]
-fn test_start_end_comment() {
-    let mut r = Reader::from_str("<b><a b=\"test\" c=\"test\"/> <a  /><!--t--></b>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_start_end_comment() {
+    let mut r = AsyncReader::from_str("<b><a b=\"test\" c=\"test\"/> <a  /><!--t--></b>");
     r.trim_text(true).expand_empty_elements(false);
     next_eq!(r, Start, b"b", Empty, b"a", Empty, b"a", Comment, b"t", End, b"b");
 }
 
-#[test]
-fn test_start_txt_end() {
-    let mut r = Reader::from_str("<a>test</a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_start_txt_end() {
+    let mut r = AsyncReader::from_str("<a>test</a>");
     r.trim_text(true);
     next_eq!(r, Start, b"a", Text, b"test", End, b"a");
 }
 
-#[test]
-fn test_comment() {
-    let mut r = Reader::from_str("<!--test-->");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_comment() {
+    let mut r = AsyncReader::from_str("<!--test-->");
     r.trim_text(true);
     next_eq!(r, Comment, b"test");
 }
 
-#[test]
-fn test_xml_decl() {
-    let mut r = Reader::from_str("<?xml version=\"1.0\" encoding='utf-8'?>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_xml_decl() {
+    let mut r = AsyncReader::from_str("<?xml version=\"1.0\" encoding='utf-8'?>");
     r.trim_text(true);
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf).unwrap() {
+    match r.read_event(&mut buf).await.unwrap() {
         Decl(ref e) => {
             match e.version() {
                 Ok(v) => assert_eq!(
@@ -157,14 +176,15 @@ fn test_xml_decl() {
     }
 }
 
-#[test]
-fn test_trim_test() {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_trim_test() {
     let txt = "<a><b>  </b></a>";
-    let mut r = Reader::from_str(txt);
+    let mut r = AsyncReader::from_str(txt);
     r.trim_text(true);
     next_eq!(r, Start, b"a", Start, b"b", End, b"b", End, b"a");
 
-    let mut r = Reader::from_str(txt);
+    let mut r = AsyncReader::from_str(txt);
     r.trim_text(false);
     next_eq!(
         r, Text, b"", Start, b"a", Text, b"", Start, b"b", Text, b"  ", End, b"b", Text, b"", End,
@@ -172,44 +192,49 @@ fn test_trim_test() {
     );
 }
 
-#[test]
-fn test_cdata() {
-    let mut r = Reader::from_str("<![CDATA[test]]>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_cdata() {
+    let mut r = AsyncReader::from_str("<![CDATA[test]]>");
     r.trim_text(true);
     next_eq!(r, CData, b"test");
 }
 
-#[test]
-fn test_cdata_open_close() {
-    let mut r = Reader::from_str("<![CDATA[test <> test]]>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_cdata_open_close() {
+    let mut r = AsyncReader::from_str("<![CDATA[test <> test]]>");
     r.trim_text(true);
     next_eq!(r, CData, b"test &lt;&gt; test");
 }
 
-#[test]
-fn test_start_attr() {
-    let mut r = Reader::from_str("<a b=\"c\">");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_start_attr() {
+    let mut r = AsyncReader::from_str("<a b=\"c\">");
     r.trim_text(true);
     next_eq!(r, Start, b"a");
 }
 
-#[test]
-fn test_nested() {
-    let mut r = Reader::from_str("<a><b>test</b><c/></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_nested() {
+    let mut r = AsyncReader::from_str("<a><b>test</b><c/></a>");
     r.trim_text(true).expand_empty_elements(false);
     next_eq!(r, Start, b"a", Start, b"b", Text, b"test", End, b"b", Empty, b"c", End, b"a");
 }
 
-#[test]
-fn test_writer() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_writer() -> Result<()> {
     let txt = include_str!("../tests/documents/test_writer.xml").trim();
-    let mut reader = Reader::from_str(txt);
+    let mut reader = AsyncReader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -217,20 +242,21 @@ fn test_writer() -> Result<()> {
 
     let result = writer.into_inner().into_inner();
     assert_eq!(result, txt.as_bytes());
+
     Ok(())
 }
 
-#[test]
-fn test_writer_borrow() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_writer_borrow() -> Result<()> {
     let txt = include_str!("../tests/documents/test_writer.xml").trim();
-    let mut reader = Reader::from_str(txt);
+    let mut reader = AsyncReader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        let event = reader.read_event(&mut buf)?;
-        match event {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             e => assert!(writer.write_event(&e).is_ok()), // either `e` or `&e`
         }
@@ -238,47 +264,43 @@ fn test_writer_borrow() -> Result<()> {
 
     let result = writer.into_inner().into_inner();
     assert_eq!(result, txt.as_bytes());
+
     Ok(())
 }
 
-#[test]
-fn test_writer_indent() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_writer_indent() -> Result<()> {
     let txt = include_str!("../tests/documents/test_writer_indent.xml");
-    let mut reader = Reader::from_str(txt);
+    let mut reader = AsyncReader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
     }
 
     let result = writer.into_inner().into_inner();
-
-    #[cfg(windows)]
-    assert!(result.into_iter().eq(txt.bytes().filter(|b| *b != 13)));
-
-    #[cfg(not(windows))]
     assert_eq!(result, txt.as_bytes());
 
     Ok(())
 }
 
-#[test]
-fn test_writer_indent_cdata() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_writer_indent_cdata() -> Result<()> {
     let txt = include_str!("../tests/documents/test_writer_indent_cdata.xml");
-    let mut reader = Reader::from_str(txt);
+    let mut reader = AsyncReader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);
     let mut buf = Vec::new();
 
     loop {
-        let event = reader.read_event(&mut buf)?;
-
-        match event {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -295,17 +317,18 @@ fn test_writer_indent_cdata() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_write_empty_element_attrs() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_write_empty_element_attrs() -> Result<()> {
     let str_from = r#"<source attr="val"/>"#;
     let expected = r#"<source attr="val"/>"#;
-    let mut reader = Reader::from_str(str_from);
+    let mut reader = AsyncReader::from_str(str_from);
     reader.expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -317,17 +340,18 @@ fn test_write_empty_element_attrs() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_write_attrs() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_write_attrs() -> Result<()> {
     let str_from = r#"<source attr="val"></source>"#;
     let expected = r#"<copy attr="val" a="b" c="d" x="y&quot;z"></copy>"#;
-    let mut reader = Reader::from_str(str_from);
+    let mut reader = AsyncReader::from_str(str_from);
     reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        let event = match reader.read_event(&mut buf)? {
+        let event = match reader.read_event(&mut buf).await? {
             Eof => break,
             Start(elem) => {
                 let mut attrs = elem.attributes().collect::<Result<Vec<_>>>().unwrap();
@@ -349,8 +373,9 @@ fn test_write_attrs() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_new_xml_decl_full() {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_new_xml_decl_full() {
     let mut writer = Writer::new(Vec::new());
     writer
         .write_event(Decl(BytesDecl::new(b"1.2", Some(b"utf-X"), Some(b"yo"))))
@@ -364,8 +389,9 @@ fn test_new_xml_decl_full() {
     );
 }
 
-#[test]
-fn test_new_xml_decl_standalone() {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_new_xml_decl_standalone() {
     let mut writer = Writer::new(Vec::new());
     writer
         .write_event(Decl(BytesDecl::new(b"1.2", None, Some(b"yo"))))
@@ -379,8 +405,9 @@ fn test_new_xml_decl_standalone() {
     );
 }
 
-#[test]
-fn test_new_xml_decl_encoding() {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_new_xml_decl_encoding() {
     let mut writer = Writer::new(Vec::new());
     writer
         .write_event(Decl(BytesDecl::new(b"1.2", Some(b"utf-X"), None)))
@@ -394,8 +421,9 @@ fn test_new_xml_decl_encoding() {
     );
 }
 
-#[test]
-fn test_new_xml_decl_version() {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_new_xml_decl_version() {
     let mut writer = Writer::new(Vec::new());
     writer
         .write_event(Decl(BytesDecl::new(b"1.2", None, None)))
@@ -410,8 +438,9 @@ fn test_new_xml_decl_version() {
 }
 
 /// This test ensures that empty XML declaration attribute values are not a problem.
-#[test]
-fn test_new_xml_decl_empty() {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_new_xml_decl_empty() {
     let mut writer = Writer::new(Vec::new());
     // An empty version should arguably be an error, but we don't expect anyone to actually supply
     // an empty version.
@@ -427,14 +456,15 @@ fn test_new_xml_decl_empty() {
     );
 }
 
-#[test]
-fn test_buf_position_err_end_element() {
-    let mut r = Reader::from_str("</a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_buf_position_err_end_element() {
+    let mut r = AsyncReader::from_str("</a>");
     r.trim_text(true).check_end_names(true);
 
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Err(_) if r.buffer_position() == 2 => (), // error at char 2: no opening tag
         Err(e) => panic!(
             "expecting buf_pos = 2, found {}, err: {:?}",
@@ -445,9 +475,10 @@ fn test_buf_position_err_end_element() {
     }
 }
 
-#[test]
-fn test_buf_position_err_comment() {
-    let mut r = Reader::from_str("<a><!--b>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_buf_position_err_comment() {
+    let mut r = AsyncReader::from_str("<a><!--b>");
     r.trim_text(true).check_end_names(true);
 
     next_eq!(r, Start, b"a");
@@ -455,7 +486,7 @@ fn test_buf_position_err_comment() {
 
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Err(_) if r.buffer_position() == 4 => {
             // error at char 5: no closing --> tag found
             assert!(true);
@@ -469,20 +500,21 @@ fn test_buf_position_err_comment() {
     }
 }
 
-#[test]
-fn test_buf_position_err_comment_2_buf() {
-    let mut r = Reader::from_str("<a><!--b>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_buf_position_err_comment_2_buf() {
+    let mut r = AsyncReader::from_str("<a><!--b>");
     r.trim_text(true).check_end_names(true);
 
     let mut buf = Vec::new();
 
-    let _ = r.read_event(&mut buf);
+    let _ = r.read_event(&mut buf).await;
 
     assert_eq!(r.buffer_position(), 3);
 
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Err(_) if r.buffer_position() == 4 => {
             // error at char 5: no closing --> tag found
             assert!(true);
@@ -496,9 +528,10 @@ fn test_buf_position_err_comment_2_buf() {
     }
 }
 
-#[test]
-fn test_buf_position_err_comment_trim_text() {
-    let mut r = Reader::from_str("<a>\r\n <!--b>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_buf_position_err_comment_trim_text() {
+    let mut r = AsyncReader::from_str("<a>\r\n <!--b>");
     r.trim_text(true).check_end_names(true);
 
     next_eq!(r, Start, b"a");
@@ -506,7 +539,7 @@ fn test_buf_position_err_comment_trim_text() {
 
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Err(_) if r.buffer_position() == 7 => {
             // error at char 5: no closing --> tag found
             assert!(true);
@@ -520,20 +553,21 @@ fn test_buf_position_err_comment_trim_text() {
     }
 }
 
-#[test]
-fn test_namespace() {
-    let mut r = Reader::from_str("<a xmlns:myns='www1'><myns:b>in namespace!</myns:b></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_namespace() {
+    let mut r = AsyncReader::from_str("<a xmlns:myns='www1'><myns:b>in namespace!</myns:b></a>");
     r.trim_text(true);
 
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
 
-    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
     } else {
         assert!(false, "expecting start element with no namespace");
     }
 
-    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
         if &*a == b"www1" {
             assert!(true);
         } else {
@@ -544,22 +578,23 @@ fn test_namespace() {
     }
 }
 
-#[test]
-fn test_default_namespace() {
-    let mut r = Reader::from_str("<a ><b xmlns=\"www1\"></b></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_default_namespace() {
+    let mut r = AsyncReader::from_str("<a ><b xmlns=\"www1\"></b></a>");
     r.trim_text(true);
 
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
 
     // <a>
-    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((None, Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
     } else {
         assert!(false, "expecting outer start element with no namespace");
     }
 
     // <b>
-    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
         if &*a == b"www1" {
             assert!(true);
         } else {
@@ -570,7 +605,7 @@ fn test_default_namespace() {
     }
 
     // </b>
-    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
         if &*a == b"www1" {
             assert!(true);
         } else {
@@ -582,21 +617,22 @@ fn test_default_namespace() {
 
     // </a> very important: a should not be in any namespace. The default namespace only applies to
     // the sub-document it is defined on.
-    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
     } else {
         assert!(false, "expecting outer end element with no namespace");
     }
 }
 
-#[test]
-fn test_default_namespace_reset() {
-    let mut r = Reader::from_str("<a xmlns=\"www1\"><b xmlns=\"\"></b></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_default_namespace_reset() {
+    let mut r = AsyncReader::from_str("<a xmlns=\"www1\"><b xmlns=\"\"></b></a>");
     r.trim_text(true);
 
     let mut buf = Vec::new();
     let mut ns_buf = Vec::new();
 
-    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((Some(a), Start(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
         assert_eq!(
             &a[..],
             b"www1",
@@ -606,17 +642,17 @@ fn test_default_namespace_reset() {
         panic!("expecting outer start element with to resolve to 'www1'");
     }
 
-    match r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    match r.read_namespaced_event(&mut buf, &mut ns_buf).await {
         Ok((None, Start(_))) => (),
         e => panic!("expecting inner start element, got {:?}", e),
     }
 
-    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((None, End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
     } else {
         assert!(false, "expecting inner end element");
     }
 
-    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf) {
+    if let Ok((Some(a), End(_))) = r.read_namespaced_event(&mut buf, &mut ns_buf).await {
         assert_eq!(
             &a[..],
             b"www1",
@@ -627,14 +663,15 @@ fn test_default_namespace_reset() {
     }
 }
 
-#[test]
-fn test_escaped_content() {
-    let mut r = Reader::from_str("<a>&lt;test&gt;</a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_escaped_content() {
+    let mut r = AsyncReader::from_str("<a>&lt;test&gt;</a>");
     r.trim_text(true);
     next_eq!(r, Start, b"a");
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Ok(Text(e)) => {
             if &*e != b"&lt;test&gt;" {
                 panic!(
@@ -668,8 +705,9 @@ fn test_escaped_content() {
     next_eq!(r, End, b"a");
 }
 
-#[test]
-fn test_read_write_roundtrip_results_in_identity() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_read_write_roundtrip_results_in_identity() -> Result<()> {
     let input = r#"
         <?xml version="1.0" encoding="UTF-8"?>
         <section ns:label="header">
@@ -679,13 +717,13 @@ fn test_read_write_roundtrip_results_in_identity() -> Result<()> {
             </section>
     "#;
 
-    let mut reader = Reader::from_str(input);
+    let mut reader = AsyncReader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -697,8 +735,9 @@ fn test_read_write_roundtrip_results_in_identity() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_read_write_roundtrip() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_read_write_roundtrip() -> Result<()> {
     let input = r#"
         <?xml version="1.0" encoding="UTF-8"?>
         <section ns:label="header">
@@ -708,13 +747,13 @@ fn test_read_write_roundtrip() -> Result<()> {
             </section>
     "#;
 
-    let mut reader = Reader::from_str(input);
+    let mut reader = AsyncReader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -726,8 +765,9 @@ fn test_read_write_roundtrip() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_read_write_roundtrip_escape() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_read_write_roundtrip_escape() -> Result<()> {
     let input = r#"
         <?xml version="1.0" encoding="UTF-8"?>
         <section ns:label="header">
@@ -737,13 +777,13 @@ fn test_read_write_roundtrip_escape() -> Result<()> {
             </section>
     "#;
 
-    let mut reader = Reader::from_str(input);
+    let mut reader = AsyncReader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             Text(e) => {
                 let t = e.escaped();
@@ -761,8 +801,9 @@ fn test_read_write_roundtrip_escape() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_read_write_roundtrip_escape_text() -> Result<()> {
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_read_write_roundtrip_escape_text() -> Result<()> {
     let input = r#"
         <?xml version="1.0" encoding="UTF-8"?>
         <section ns:label="header">
@@ -772,13 +813,13 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
             </section>
     "#;
 
-    let mut reader = Reader::from_str(input);
+    let mut reader = AsyncReader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event(&mut buf).await? {
             Eof => break,
             Text(e) => {
                 let t = e.unescape_and_decode(&reader).unwrap();
@@ -796,13 +837,14 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_closing_bracket_in_single_quote_attr() {
-    let mut r = Reader::from_str("<a attr='>' check='2'></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_closing_bracket_in_single_quote_attr() {
+    let mut r = AsyncReader::from_str("<a attr='>' check='2'></a>");
     r.trim_text(true);
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
@@ -820,13 +862,14 @@ fn test_closing_bracket_in_single_quote_attr() {
     next_eq!(r, End, b"a");
 }
 
-#[test]
-fn test_closing_bracket_in_double_quote_attr() {
-    let mut r = Reader::from_str("<a attr=\">\" check=\"2\"></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_closing_bracket_in_double_quote_attr() {
+    let mut r = AsyncReader::from_str("<a attr=\">\" check=\"2\"></a>");
     r.trim_text(true);
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
@@ -844,13 +887,14 @@ fn test_closing_bracket_in_double_quote_attr() {
     next_eq!(r, End, b"a");
 }
 
-#[test]
-fn test_closing_bracket_in_double_quote_mixed() {
-    let mut r = Reader::from_str("<a attr=\"'>'\" check=\"'2'\"></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_closing_bracket_in_double_quote_mixed() {
+    let mut r = AsyncReader::from_str("<a attr=\"'>'\" check=\"'2'\"></a>");
     r.trim_text(true);
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
@@ -868,13 +912,14 @@ fn test_closing_bracket_in_double_quote_mixed() {
     next_eq!(r, End, b"a");
 }
 
-#[test]
-fn test_closing_bracket_in_single_quote_mixed() {
-    let mut r = Reader::from_str("<a attr='\">\"' check='\"2\"'></a>");
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
+async fn test_closing_bracket_in_single_quote_mixed() {
+    let mut r = AsyncReader::from_str("<a attr='\">\"' check='\"2\"'></a>");
     r.trim_text(true);
     let mut buf = Vec::new();
 
-    match r.read_event(&mut buf) {
+    match r.read_event(&mut buf).await {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             match attrs.next() {
@@ -892,19 +937,20 @@ fn test_closing_bracket_in_single_quote_mixed() {
     next_eq!(r, End, b"a");
 }
 
-#[test]
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
 #[cfg(not(feature = "encoding"))]
-fn test_unescape_and_decode_without_bom_removes_utf8_bom() {
+async fn test_unescape_and_decode_without_bom_removes_utf8_bom() {
     let input: &str = std::str::from_utf8(b"\xEF\xBB\xBF<?xml version=\"1.0\"?>").unwrap();
 
-    let mut reader = Reader::from_str(&input);
+    let mut reader = AsyncReader::from_str(&input);
     reader.trim_text(true);
 
     let mut txt = Vec::new();
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf) {
+        match reader.read_event(&mut buf).await {
             Ok(Event::Text(e)) => txt.push(e.unescape_and_decode_without_bom(&reader).unwrap()),
             Ok(Event::Eof) => break,
             _ => (),
@@ -913,17 +959,20 @@ fn test_unescape_and_decode_without_bom_removes_utf8_bom() {
     assert_eq!(txt, vec![""]);
 }
 
-#[test]
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
 #[cfg(feature = "encoding")]
-fn test_unescape_and_decode_without_bom_removes_utf16be_bom() {
-    let mut reader = Reader::from_file("./tests/documents/utf16be.xml").unwrap();
+async fn test_unescape_and_decode_without_bom_removes_utf16be_bom() {
+    let mut reader = AsyncReader::from_file("./tests/documents/utf16be.xml")
+        .await
+        .unwrap();
     reader.trim_text(true);
 
     let mut txt = Vec::new();
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf) {
+        match reader.read_event(&mut buf).await {
             Ok(Event::Text(e)) => txt.push(e.unescape_and_decode_without_bom(&mut reader).unwrap()),
             Ok(Event::Eof) => break,
             _ => (),
@@ -932,17 +981,20 @@ fn test_unescape_and_decode_without_bom_removes_utf16be_bom() {
     assert_eq!(txt[0], "");
 }
 
-#[test]
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
 #[cfg(feature = "encoding")]
-fn test_unescape_and_decode_without_bom_removes_utf16le_bom() {
-    let mut reader = Reader::from_file("./tests/documents/utf16le.xml").unwrap();
+async fn test_unescape_and_decode_without_bom_removes_utf16le_bom() {
+    let mut reader = AsyncReader::from_file("./tests/documents/utf16le.xml")
+        .await
+        .unwrap();
     reader.trim_text(true);
 
     let mut txt = Vec::new();
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf) {
+        match reader.read_event(&mut buf).await {
             Ok(Event::Text(e)) => txt.push(e.unescape_and_decode_without_bom(&mut reader).unwrap()),
             Ok(Event::Eof) => break,
             _ => (),
@@ -951,19 +1003,20 @@ fn test_unescape_and_decode_without_bom_removes_utf16le_bom() {
     assert_eq!(txt[0], "");
 }
 
-#[test]
+#[cfg(feature = "asynchronous")]
+#[tokio::test]
 #[cfg(not(feature = "encoding"))]
-fn test_unescape_and_decode_without_bom_does_nothing_if_no_bom_exists() {
+async fn test_unescape_and_decode_without_bom_does_nothing_if_no_bom_exists() {
     let input: &str = std::str::from_utf8(b"<?xml version=\"1.0\"?>").unwrap();
 
-    let mut reader = Reader::from_str(&input);
+    let mut reader = AsyncReader::from_str(&input);
     reader.trim_text(true);
 
     let mut txt = Vec::new();
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf) {
+        match reader.read_event(&mut buf).await {
             Ok(Event::Text(e)) => txt.push(e.unescape_and_decode_without_bom(&mut reader).unwrap()),
             Ok(Event::Eof) => break,
             _ => (),


### PR DESCRIPTION
I would like to use `quick-xml` together with `tokio`'s `AsyncRead`, as I am fetching an object from S3 with `rusoto_s3` and that returns a body that implements `AsyncRead`. This is an attempt at making that happen.