### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "High performance xml reader and writer"
 documentation = "https://docs.rs/quick-xml"
 repository = "https://github.com/tafia/quick-xml"
 
-readme = "README.md"
 keywords = ["xml", "reader", "parser", "writer", "html"]
 categories = ["encoding", "parsing", "text-processing"]
 license = "MIT"


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).
