### PR TITLE
README.md: Replace dead benchmark link

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ test bench_serde_quick_xml      ... bench:   1,181,198 ns/iter (+/- 138,290)
 test bench_serde_xml_rs         ... bench:  15,039,564 ns/iter (+/- 783,485)
 ```
 
-For a feature and performance comparison, you can also have a look at RazrFalcon's [choose-your-xml-rs](https://github.com/RazrFalcon/choose-your-xml-rs).
+For a feature and performance comparison, you can also have a look at RazrFalcon's [parser comparison table](https://github.com/RazrFalcon/roxmltree#parsing).
 
 ## Contribute
 


### PR DESCRIPTION
Replace the benchmark link, which is now dead, with the new location of roughly the same table (by the same author).