### PR TITLE
Fix warnings from newer rust compiler which will be hard errors in Rust 2021

### DIFF
--- a/tests/serde-migrated.rs
+++ b/tests/serde-migrated.rs
@@ -953,12 +953,12 @@ fn futile2() {
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
     struct Object {
         field: Option<Null>,
-    };
+    }
 
     #[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
     struct Stuff {
         stuff_field: Option<Object>,
-    };
+    }
 
     test_parse_ok(&[
         (

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -211,7 +211,7 @@ fn test_writer() {
         match reader.read_event(&mut buf) {
             Ok(Eof) => break,
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -230,7 +230,7 @@ fn test_writer_borrow() {
         match reader.read_event(&mut buf) {
             Ok(Eof) => break,
             Ok(e) => assert!(writer.write_event(&e).is_ok()), // either `e` or `&e`
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -249,7 +249,7 @@ fn test_writer_indent() {
         match reader.read_event(&mut buf) {
             Ok(Eof) => break,
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -274,7 +274,7 @@ fn test_writer_indent_cdata() {
         match reader.read_event(&mut buf) {
             Ok(Eof) => break,
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -299,7 +299,7 @@ fn test_write_empty_element_attrs() {
         match reader.read_event(&mut buf) {
             Ok(Eof) => break,
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -328,7 +328,7 @@ fn test_write_attrs() {
             }
             Ok(End(_)) => End(BytesEnd::borrowed(b"copy")),
             Ok(e) => e,
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         };
         assert!(writer.write_event(event).is_ok());
     }
@@ -664,7 +664,7 @@ fn test_read_write_roundtrip_results_in_identity() {
         match reader.read_event(&mut buf) {
             Ok(Eof) => break,
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -691,7 +691,7 @@ fn test_read_write_roundtrip() {
         match reader.read_event(&mut buf) {
             Ok(Eof) => break,
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -724,7 +724,7 @@ fn test_read_write_roundtrip_escape() {
                     .is_ok());
             }
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -757,7 +757,7 @@ fn test_read_write_roundtrip_escape_text() {
                     .is_ok());
             }
             Ok(e) => assert!(writer.write_event(e).is_ok()),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 


### PR DESCRIPTION
Specifically fix the following warnings:

```console
warning: panic message is not a string literal
   --> tests\unit_tests.rs:760:30
    |
760 |             Err(e) => panic!(e),
    |                              ^
    |
    = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
    |
760 |             Err(e) => panic!("{}", e),
    |                              ^^^^^
help: or use std::panic::panic_any instead
    |
760 |             Err(e) => std::panic::panic_any(e),
    |                       ^^^^^^^^^^^^^^^^^^^^^
```

All `panic!(e)` invocations replaced by `panic!("{}", e)` as suggested because `panic_any` is availible only from `1.51.0`