### PR TITLE
add `*_with_custom_entities` versions of all `unescape_*\ methods

### DIFF
--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -1,0 +1,71 @@
+//! This example demonstrate how custom entities can be extracted from the DOCTYPE!,
+//! and later use to decode text and attribute values.
+//!
+//! NB: this example is deliberately kept simple:
+//! * it only handles internal entities;
+//! * the regex in this example is simple but brittle;
+//! * it does not support the use of entities in entity declaration.
+
+extern crate quick_xml;
+extern crate regex;
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use regex::bytes::Regex;
+use std::collections::HashMap;
+
+const DATA: &str = r#"
+
+    <?xml version="1.0"?>
+    <!DOCTYPE test [
+    <!ENTITY msg "hello world" >
+    ]>
+    <test label="&msg;">&msg;</test>
+
+"#;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut reader = Reader::from_str(DATA);
+    reader.trim_text(true);
+
+    let mut buf = Vec::new();
+    let mut custom_entities = HashMap::new();
+    let entity_re =
+        Regex::new(r#"<!ENTITY\s+([^ \t\r\n]+)\s+"([^"]*)"\s*>"#)?;
+
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(Event::DocType(ref e)) => {
+                for cap in entity_re.captures_iter(&e) {
+                    custom_entities.insert(cap[1].to_vec(), cap[2].to_vec());
+                }
+            }
+            Ok(Event::Start(ref e)) => match e.name() {
+                b"test" => println!(
+                    "attributes values: {:?}",
+                    e.attributes()
+                        .map(|a| a
+                            .unwrap()
+                            .unescape_and_decode_value_with_custom_entities(
+                                &reader,
+                                &custom_entities
+                            )
+                            .unwrap())
+                        .collect::<Vec<_>>()
+                ),
+                _ => (),
+            },
+            Ok(Event::Text(ref e)) => {
+                println!(
+                    "text value: {}",
+                    e.unescape_and_decode_with_custom_entities(&reader, &custom_entities)
+                        .unwrap()
+                );
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            _ => (),
+        }
+    }
+    Ok(())
+}

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -2,6 +2,7 @@
 //! and later use to decode text and attribute values.
 //!
 //! NB: this example is deliberately kept simple:
+//! * it assumes that the XML file is UTF-8 encoded (custom_entities must only contain UTF-8 data)
 //! * it only handles internal entities;
 //! * the regex in this example is simple but brittle;
 //! * it does not support the use of entities in entity declaration.
@@ -30,8 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut buf = Vec::new();
     let mut custom_entities = HashMap::new();
-    let entity_re =
-        Regex::new(r#"<!ENTITY\s+([^ \t\r\n]+)\s+"([^"]*)"\s*>"#)?;
+    let entity_re = Regex::new(r#"<!ENTITY\s+([^ \t\r\n]+)\s+"([^"]*)"\s*>"#)?;
 
     loop {
         match reader.read_event(&mut buf) {

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -147,7 +147,7 @@ fn do_unescape_with<'a>(
                     b"amp" => unescaped.push(b'&'),
                     b"apos" => unescaped.push(b'\''),
                     b"quot" => unescaped.push(b'\"'),
-                    bytes if bytes[0] == b'#' => {
+                    bytes if bytes.starts_with(b"#") => {
                         let bytes = &bytes[1..];
                         let code = if bytes.starts_with(b"x") {
                             parse_hexadecimal(&bytes[1..])
@@ -5556,7 +5556,7 @@ fn do_unescape_with<'a>(
                         unescaped.push(b'\x1D');
                         unescaped.push(b'\x56');
                     }
-                    bytes if bytes[0] == b'#' => {
+                    bytes if bytes.starts_with(b"#") => {
                         let bytes = &bytes[1..];
                         let code = if bytes.starts_with(b"x") {
                             parse_hexadecimal(&bytes[1..])

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -2,6 +2,7 @@
 
 use memchr;
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub enum EscapeError {
@@ -107,6 +108,24 @@ pub fn escape(raw: &[u8]) -> Cow<[u8]> {
 /// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
 /// value
 pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
+    do_unescape_with(raw, None)
+}
+
+/// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
+/// value, using a dictionnary of custom entities.
+pub fn unescape_with<'a>(
+    raw: &'a [u8],
+    custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
+) -> Result<Cow<'a, [u8]>, EscapeError> {
+    do_unescape_with(raw, Some(custom_entities))
+}
+
+/// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
+/// value, using an optional dictionnary of custom entities.
+fn do_unescape_with<'a>(
+    raw: &'a [u8],
+    custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
+) -> Result<Cow<'a, [u8]>, EscapeError> {
     let mut unescaped = None;
     let mut last_end = 0;
     let mut iter = memchr::memchr2_iter(b'&', b';', raw);
@@ -128,22 +147,27 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
                     b"amp" => unescaped.push(b'&'),
                     b"apos" => unescaped.push(b'\''),
                     b"quot" => unescaped.push(b'\"'),
-                    bytes => {
-                        let code = if bytes.starts_with(b"#x") {
-                            parse_hexadecimal(&bytes[2..])
-                        } else if bytes.starts_with(b"#") {
-                            parse_decimal(&bytes[1..])
+                    bytes if bytes[0] == b'#' => {
+                        let bytes = &bytes[1..];
+                        let code = if bytes.starts_with(b"x") {
+                            parse_hexadecimal(&bytes[1..])
                         } else {
-                            Err(EscapeError::UnrecognizedSymbol(
-                                start + 1..end,
-                                String::from_utf8(bytes.to_vec()),
-                            ))
+                            parse_decimal(&bytes)
                         }?;
                         if code == 0 {
                             return Err(EscapeError::EntityWithNull(start..end));
                         }
                         push_utf8(unescaped, code);
                     }
+                    bytes => match custom_entities.and_then(|hm| hm.get(bytes)) {
+                        Some(value) => unescaped.extend_from_slice(&value),
+                        None => {
+                            return Err(EscapeError::UnrecognizedSymbol(
+                                start + 1..end,
+                                String::from_utf8(bytes.to_vec()),
+                            ))
+                        }
+                    },
                 }
 
                 #[cfg(feature = "escape-html")]
@@ -5532,22 +5556,27 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
                         unescaped.push(b'\x1D');
                         unescaped.push(b'\x56');
                     }
-                    bytes => {
-                        let code = if bytes.starts_with(b"#x") {
-                            parse_hexadecimal(&bytes[2..])
-                        } else if bytes.starts_with(b"#") {
-                            parse_decimal(&bytes[1..])
+                    bytes if bytes[0] == b'#' => {
+                        let bytes = &bytes[1..];
+                        let code = if bytes.starts_with(b"x") {
+                            parse_hexadecimal(&bytes[1..])
                         } else {
-                            Err(EscapeError::UnrecognizedSymbol(
-                                start + 1..end,
-                                String::from_utf8(bytes.to_vec()),
-                            ))
+                            parse_decimal(&bytes)
                         }?;
                         if code == 0 {
                             return Err(EscapeError::EntityWithNull(start..end));
                         }
                         push_utf8(unescaped, code);
                     }
+                    bytes => match custom_entities.and_then(|hm| hm.get(bytes)) {
+                        Some(value) => unescaped.extend_from_slice(&value),
+                        None => {
+                            return Err(EscapeError::UnrecognizedSymbol(
+                                start + 1..end,
+                                String::from_utf8(bytes.to_vec()),
+                            ))
+                        }
+                    },
                 }
                 last_end = end + 1;
             }
@@ -5623,6 +5652,23 @@ fn test_unescape() {
     assert_eq!(&*unescape(b"&lt;test&gt;").unwrap(), b"<test>");
     assert_eq!(&*unescape(b"&#x30;").unwrap(), b"0");
     assert_eq!(&*unescape(b"&#48;").unwrap(), b"0");
+    assert!(unescape(b"&foo;").is_err());
+}
+
+#[test]
+fn test_unescape_with() {
+    let custom_entities = vec![(b"foo".to_vec(), b"BAR".to_vec())]
+        .into_iter()
+        .collect();
+    assert_eq!(&*unescape_with(b"test", &custom_entities).unwrap(), b"test");
+    assert_eq!(
+        &*unescape_with(b"&lt;test&gt;", &custom_entities).unwrap(),
+        b"<test>"
+    );
+    assert_eq!(&*unescape_with(b"&#x30;", &custom_entities).unwrap(), b"0");
+    assert_eq!(&*unescape_with(b"&#48;", &custom_entities).unwrap(), b"0");
+    assert_eq!(&*unescape_with(b"&foo;", &custom_entities).unwrap(), b"BAR");
+    assert!(unescape_with(b"&fop;", &custom_entities).is_err());
 }
 
 #[test]

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -113,6 +113,10 @@ pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
 
 /// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
 /// value, using a dictionnary of custom entities.
+///
+/// # Pre-condition
+///
+/// The keys and values of `custom_entities`, if any, must be valid UTF-8.
 pub fn unescape_with<'a>(
     raw: &'a [u8],
     custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
@@ -122,7 +126,11 @@ pub fn unescape_with<'a>(
 
 /// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
 /// value, using an optional dictionnary of custom entities.
-fn do_unescape_with<'a>(
+///
+/// # Pre-condition
+///
+/// The keys and values of `custom_entities`, if any, must be valid UTF-8.
+pub(crate) fn do_unescape_with<'a>(
     raw: &'a [u8],
     custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
 ) -> Result<Cow<'a, [u8]>, EscapeError> {

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -108,7 +108,7 @@ pub fn escape(raw: &[u8]) -> Cow<[u8]> {
 /// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
 /// value
 pub fn unescape(raw: &[u8]) -> Result<Cow<[u8]>, EscapeError> {
-    do_unescape_with(raw, None)
+    do_unescape(raw, None)
 }
 
 /// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
@@ -121,7 +121,7 @@ pub fn unescape_with<'a>(
     raw: &'a [u8],
     custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
 ) -> Result<Cow<'a, [u8]>, EscapeError> {
-    do_unescape_with(raw, Some(custom_entities))
+    do_unescape(raw, Some(custom_entities))
 }
 
 /// Unescape a `&[u8]` and replaces all xml escaped characters ('&...;') into their corresponding
@@ -130,7 +130,7 @@ pub fn unescape_with<'a>(
 /// # Pre-condition
 ///
 /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
-pub(crate) fn do_unescape_with<'a>(
+pub fn do_unescape<'a>(
     raw: &'a [u8],
     custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
 ) -> Result<Cow<'a, [u8]>, EscapeError> {

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -108,6 +108,10 @@ impl<'a> Attribute<'a> {
     /// This will allocate if the value contains any escape sequences.
     ///
     /// See also [`unescaped_value()`](#method.unescaped_value)
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     pub fn unescaped_value_with_custom_entities(
         &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
@@ -159,6 +163,10 @@ impl<'a> Attribute<'a> {
     ///
     /// [`unescaped_value_with_custom_entities()`]: #method.unescaped_value
     /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(feature = "encoding")]
     pub fn unescape_and_decode_value_with_custom_entities<B: BufRead>(
         &self,
@@ -181,6 +189,10 @@ impl<'a> Attribute<'a> {
     ///
     /// [`unescaped_value_with_custom_entities()`]: #method.unescaped_value_with_custom_entities
     /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(not(feature = "encoding"))]
     pub fn unescape_and_decode_value_with_custom_entities<B: BufRead>(
         &self,
@@ -234,6 +246,10 @@ impl<'a> Attribute<'a> {
     /// it might be wiser to manually use
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(feature = "encoding")]
     pub fn unescape_and_decode_without_bom_with_custom_entities<B: BufRead>(
         &self,
@@ -253,6 +269,10 @@ impl<'a> Attribute<'a> {
     /// it might be wiser to manually use
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(not(feature = "encoding"))]
     pub fn unescape_and_decode_without_bom_with_custom_entities<B: BufRead>(
         &self,

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -3,7 +3,7 @@
 //! Provides an iterator over attributes key/value pairs
 
 use errors::{Error, Result};
-use escape::{escape, unescape, unescape_with};
+use escape::{do_unescape, escape};
 use reader::{is_whitespace, Reader};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -96,7 +96,7 @@ impl<'a> Attribute<'a> {
     ///
     /// See also [`unescaped_value_with_custom_entities()`](#method.unescaped_value_with_custom_entities)
     pub fn unescaped_value(&self) -> Result<Cow<[u8]>> {
-        unescape(&*self.value).map_err(Error::EscapeError)
+        self.make_unescaped_value(None)
     }
 
     /// Returns the unescaped value, using custom entities.
@@ -116,67 +116,28 @@ impl<'a> Attribute<'a> {
         &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<Cow<[u8]>> {
-        unescape_with(&*self.value, custom_entities).map_err(Error::EscapeError)
+        self.make_unescaped_value(Some(custom_entities))
     }
 
-    /// Decode then unescapes the value
-    ///
-    /// This allocates a `String` in all cases. For performance reasons it might be a better idea to
-    /// instead use one of:
-    ///
-    /// * [`Reader::decode()`], as it only allocates when the decoding can't be performed otherwise.
-    /// * [`unescaped_value()`], as it doesn't allocate when no escape sequences are used.
-    ///
-    /// [`unescaped_value()`]: #method.unescaped_value
-    /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
-    #[cfg(feature = "encoding")]
-    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
-        let decoded = reader.decode(&*self.value);
-        let unescaped = unescape(decoded.as_bytes()).map_err(Error::EscapeError)?;
-        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
-    }
-
-    /// Decode then unescapes the value
-    ///
-    /// This allocates a `String` in all cases. For performance reasons it might be a better idea to
-    /// instead use one of:
-    ///
-    /// * [`Reader::decode()`], as it only allocates when the decoding can't be performed otherwise.
-    /// * [`unescaped_value()`], as it doesn't allocate when no escape sequences are used.
-    ///
-    /// [`unescaped_value()`]: #method.unescaped_value
-    /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
-    #[cfg(not(feature = "encoding"))]
-    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
-        let decoded = reader.decode(&*self.value)?;
-        let unescaped = unescape(decoded.as_bytes()).map_err(Error::EscapeError)?;
-        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
-    }
-
-    /// Decode then unescapes the value with custom entities
-    ///
-    /// This allocates a `String` in all cases. For performance reasons it might be a better idea to
-    /// instead use one of:
-    ///
-    /// * [`Reader::decode()`], as it only allocates when the decoding can't be performed otherwise.
-    /// * [`unescaped_value()`], as it doesn't allocate when no escape sequences are used.
-    ///
-    /// [`unescaped_value_with_custom_entities()`]: #method.unescaped_value
-    /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
-    ///
-    /// # Pre-condition
-    ///
-    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
-    #[cfg(feature = "encoding")]
-    pub fn unescape_and_decode_value_with_custom_entities<B: BufRead>(
+    fn make_unescaped_value(
         &self,
-        reader: &Reader<B>,
-        custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
-    ) -> Result<String> {
-        let decoded = reader.decode(&*self.value);
-        let unescaped =
-            unescape_with(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
-        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
+        custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
+    ) -> Result<Cow<[u8]>> {
+        do_unescape(&*self.value, custom_entities).map_err(Error::EscapeError)
+    }
+
+    /// Decode then unescapes the value
+    ///
+    /// This allocates a `String` in all cases. For performance reasons it might be a better idea to
+    /// instead use one of:
+    ///
+    /// * [`Reader::decode()`], as it only allocates when the decoding can't be performed otherwise.
+    /// * [`unescaped_value()`], as it doesn't allocate when no escape sequences are used.
+    ///
+    /// [`unescaped_value()`]: #method.unescaped_value
+    /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
+    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
+        self.do_unescape_and_decode_value(reader, None)
     }
 
     /// Decode then unescapes the value with custom entities
@@ -193,15 +154,36 @@ impl<'a> Attribute<'a> {
     /// # Pre-condition
     ///
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
-    #[cfg(not(feature = "encoding"))]
     pub fn unescape_and_decode_value_with_custom_entities<B: BufRead>(
         &self,
         reader: &Reader<B>,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<String> {
+        self.do_unescape_and_decode_value(reader, Some(custom_entities))
+    }
+
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
+    #[cfg(feature = "encoding")]
+    fn do_unescape_and_decode_value<B: BufRead>(
+        &self,
+        reader: &Reader<B>,
+        custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
+    ) -> Result<String> {
+        let decoded = reader.decode(&*self.value);
+        let unescaped =
+            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
+    }
+
+    #[cfg(not(feature = "encoding"))]
+    fn do_unescape_and_decode_value<B: BufRead>(
+        &self,
+        reader: &Reader<B>,
+        custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
+    ) -> Result<String> {
         let decoded = reader.decode(&*self.value)?;
         let unescaped =
-            unescape_with(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -217,9 +199,7 @@ impl<'a> Attribute<'a> {
         &self,
         reader: &mut Reader<B>,
     ) -> Result<String> {
-        let decoded = reader.decode_without_bom(&*self.value);
-        let unescaped = unescape(decoded.as_bytes()).map_err(Error::EscapeError)?;
-        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
+        self.do_unescape_and_decode_without_bom(reader, None)
     }
 
     /// helper method to unescape then decode self using the reader encoding
@@ -234,9 +214,7 @@ impl<'a> Attribute<'a> {
         &self,
         reader: &Reader<B>,
     ) -> Result<String> {
-        let decoded = reader.decode_without_bom(&*self.value)?;
-        let unescaped = unescape(decoded.as_bytes()).map_err(Error::EscapeError)?;
-        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
+        self.do_unescape_and_decode_without_bom(reader, None)
     }
 
     /// helper method to unescape then decode self using the reader encoding with custom entities
@@ -256,10 +234,7 @@ impl<'a> Attribute<'a> {
         reader: &mut Reader<B>,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<String> {
-        let decoded = reader.decode_without_bom(&*self.value);
-        let unescaped =
-            unescape_with(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
-        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
+        self.do_unescape_and_decode_without_bom(reader, Some(custom_entities))
     }
 
     /// helper method to unescape then decode self using the reader encoding with custom entities
@@ -279,9 +254,30 @@ impl<'a> Attribute<'a> {
         reader: &Reader<B>,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<String> {
+        self.do_unescape_and_decode_without_bom(reader, Some(custom_entities))
+    }
+
+    #[cfg(feature = "encoding")]
+    fn do_unescape_and_decode_without_bom<B: BufRead>(
+        &self,
+        reader: &mut Reader<B>,
+        custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
+    ) -> Result<String> {
+        let decoded = reader.decode_without_bom(&*self.value);
+        let unescaped =
+            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
+    }
+
+    #[cfg(not(feature = "encoding"))]
+    fn do_unescape_and_decode_without_bom<B: BufRead>(
+        &self,
+        reader: &Reader<B>,
+        custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
+    ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value)?;
         let unescaped =
-            unescape_with(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -172,6 +172,10 @@ impl<'a> BytesStart<'a> {
     /// "`<`".
     /// Additional entities can be provided in `custom_entities`.
     ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
+    ///
     /// See also [`unescaped()`](#method.unescaped)
     #[inline]
     pub fn unescaped_with_custom_entities<'s>(
@@ -260,6 +264,10 @@ impl<'a> BytesStart<'a> {
     ///
     /// [`unescaped_with_custom_entities()`]: #method.unescaped_with_custom_entities
     /// [`Reader::decode()`]: ../reader/struct.Reader.html#method.decode
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(feature = "encoding")]
     #[inline]
     pub fn unescape_and_decode_with_custom_entities<B: BufRead>(
@@ -283,6 +291,10 @@ impl<'a> BytesStart<'a> {
     ///
     /// [`unescaped_with_custom_entities()`]: #method.unescaped_with_custom_entities
     /// [`Reader::decode()`]: ../reader/struct.Reader.html#method.decode
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(not(feature = "encoding"))]
     #[inline]
     pub fn unescape_and_decode_with_custom_entities<B: BufRead>(
@@ -592,6 +604,10 @@ impl<'a> BytesText<'a> {
     /// returns Malformed error with index within element if '&' is not followed by ';'
     /// Additional entities can be provided in `custom_entities`.
     ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
+    ///
     /// See also [`unescaped()`](#method.unescaped)
     pub fn unescaped_with_custom_entities<'s>(
         &'s self,
@@ -641,6 +657,10 @@ impl<'a> BytesText<'a> {
     /// it might be wiser to manually use
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(feature = "encoding")]
     pub fn unescape_and_decode_without_bom_with_custom_entities<B: BufRead>(
         &self,
@@ -660,6 +680,14 @@ impl<'a> BytesText<'a> {
     /// it might be wiser to manually use
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(not(feature = "encoding"))]
     pub fn unescape_and_decode_without_bom_with_custom_entities<B: BufRead>(
         &self,
@@ -704,6 +732,10 @@ impl<'a> BytesText<'a> {
     /// it might be wiser to manually use
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(feature = "encoding")]
     pub fn unescape_and_decode_with_custom_entities<B: BufRead>(
         &self,
@@ -722,6 +754,10 @@ impl<'a> BytesText<'a> {
     /// it might be wiser to manually use
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
+    ///
+    /// # Pre-condition
+    ///
+    /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     #[cfg(not(feature = "encoding"))]
     pub fn unescape_and_decode_with_custom_entities<B: BufRead>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ mod escapei;
 pub mod escape {
     //! Manage xml character escapes
     pub(crate) use escapei::EscapeError;
-    pub use escapei::{escape, unescape};
+    pub use escapei::{escape, unescape, unescape_with};
 }
 pub mod events;
 mod reader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ mod errors;
 mod escapei;
 pub mod escape {
     //! Manage xml character escapes
-    pub(crate) use escapei::EscapeError;
+    pub(crate) use escapei::{do_unescape, EscapeError};
     pub use escapei::{escape, unescape, unescape_with};
 }
 pub mod events;


### PR DESCRIPTION
these versions expect an additional parameter:
a hashmap containing custom entity definitions.
A typical use-case is for the user to parse those entities definitions
from the DOCTYPE.
An example is provided: examples/custom_entities.rs .