### PR TITLE
Implement unflattening structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,20 @@ struct Foo {
 }
 ```
 
+### Unflattening structs into verbose XML
+
+If your XML files look like `<root><first>value</first><second>value</second></root>`, you can
+(de)serialize them with the special name prefix `$unflatten=`:
+
+```rust,ignore
+struct Root {
+    #[serde(rename = "$unflatten=first")]
+    first: String,
+    #[serde(rename = "$unflatten=second")]
+    other_field: String,
+}
+```
+
 ### Performance
 
 Note that despite not focusing on performance (there are several unecessary copies), it remains about 10x faster than serde-xml-rs.

--- a/tests/serde_roundtrip.rs
+++ b/tests/serde_roundtrip.rs
@@ -125,6 +125,24 @@ fn no_contiguous_fields() {
 }
 
 #[test]
+fn test_parse_unflatten_field() {
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct Unflatten {
+        #[serde(rename = "$unflatten=NewKey")]
+        field: String
+    }
+
+    let source = "<Unflatten><NewKey>Foo</NewKey></Unflatten>";
+    let expected = Unflatten { field: "Foo".to_string() };
+
+    let parsed: Unflatten = ::quick_xml::de::from_str(source).unwrap();
+    assert_eq!(&parsed, &expected);
+
+    let stringified = to_string(&parsed).unwrap();
+    assert_eq!(&stringified, source);
+}
+
+#[test]
 fn escapes_in_cdata() {
     #[derive(Debug, Deserialize, PartialEq)]
     pub struct Protocols {


### PR DESCRIPTION
This pull gives an (non-ideal) implementation for #245.

Essentially this allows `<root><first>value</first><second>value</second></root>` to be (de)serialized with the special name prefix `$unflatten=`:
```rust,ignore
struct Root {
    #[serde(rename = "$unflatten=first")]
    first: String,
    #[serde(rename = "$unflatten=second")]
    other_field: String,
}
```

Ideally this would be something that could be configured on a struct level, but since from what I understand Serde doesn't allow custom per-implementation attributes... so this uses `rename` as a backchannel, like $value does.

It would be nicer to implement a separate XML trait, but Serde doesn't really like that either, like the comment in #205 knows.
https://github.com/tafia/quick-xml/pull/205#issuecomment-605680462