### PR TITLE
Add $primitive for serializing unit variants as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,23 @@ struct Root {
 }
 ```
 
+### Serializing unit variants as primitives
+
+The `$primitive` prefix lets you serialize enum variants without associated values (internally referred to as _unit variants_) as primitive strings rather than self-closing tags. Consider the following definitions:
+
+```rust,ignore
+enum Foo {
+    #[serde(rename = "$primitive=Bar")]
+    Bar
+}
+
+struct Root {
+    foo: Foo
+}
+```
+
+Serializing `Root { foo: Foo::Bar }` will then yield `<Root foo="Bar"/>` instead of `<Root><Bar/></Root>`.
+
 ### Performance
 
 Note that despite not focusing on performance (there are several unecessary copies), it remains about 10x faster than serde-xml-rs.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -125,6 +125,7 @@ use std::io::BufRead;
 
 pub(crate) const INNER_VALUE: &str = "$value";
 pub(crate) const UNFLATTEN_PREFIX: &str = "$unflatten=";
+pub(crate) const PRIMITIVE_PREFIX: &str = "$primitive=";
 
 /// An xml deserializer
 pub struct Deserializer<'de, R: BorrowingReader<'de>> {

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -232,7 +232,7 @@ impl<'r, 'w, W: Write> ser::Serializer for &'w mut Serializer<'r, W> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, DeError> {
-        self.write_self_closed(variant)
+        self.write_primitive(variant, false)
     }
 
     fn serialize_newtype_struct<T: ?Sized + Serialize>(
@@ -654,7 +654,7 @@ mod tests {
             #[test]
             fn unit() {
                 let mut buffer = Vec::new();
-                let should_be = "<Unit/>";
+                let should_be = "Unit";
 
                 {
                     let mut ser = Serializer::with_root(Writer::new(&mut buffer), Some("root"));

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -4,6 +4,7 @@ mod var;
 
 use self::var::{Map, Seq, Struct, Tuple};
 use crate::{
+    de::PRIMITIVE_PREFIX,
     errors::serialize::DeError,
     events::{BytesEnd, BytesStart, BytesText, Event},
     writer::Writer,
@@ -232,7 +233,12 @@ impl<'r, 'w, W: Write> ser::Serializer for &'w mut Serializer<'r, W> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, DeError> {
-        self.write_primitive(variant, false)
+        if variant.starts_with(PRIMITIVE_PREFIX) {
+            let variant = variant.split_at(PRIMITIVE_PREFIX.len()).1;
+            self.write_primitive(variant, false)
+        } else {
+            self.write_self_closed(variant)
+        }
     }
 
     fn serialize_newtype_struct<T: ?Sized + Serialize>(
@@ -634,6 +640,8 @@ mod tests {
             #[derive(Serialize)]
             enum Node {
                 Unit,
+                #[serde(rename = "$primitive=PrimitiveUnit")]
+                PrimitiveUnit,
                 Newtype(bool),
                 Tuple(f64, String),
                 Struct {
@@ -654,11 +662,26 @@ mod tests {
             #[test]
             fn unit() {
                 let mut buffer = Vec::new();
-                let should_be = "Unit";
+                let should_be = "<Unit/>";
 
                 {
                     let mut ser = Serializer::with_root(Writer::new(&mut buffer), Some("root"));
                     let node = Node::Unit;
+                    node.serialize(&mut ser).unwrap();
+                }
+
+                let got = String::from_utf8(buffer).unwrap();
+                assert_eq!(got, should_be);
+            }
+
+            #[test]
+            fn primitive_unit() {
+                let mut buffer = Vec::new();
+                let should_be = "PrimitiveUnit";
+
+                {
+                    let mut ser = Serializer::with_root(Writer::new(&mut buffer), Some("root"));
+                    let node = Node::PrimitiveUnit;
                     node.serialize(&mut ser).unwrap();
                 }
 


### PR DESCRIPTION
### Fixes #283 

This PR updates the serializer for unit variants to serialize them as string primitives instead of self-closing tags if prefixed with `$primitive`. For example, if we define

```rust
enum X {
    #[serde(rename = "$primitive=A")]
    A
}

struct Y {
    x: X
}
```

`X::A` will now serialize to `A` instead of `<A/>` and `Y { x: X::A }` will now serialize to `<Y x="A"/>` instead of `<Y><A/></Y>`.