### PR TITLE
Parse & in cdata correctly

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -371,7 +371,7 @@ impl<B: BufRead> Reader<B> {
                             Err(e) => return Err(e),
                         }
                     }
-                    Ok(Event::CData(BytesText::from_escaped(
+                    Ok(Event::CData(BytesText::from_plain(
                         &buf[buf_start + 8..buf.len() - 2],
                     )))
                 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -183,7 +183,7 @@ fn test_cdata() {
 fn test_cdata_open_close() {
     let mut r = Reader::from_str("<![CDATA[test <> test]]>");
     r.trim_text(true);
-    next_eq!(r, CData, b"test <> test");
+    next_eq!(r, CData, b"test &lt;&gt; test");
 }
 
 #[test]


### PR DESCRIPTION
The BytesText buffer should always contain escaped string, so escape
anything in cdata, rather than assume it is already escaped.

This should fix #184 

Signed-off-by: Sean Young <sean@mess.org>