### PR TITLE
serialize a key as <key/> instead of aborting as an error

### DIFF
--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -33,12 +33,14 @@ where
     type Error = DeError;
 
     fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), DeError> {
-        // Err(DeError::Unsupported(
-        //    "impossible to serialize the key on its own, please use serialize_entry()",
-        //))
-        write!(self.parent.writer.inner(), "<").map_err(Error::Io)?;
+        /*
+        Err(DeError::Unsupported(
+            "impossible to serialize the key on its own, please use serialize_entry()",
+        ))
+        */
+        write!(self.parent.writer.inner(), "<enum key=\"").map_err(Error::Io)?;
         key.serialize(&mut *self.parent)?;
-        write!(self.parent.writer.inner(), "/>").map_err(Error::Io)?;
+        write!(self.parent.writer.inner(), "\"/>").map_err(Error::Io)?;
         Ok(())
     }
 

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -32,10 +32,14 @@ where
     type Ok = ();
     type Error = DeError;
 
-    fn serialize_key<T: ?Sized + Serialize>(&mut self, _: &T) -> Result<(), DeError> {
-        Err(DeError::Unsupported(
-            "impossible to serialize the key on its own, please use serialize_entry()",
-        ))
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), DeError> {
+        // Err(DeError::Unsupported(
+        //    "impossible to serialize the key on its own, please use serialize_entry()",
+        //))
+        write!(self.parent.writer.inner(), "<").map_err(Error::Io)?;
+        key.serialize(&mut *self.parent)?;
+        write!(self.parent.writer.inner(), "/>").map_err(Error::Io)?;
+        Ok(())
     }
 
     fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), DeError> {


### PR DESCRIPTION
I work on Huawei's Trusted Programming Language project, which was recently asked to convert Rust source code files into XML format. We believe that quick-xml can help for this purpose. However, it turns out that saving key-only is considered Unsupported and the serializer aborts the execution. Hence, I've completed a working prototype for handle this special case.

If someone with more experience developing in `quick-xml` can give this an early look and send feedback, that would be really helpful. Apologies in advance for the current lack of tests and limited documentation. I'll be working on this full time for a while, so it will improve rapidly.

Thanks!