### PR TITLE
Add serde tests, implement newtype and tuple serializations, fix some bugs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
   serialize type with serde
 - feat: Add support for serialization of
   - unit enums variants
+  - newtype structs and enum variants
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,12 +8,15 @@
   - test: Adding missing tests
   - chore: Changes to the build process or auxiliary tools/libraries/documentation
 
+## Unreleased
+- test: Add tests for indentation
+
 ## 0.19.0
 - docs: Add example for nested parsing
 - fix: `buffer_position` not properly set sometimes
 - feat: Make escape module public apart from EscapeError
 - feat: Nake Reader `Clone`able
-- feat: Enable writing manual identation (and fix underflow on shrink)
+- feat: Enable writing manual indentation (and fix underflow on shrink)
 - style: Forbid unsafe code
 - fix: Use `write_all` instead of `write`
 - fix: (Serde) Serialize basic types as attributes (breaking change)
@@ -41,7 +44,7 @@
 - refactor: move xml-rs bench dependency into another local crate
 
 ## 0.16.0
-- feat: (breaking change) set failure and encoding_rs crates as optional. 
+- feat: (breaking change) set failure and encoding_rs crates as optional.
 You should now use respectively `use-failure` and `encoding` features to get the old behavior
 - perf: improve perf using memchr3 iterator. Reading is 18% better on benches
 
@@ -194,7 +197,7 @@ Major refactoring. Breaks most of existing functionalities
 
 ## 0.2.3
 - fix: do not write attributes on `Event::End`
- 
+
 ## 0.2.2
 - refactor: code refactoring, split largest functions into smaller ones
 - refactor: use `Range` instead of `usize`s in `Element` definition

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 - test: Add tests for indentation
+- feat: Use self-closed tags when serialize types without nested elements with serde
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 - test: Add tests for indentation
+- test: Add complete tests for serde deserialization
 - feat: Use self-closed tags when serialize types without nested elements with serde
 - feat: Add two new API to the `BytesStart`: `to_borrowed()` and `to_end()`
 - feat: Add ability to specify name of the root tag and indentation settings when

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@
 - test: Add tests for indentation
 - feat: Use self-closed tags when serialize types without nested elements with serde
 - feat: Add two new API to the `BytesStart`: `to_borrowed()` and `to_end()`
+- feat: Add ability to specify name of the root tag and indentation settings when
+  serialize type with serde
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 ## Unreleased
 - test: Add tests for indentation
 - feat: Use self-closed tags when serialize types without nested elements with serde
+- feat: Add two new API to the `BytesStart`: `to_borrowed()` and `to_end()`
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
   - unnamed tuples, tuple structs and enum variants
 - fix: More consistent structs serialization
 - fix: Deserialization of newtype structs
+- fix: `unit` deserialization and newtype and struct deserialization in adjacently tagged enums
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
   - newtype structs and enum variants
   - unnamed tuples, tuple structs and enum variants
 - fix: More consistent structs serialization
+- fix: Deserialization of newtype structs
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 - feat: Add support for serialization of
   - unit enums variants
   - newtype structs and enum variants
+  - unnamed tuples, tuple structs and enum variants
 - fix: More consistent structs serialization
 
 ## 0.19.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 - feat: Add support for serialization of
   - unit enums variants
   - newtype structs and enum variants
+- fix: More consistent structs serialization
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@
 - feat: Add two new API to the `BytesStart`: `to_borrowed()` and `to_end()`
 - feat: Add ability to specify name of the root tag and indentation settings when
   serialize type with serde
+- feat: Add support for serialization of
+  - unit enums variants
 
 ## 0.19.0
 - docs: Add example for nested parsing

--- a/src/de/escape.rs
+++ b/src/de/escape.rs
@@ -15,7 +15,9 @@ use std::borrow::Cow;
 #[derive(Clone)]
 pub(crate) struct EscapedDeserializer {
     decoder: Decoder,
+    /// Possible escaped value of text/CDATA or attribute value
     escaped_value: Vec<u8>,
+    /// If `true`, value requires unescaping before using
     escaped: bool,
 }
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -17,8 +17,14 @@ enum MapValue {
 
 /// A deserializer for `Attributes`
 pub(crate) struct MapAccess<'a, R: BufRead> {
+    /// Tag -- owner of attributes
     start: BytesStart<'static>,
     de: &'a mut Deserializer<R>,
+    /// Position in flat byte slice of all attributes from which next
+    /// attribute should be parsed. This field is required because we
+    /// do not store reference to `Attributes` itself but instead create
+    /// a new object on each advance of `Attributes` iterator, so we need
+    /// to restore last position before advance.
     position: usize,
     value: MapValue,
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -803,6 +803,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
         fn elements() {
             let data: Struct = from_str(
                 r#"<root><float>42</float><string>answer</string></root>"#
@@ -936,6 +937,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<Flatten><float>42</float><string>answer</string></Flatten>"#
@@ -1014,6 +1016,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><tag>Newtype</tag><value>true</value></root>"#
@@ -1022,6 +1025,7 @@ mod tests {
                 }
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn attributes() {
                     let data: Node = from_str(
                         r#"<root tag="Newtype" value="true"/>"#
@@ -1034,6 +1038,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><tag>Struct</tag><float>42</float><string>answer</string></root>"#
@@ -1060,6 +1065,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><tag>Holder</tag><string>answer</string><nested><float>42</float></nested></root>"#
@@ -1086,6 +1092,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><tag>Flatten</tag><float>42</float><string>answer</string></root>"#
@@ -1192,6 +1199,7 @@ mod tests {
                 }
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn attributes() {
                     let data: Workaround = from_str(
                         r#"<root tag="Tuple" content="42"><content>answer</content></root>"#
@@ -1264,6 +1272,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><tag>Flatten</tag><content><float>42</float><string>answer</string></content></root>"#
@@ -1322,6 +1331,7 @@ mod tests {
             }
 
             #[test]
+            #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
             fn unit() {
                 // Unit variant consists just from the tag, and because tags
                 // are not written, nothing is written
@@ -1330,12 +1340,14 @@ mod tests {
             }
 
             #[test]
+            #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
             fn newtype() {
                 let data: Node = from_str("true").unwrap();
                 assert_eq!(data, Node::Newtype(true));
             }
 
             #[test]
+            #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
             fn tuple_struct() {
                 let data: Workaround = from_str(
                     "<root>42</root><root>answer</root>"
@@ -1347,6 +1359,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><float>42</float><string>answer</string></root>"#
@@ -1358,6 +1371,7 @@ mod tests {
                 }
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn attributes() {
                     let data: Node = from_str(
                         r#"<root float="42" string="answer"/>"#
@@ -1373,6 +1387,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><string>answer</string><nested><float>42</float></nested></root>"#
@@ -1399,6 +1414,7 @@ mod tests {
                 use super::*;
 
                 #[test]
+                #[ignore = "Prime cause: deserialize_any under the hood + https://github.com/serde-rs/serde/issues/1183"]
                 fn elements() {
                     let data: Node = from_str(
                         r#"<root><float>42</float><string2>answer</string2></root>"#

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -253,7 +253,7 @@ macro_rules! deserialize_type {
 impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
     type Error = DeError;
 
-    forward_to_deserialize_any! { newtype_struct identifier }
+    forward_to_deserialize_any! { identifier }
 
     fn deserialize_struct<V: de::Visitor<'de>>(
         self,
@@ -365,6 +365,14 @@ impl<'de, 'a, R: BufRead> de::Deserializer<'de> for &'a mut Deserializer<R> {
         visitor: V,
     ) -> Result<V::Value, DeError> {
         self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, DeError> {
+        self.deserialize_tuple(1, visitor)
     }
 
     fn deserialize_tuple<V: de::Visitor<'de>>(

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -662,4 +662,747 @@ mod tests {
 
         assert_eq!(item, Item);
     }
+
+    #[test]
+    fn unit() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Unit;
+
+        let data: Unit = from_str("<root/>").unwrap();
+        assert_eq!(data, Unit);
+    }
+
+    #[test]
+    fn newtype() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Newtype(bool);
+
+        let data: Newtype = from_str("<root>true</root>").unwrap();
+        assert_eq!(data, Newtype(true));
+    }
+
+    #[test]
+    fn tuple() {
+        let data: (f32, String) = from_str(
+            "<root>42</root><root>answer</root>"
+        ).unwrap();
+        assert_eq!(data, (42.0, "answer".into()));
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Tuple(f32, String);
+
+        let data: Tuple = from_str(
+            "<root>42</root><root>answer</root>"
+        ).unwrap();
+        assert_eq!(data, Tuple(42.0, "answer".into()));
+    }
+
+    mod struct_ {
+        use super::*;
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Struct {
+            float: f64,
+            string: String,
+        }
+
+        #[test]
+        fn elements() {
+            let data: Struct = from_str(
+                r#"<root><float>42</float><string>answer</string></root>"#
+            ).unwrap();
+            assert_eq!(data, Struct {
+                float: 42.0,
+                string: "answer".into()
+            });
+        }
+
+        #[test]
+        fn attributes() {
+            let data: Struct = from_str(
+                r#"<root float="42" string="answer"/>"#
+            ).unwrap();
+            assert_eq!(data, Struct {
+                float: 42.0,
+                string: "answer".into()
+            });
+        }
+    }
+
+    mod nested_struct {
+        use super::*;
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Struct {
+            nested: Nested,
+            string: String,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Nested {
+            float: f32,
+        }
+
+        #[test]
+        fn elements() {
+            let data: Struct = from_str(
+                r#"<root><string>answer</string><nested><float>42</float></nested></root>"#
+            ).unwrap();
+            assert_eq!(data, Struct {
+                nested: Nested { float: 42.0 },
+                string: "answer".into()
+            });
+        }
+
+        #[test]
+        fn attributes() {
+            let data: Struct = from_str(
+                r#"<root string="answer"><nested float="42"/></root>"#
+            ).unwrap();
+            assert_eq!(data, Struct {
+                nested: Nested { float: 42.0 },
+                string: "answer".into()
+            });
+        }
+    }
+
+    mod flatten_struct {
+        use super::*;
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Struct {
+            #[serde(flatten)]
+            nested: Nested,
+            string: String,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Nested {
+            //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
+            float: String,
+        }
+
+        #[test]
+        fn elements() {
+            let data: Struct = from_str(
+                r#"<root><float>42</float><string>answer</string></root>"#
+            ).unwrap();
+            assert_eq!(data, Struct {
+                nested: Nested { float: "42".into() },
+                string: "answer".into()
+            });
+        }
+
+        #[test]
+        fn attributes() {
+            let data: Struct = from_str(
+                r#"<root float="42" string="answer"/>"#
+            ).unwrap();
+            assert_eq!(data, Struct {
+                nested: Nested { float: "42".into() },
+                string: "answer".into()
+            });
+        }
+    }
+
+    mod enum_ {
+        use super::*;
+
+        mod externally_tagged {
+            use super::*;
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum Node {
+                Unit,
+                Newtype(bool),
+                //TODO: serde bug https://github.com/serde-rs/serde/issues/1904
+                // Tuple(f64, String),
+                Struct { float: f64, string: String },
+                Holder { nested: Nested, string: String },
+                Flatten {
+                    #[serde(flatten)]
+                    nested: Nested,
+                    string: String
+                },
+            }
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct Nested {
+                //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
+                float: String,
+            }
+
+            /// Workaround for serde bug https://github.com/serde-rs/serde/issues/1904
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum Workaround {
+                Tuple(f64, String),
+            }
+
+            #[test]
+            fn unit() {
+                let data: Node = from_str("<Unit/>").unwrap();
+                assert_eq!(data, Node::Unit);
+            }
+
+            #[test]
+            fn newtype() {
+                let data: Node = from_str(
+                    "<Newtype>true</Newtype>"
+                ).unwrap();
+                assert_eq!(data, Node::Newtype(true));
+            }
+
+            #[test]
+            fn tuple_struct() {
+                let data: Workaround = from_str(
+                    "<Tuple>42</Tuple><Tuple>answer</Tuple>"
+                ).unwrap();
+                assert_eq!(data, Workaround::Tuple(42.0, "answer".into()));
+            }
+
+            mod struct_ {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<Struct><float>42</float><string>answer</string></Struct>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: 42.0,
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<Struct float="42" string="answer"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: 42.0,
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod nested_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<Holder><string>answer</string><nested><float>42</float></nested></Holder>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<Holder string="answer"><nested float="42"/></Holder>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod flatten_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<Flatten><float>42</float><string>answer</string></Flatten>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<Flatten float="42" string="answer"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+            }
+        }
+
+        mod internally_tagged {
+            use super::*;
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            #[serde(tag = "tag")]
+            enum Node {
+                Unit,
+                /// Primitives (such as `bool`) are not supported by serde in the internally tagged mode
+                Newtype(NewtypeContent),
+                // Tuple(f64, String),// Tuples are not supported in the internally tagged mode
+                //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
+                Struct { float: String, string: String },
+                Holder { nested: Nested, string: String },
+                Flatten {
+                    #[serde(flatten)]
+                    nested: Nested,
+                    string: String
+                },
+            }
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct NewtypeContent {
+                value: bool,
+            }
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct Nested {
+                //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
+                float: String,
+            }
+
+            mod unit {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Unit</tag></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Unit);
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Unit"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Unit);
+                }
+            }
+
+            mod newtype {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Newtype</tag><value>true</value></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Newtype(NewtypeContent { value: true }));
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Newtype" value="true"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Newtype(NewtypeContent { value: true }));
+                }
+            }
+
+            mod struct_ {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Struct</tag><float>42</float><string>answer</string></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: "42".into(),
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Struct" float="42" string="answer"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: "42".into(),
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod nested_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Holder</tag><string>answer</string><nested><float>42</float></nested></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Holder" string="answer"><nested float="42"/></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod flatten_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Flatten</tag><float>42</float><string>answer</string></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Flatten" float="42" string="answer"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+            }
+        }
+
+        mod adjacently_tagged {
+            use super::*;
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            #[serde(tag = "tag", content = "content")]
+            enum Node {
+                Unit,
+                Newtype(bool),
+                //TODO: serde bug https://github.com/serde-rs/serde/issues/1904
+                // Tuple(f64, String),
+                Struct { float: f64, string: String },
+                Holder { nested: Nested, string: String },
+                Flatten {
+                    #[serde(flatten)]
+                    nested: Nested,
+                    string: String
+                },
+            }
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct Nested {
+                //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
+                float: String,
+            }
+
+            /// Workaround for serde bug https://github.com/serde-rs/serde/issues/1904
+            #[derive(Debug, Deserialize, PartialEq)]
+            #[serde(tag = "tag", content = "content")]
+            enum Workaround {
+                Tuple(f64, String),
+            }
+
+            mod unit {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Unit</tag></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Unit);
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Unit"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Unit);
+                }
+            }
+
+            mod newtype {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Newtype</tag><content>true</content></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Newtype(true));
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Newtype" content="true"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Newtype(true));
+                }
+            }
+
+            mod tuple_struct {
+                use super::*;
+                #[test]
+                fn elements() {
+                    let data: Workaround = from_str(
+                        r#"<root><tag>Tuple</tag><content>42</content><content>answer</content></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Workaround::Tuple(42.0, "answer".into()));
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Workaround = from_str(
+                        r#"<root tag="Tuple" content="42"><content>answer</content></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Workaround::Tuple(42.0, "answer".into()));
+                }
+            }
+
+            mod struct_ {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Struct</tag><content><float>42</float><string>answer</string></content></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: 42.0,
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Struct"><content float="42" string="answer"/></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: 42.0,
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod nested_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root>
+                            <tag>Holder</tag>
+                            <content>
+                                <string>answer</string>
+                                <nested>
+                                    <float>42</float>
+                                </nested>
+                            </content>
+                        </root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Holder"><content string="answer"><nested float="42"/></content></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod flatten_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><tag>Flatten</tag><content><float>42</float><string>answer</string></content></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root tag="Flatten"><content float="42" string="answer"/></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+            }
+        }
+
+        mod untagged {
+            use super::*;
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            #[serde(untagged)]
+            enum Node {
+                Unit,
+                Newtype(bool),
+                // serde bug https://github.com/serde-rs/serde/issues/1904
+                // Tuple(f64, String),
+                Struct { float: f64, string: String },
+                Holder { nested: Nested, string: String },
+                Flatten {
+                    #[serde(flatten)]
+                    nested: Nested,
+                    // Can't use "string" as name because in that case this variant
+                    // will have no difference from `Struct` variant
+                    string2: String,
+                },
+            }
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct Nested {
+                //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
+                float: String,
+            }
+
+            /// Workaround for serde bug https://github.com/serde-rs/serde/issues/1904
+            #[derive(Debug, Deserialize, PartialEq)]
+            #[serde(untagged)]
+            enum Workaround {
+                Tuple(f64, String),
+            }
+
+            #[test]
+            fn unit() {
+                // Unit variant consists just from the tag, and because tags
+                // are not written, nothing is written
+                let data: Node = from_str("").unwrap();
+                assert_eq!(data, Node::Unit);
+            }
+
+            #[test]
+            fn newtype() {
+                let data: Node = from_str("true").unwrap();
+                assert_eq!(data, Node::Newtype(true));
+            }
+
+            #[test]
+            fn tuple_struct() {
+                let data: Workaround = from_str(
+                    "<root>42</root><root>answer</root>"
+                ).unwrap();
+                assert_eq!(data, Workaround::Tuple(42.0, "answer".into()));
+            }
+
+            mod struct_ {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><float>42</float><string>answer</string></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: 42.0,
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root float="42" string="answer"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Struct {
+                        float: 42.0,
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod nested_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><string>answer</string><nested><float>42</float></nested></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root string="answer"><nested float="42"/></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Holder {
+                        nested: Nested { float: "42".into() },
+                        string: "answer".into()
+                    });
+                }
+            }
+
+            mod flatten_struct {
+                use super::*;
+
+                #[test]
+                fn elements() {
+                    let data: Node = from_str(
+                        r#"<root><float>42</float><string2>answer</string2></root>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string2: "answer".into()
+                    });
+                }
+
+                #[test]
+                fn attributes() {
+                    let data: Node = from_str(
+                        r#"<root float="42" string2="answer"/>"#
+                    ).unwrap();
+                    assert_eq!(data, Node::Flatten {
+                        nested: Nested { float: "42".into() },
+                        string2: "answer".into()
+                    });
+                }
+            }
+        }
+    }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -92,6 +92,39 @@ impl<'a> BytesStart<'a> {
         Self::owned(self.buf.to_owned(), self.name_len)
     }
 
+    /// Converts the event into a borrowed event. Most useful when paired with [`to_end`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use quick_xml::{Error, Writer};
+    /// use quick_xml::events::{BytesStart, Event};
+    ///
+    /// struct SomeStruct<'a> {
+    ///     attrs: BytesStart<'a>,
+    ///     // ...
+    /// }
+    /// # impl<'a> SomeStruct<'a> {
+    /// # fn example(&self) -> Result<(), Error> {
+    /// # let mut writer = Writer::new(Vec::new());
+    ///
+    /// writer.write_event(Event::Start(self.attrs.to_borrowed()))?;
+    /// // ...
+    /// writer.write_event(Event::End(self.attrs.to_end()))?;
+    /// # Ok(())
+    /// # }}
+    /// ```
+    ///
+    /// [`to_end`]: #method.to_end
+    pub fn to_borrowed(&self) -> BytesStart {
+        BytesStart::borrowed(&self.buf, self.name_len)
+    }
+
+    /// Creates new paired close tag
+    pub fn to_end(&self) -> BytesEnd {
+        BytesEnd::borrowed(self.name())
+    }
+
     /// Consumes `self` and yield a new `BytesStart` with additional attributes from an iterator.
     ///
     /// The yielded items must be convertible to [`Attribute`] using `Into`.

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -237,7 +237,7 @@ impl<'w, W: Write> ser::Serializer for &'w mut Serializer<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::ser::{SerializeMap, SerializeStruct};
+    use serde::ser::SerializeMap;
     use serde::{Serialize, Serializer as SerSerializer};
 
     #[test]
@@ -255,23 +255,6 @@ mod tests {
             let got = String::from_utf8(buffer).unwrap();
             assert_eq!(got, should_be);
         }
-    }
-
-    #[test]
-    fn test_serialize_struct_field() {
-        let mut buffer = Vec::new();
-
-        {
-            let mut ser = Serializer::new(&mut buffer);
-            let mut struct_ser = Struct::new(&mut ser, "baz");
-            struct_ser.serialize_field("foo", "bar").unwrap();
-            let attrs = std::str::from_utf8(&struct_ser.attrs).unwrap();
-            assert_eq!(attrs, "baz foo=\"bar\"");
-            let _ = struct_ser.end().unwrap();
-        }
-
-        let got = String::from_utf8(buffer).unwrap();
-        assert_eq!(got, "<baz foo=\"bar\"/>");
     }
 
     #[test]

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -220,8 +220,6 @@ impl<'w, W: Write> ser::Serializer for &'w mut Serializer<W> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, DeError> {
-        write!(self.writer.inner(), "<{}", name)
-            .map_err(|err| DeError::Custom(format!("serialize struct {} failed: {}", name, err)))?;
         Ok(Struct::new(self, name))
     }
 
@@ -260,19 +258,6 @@ mod tests {
     }
 
     #[test]
-    fn test_start_serialize_struct() {
-        let mut buffer = Vec::new();
-
-        {
-            let mut ser = Serializer::new(&mut buffer);
-            let _ = ser.serialize_struct("foo", 0).unwrap();
-        }
-
-        let got = String::from_utf8(buffer).unwrap();
-        assert_eq!(got, "<foo");
-    }
-
-    #[test]
     fn test_serialize_struct_field() {
         let mut buffer = Vec::new();
 
@@ -281,12 +266,12 @@ mod tests {
             let mut struct_ser = Struct::new(&mut ser, "baz");
             struct_ser.serialize_field("foo", "bar").unwrap();
             let attrs = std::str::from_utf8(&struct_ser.attrs).unwrap();
-            assert_eq!(attrs, " foo=\"bar\"");
+            assert_eq!(attrs, "baz foo=\"bar\"");
             let _ = struct_ser.end().unwrap();
         }
 
         let got = String::from_utf8(buffer).unwrap();
-        assert_eq!(got, " foo=\"bar\"></baz>");
+        assert_eq!(got, "<baz foo=\"bar\"/>");
     }
 
     #[test]
@@ -301,7 +286,7 @@ mod tests {
             name: "Bob".to_string(),
             age: 42,
         };
-        let should_be = "<Person name=\"Bob\" age=\"42\"></Person>";
+        let should_be = "<Person name=\"Bob\" age=\"42\"/>";
         let mut buffer = Vec::new();
 
         {

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -7,24 +7,24 @@ use serde::ser::{self, Serialize};
 use std::io::Write;
 
 /// An implementation of `SerializeMap` for serializing to XML.
-pub struct Map<'w, W>
+pub struct Map<'r, 'w, W>
 where
     W: 'w + Write,
 {
-    parent: &'w mut Serializer<W>,
+    parent: &'w mut Serializer<'r, W>,
 }
 
-impl<'w, W> Map<'w, W>
+impl<'r, 'w, W> Map<'r, 'w, W>
 where
     W: 'w + Write,
 {
     /// Create a new Map
-    pub fn new(parent: &'w mut Serializer<W>) -> Map<'w, W> {
+    pub fn new(parent: &'w mut Serializer<'r, W>) -> Self {
         Map { parent }
     }
 }
 
-impl<'w, W> ser::SerializeMap for Map<'w, W>
+impl<'r, 'w, W> ser::SerializeMap for Map<'r, 'w, W>
 where
     W: 'w + Write,
 {
@@ -66,11 +66,11 @@ where
 }
 
 /// An implementation of `SerializeStruct` for serializing to XML.
-pub struct Struct<'w, W>
+pub struct Struct<'r, 'w, W>
 where
     W: 'w + Write,
 {
-    parent: &'w mut Serializer<W>,
+    parent: &'w mut Serializer<'r, W>,
     /// Buffer for holding fields, serialized as attributes. Doesn't allocate
     /// if there are no fields represented as attributes
     attrs: BytesStart<'w>,
@@ -80,12 +80,12 @@ where
     buffer: Vec<u8>,
 }
 
-impl<'w, W> Struct<'w, W>
+impl<'r, 'w, W> Struct<'r, 'w, W>
 where
     W: 'w + Write,
 {
     /// Create a new `Struct`
-    pub fn new(parent: &'w mut Serializer<W>, name: &'w str) -> Struct<'w, W> {
+    pub fn new(parent: &'w mut Serializer<'r, W>, name: &'r str) -> Self {
         let name = name.as_bytes();
         Struct {
             parent,
@@ -96,7 +96,7 @@ where
     }
 }
 
-impl<'w, W> ser::SerializeStruct for Struct<'w, W>
+impl<'r, 'w, W> ser::SerializeStruct for Struct<'r, 'w, W>
 where
     W: 'w + Write,
 {
@@ -139,24 +139,24 @@ where
 }
 
 /// An implementation of `SerializeSeq' for serializing to XML.
-pub struct Seq<'w, W>
+pub struct Seq<'r, 'w, W>
 where
     W: 'w + Write,
 {
-    parent: &'w mut Serializer<W>,
+    parent: &'w mut Serializer<'r, W>,
 }
 
-impl<'w, W> Seq<'w, W>
+impl<'r, 'w, W> Seq<'r, 'w, W>
 where
     W: 'w + Write,
 {
     /// Create a new `Seq`
-    pub fn new(parent: &'w mut Serializer<W>) -> Seq<'w, W> {
+    pub fn new(parent: &'w mut Serializer<'r, W>) -> Self {
         Seq { parent }
     }
 }
 
-impl<'w, W> ser::SerializeSeq for Seq<'w, W>
+impl<'r, 'w, W> ser::SerializeSeq for Seq<'r, 'w, W>
 where
     W: 'w + Write,
 {

--- a/tests/serde_attrs.rs
+++ b/tests/serde_attrs.rs
@@ -12,13 +12,18 @@ use std::borrow::Cow;
 #[derive(Serialize)]
 #[serde(rename = "classroom")]
 struct Classroom {
-    pub students: Vec<Person>,
+    pub students: Students,
     pub number: String,
     pub adviser: Person,
 }
 
 #[derive(Serialize)]
-#[serde(rename = "person")]
+struct Students {
+    #[serde(rename = "person")]
+    pub persons: Vec<Person>,
+}
+
+#[derive(Serialize)]
 struct Person {
     pub name: String,
     pub age: u32,
@@ -43,7 +48,7 @@ fn test_nested() {
         age: 88,
     };
     let doc = Classroom {
-        students: vec![s1, s2],
+        students: Students { persons: vec![s1, s2] },
         number: "3-1".to_string(),
         adviser: t,
     };
@@ -54,9 +59,7 @@ fn test_nested() {
                       <person name="sherlock" age="20"/>
                       <person name="harry" age="19"/>
                    </students>
-                   <adviser>
-                     <person name="albus" age="88"/>
-                   </adviser>
+                   <adviser name="albus" age="88"/>
                  </classroom>"#;
     assert_eq!(xml, inline(str));
 }

--- a/tests/serde_attrs.rs
+++ b/tests/serde_attrs.rs
@@ -51,11 +51,11 @@ fn test_nested() {
 
     let str = r#"<classroom number="3-1">
                    <students>
-                      <person name="sherlock" age="20"></person>
-                      <person name="harry" age="19"></person>
+                      <person name="sherlock" age="20"/>
+                      <person name="harry" age="19"/>
                    </students>
                    <adviser>
-                     <person name="albus" age="88"></person>
+                     <person name="albus" age="88"/>
                    </adviser>
                  </classroom>"#;
     assert_eq!(xml, inline(str));
@@ -70,5 +70,5 @@ fn inline(str: &str) -> Cow<str> {
 fn test_empty() {
     let e = Empty {};
     let xml = to_string(&e).unwrap();
-    assert_eq!(xml, "<empty></empty>");
+    assert_eq!(xml, "<empty/>");
 }

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -37,7 +37,7 @@ fn basic_struct() {
     assert_eq!(item, should_be);
 
     let reserialized_item = to_string(&item).unwrap();
-    let src = "<Item name=\"Banana\" source=\"Store\"></Item>";
+    let src = "<Item name=\"Banana\" source=\"Store\"/>";
     assert_eq!(src, reserialized_item);
 }
 


### PR DESCRIPTION
# Summary
- test: Add tests for indentation
- test: Add complete tests for serde deserialization
- feat: Use self-closed tags when serialize types without nested elements with serde
- feat: Add two new API to the `BytesStart`: `to_borrowed()` and `to_end()`
- feat: Add ability to specify name of the root tag and indentation settings when
  serialize type with serde
- feat: Add support for serialization of
  - unit enum variants
  - newtype structs and enum variants
  - unnamed tuples, tuple structs and enum variants
- fix: More consistent structs serialization
- fix: Deserialization of newtype structs
- fix: `unit` deserialization and newtype and struct deserialization in adjacently tagged enums

# Affected issues
- Fixes #181
- Fixes #204
- Fixes #225 (duplicate of previous)

# Breaking changes in serialization
Most notable change -- serialization of embedded structs:
```rust
struct Inner {
  inner: String,
}
struct Outer {
  outer: Inner,
  vec: Vec<Inner>,
}
```
Before PR changes struct `Outer` serialized as:
```xml
<Outer>
  <outer>
    <Inner inner="..."></inner>
  </outer>

  <vec>
    <Inner inner="..."></inner>
  </vec>
  <vec>
    <Inner inner="..."></inner>
  </vec>
</Outer>
```
This is counterintuitive, uncomposable and can't be deserialized back into the same struct. After changes resulting XML is:

```xml
<!--
  For backward compatibility and for usable reasons name of the top-level
  tag can be inferred from the struct/enum name. Of course, this will not
  work for primitive types - in that case you required to specify name when
  creating serializer, using Serializer::with_root
-->
<Outer>
  <!-- Name of Inner struct not used anymore in the XML -->
  <outer inner="..."/>

  <!-- Tags are self-closed when possible -->
  <vec inner="..."/>
  <vec inner="..."/>
</Outer>
```

# Examples of serialization

Following rust types is serialized:
```rust
struct Unit;
struct Newtype(bool);
struct Tuple(String, u32);
struct Struct {
  question: String,
  answer: u32,
}
enum Node {
  Unit,
  Newtype(bool),
  Tuple(String, u32),
  Struct {
    question: String,
    answer: u32,
  },
}
```
`root` in examples means `root_tag` parameter from `Serialize::with_root`. When struct serialized as field of another struct, that is field name. When struct serialized as part of externally tagged enum newtype, that is variant name.

Ordinal tuples, newtypes and structs serialized in the same manner, as externally tagged enums, but instead of variant name `root_tag` name of serializer is used. If serializer was created without `root_name`, then name of newtype/named tuple/struct is used for top-level elements.

Examples:

## `Unit` / `Node::Unit`
```xml
<!-- (), None, unit structs -->
<root/>

<!-- externally tagged -->
<Unit/>
<!-- internally tagged -->
<root tag="Unit"/>
<!-- adjacently tagged -->
<root tag="Unit"/>
<!-- untagged -->
<!-- (empty) -->
```

## `Newtype(true)` / `Node::Newtype(true)`
```xml
<!-- Any newtype -->
<root>true</root>

<!-- externally tagged -->
<Newtype>true</Newtype>
<!-- internally tagged: required Serializer::with_root -->
<root tag="Newtype">true</root>
<!-- adjacently tagged -->
<root tag="Newtype" content="true"/>
<!-- untagged -->
true
```

## `Tuple("...", 42)` / `Node::Tuple("...", 42)`
```xml
<!-- named and unnamed tuples -->
<root>...</root>
<root>42</root>

<!-- externally tagged -->
<Tuple>...</Tuple>
<Tuple>42</Tuple>
<!-- internally tagged: unsupported in serde model -->
<!-- adjacently tagged -->
<root tag="Tuple">
  <content>...</content>
  <content>42</content>
</root>
<!-- untagged -->
<root>...</root>
<root>42</root>
```

## `String { question: "...", answer: 42 }` / `Node::String { question: "...", answer: 42 }`
```xml
<!-- struct -->
<root question="..." answer="42"/>

<!-- externally tagged -->
<Struct question="..." answer="42"/>
<!-- internally tagged -->
<root tag="Struct" question="..." answer="42"/>
<!-- adjacently tagged -->
<root tag="Struct">
  <content question="..." answer="42"/>
</root>
<!-- untagged -->
<root question="..." answer="42"/>
```
