### PR TITLE
Additional basic tests for serde deserializer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,10 @@
 
 ## Unreleased
 
+- test: add tests for malformed inputs for serde deserializer
+- fix: allow to deserialize `unit`s from any data in attribute values and text nodes
+- refactor: unify errors when EOF encountered during serde deserialization
+
 ## 0.23.0-alpha3
 
 - fix: use element name (with namespace) when unflattening (serialize feature)

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@
 - test: add tests for malformed inputs for serde deserializer
 - fix: allow to deserialize `unit`s from any data in attribute values and text nodes
 - refactor: unify errors when EOF encountered during serde deserialization
+- test: ensure that after deserializing all XML was consumed
+- feat: add `Deserializer::from_str` and `Deserializer::from_bytes`
 
 ## 0.23.0-alpha3
 

--- a/src/de/escape.rs
+++ b/src/de/escape.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 /// Escaping the value is actually not always necessary, for instance
 /// when converting to float, we don't expect any escapable character
 /// anyway
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct EscapedDeserializer {
     decoder: Decoder,
     /// Possible escaped value of text/CDATA or attribute value

--- a/src/de/escape.rs
+++ b/src/de/escape.rs
@@ -145,13 +145,7 @@ impl<'de> serde::Deserializer<'de> for EscapedDeserializer {
     where
         V: Visitor<'de>,
     {
-        if self.escaped_value.is_empty() {
-            visitor.visit_unit()
-        } else {
-            Err(DeError::InvalidUnit(
-                "Expecting unit, got non empty attribute".into(),
-            ))
-        }
+        visitor.visit_unit()
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -870,37 +870,97 @@ mod tests {
         assert_eq!(item, Item);
     }
 
-    #[test]
-    fn unit() {
+    mod unit {
+        use super::*;
+
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
 
-        let data: Unit = from_str("<root/>").unwrap();
-        assert_eq!(data, Unit);
+        #[test]
+        fn simple() {
+            let data: Unit = from_str("<root/>").unwrap();
+            assert_eq!(data, Unit);
+        }
+
+        #[test]
+        fn excess_attribute() {
+            let data: Unit = from_str(r#"<root excess="attribute"/>"#).unwrap();
+            assert_eq!(data, Unit);
+        }
+
+        #[test]
+        fn excess_element() {
+            let data: Unit = from_str(r#"<root><excess>element</excess></root>"#).unwrap();
+            assert_eq!(data, Unit);
+        }
+
+        #[test]
+        fn excess_text() {
+            let data: Unit = from_str(r#"<root>excess text</root>"#).unwrap();
+            assert_eq!(data, Unit);
+        }
+
+        #[test]
+        fn excess_cdata() {
+            let data: Unit = from_str(r#"<root><![CDATA[excess CDATA]]></root>"#).unwrap();
+            assert_eq!(data, Unit);
+        }
     }
 
-    #[test]
-    fn newtype() {
+    mod newtype {
+        use super::*;
+
         #[derive(Debug, Deserialize, PartialEq)]
         struct Newtype(bool);
 
-        let data: Newtype = from_str("<root>true</root>").unwrap();
-        assert_eq!(data, Newtype(true));
+        #[test]
+        fn simple() {
+            let data: Newtype = from_str("<root>true</root>").unwrap();
+            assert_eq!(data, Newtype(true));
+        }
+
+        #[test]
+        fn excess_attribute() {
+            let data: Newtype = from_str(r#"<root excess="attribute">true</root>"#).unwrap();
+            assert_eq!(data, Newtype(true));
+        }
     }
 
-    #[test]
-    fn tuple() {
-        let data: (f32, String) = from_str("<root>42</root><root>answer</root>").unwrap();
-        assert_eq!(data, (42.0, "answer".into()));
+    mod tuple {
+        use super::*;
+
+        #[test]
+        fn simple() {
+            let data: (f32, String) = from_str("<root>42</root><root>answer</root>").unwrap();
+            assert_eq!(data, (42.0, "answer".into()));
+        }
+
+        #[test]
+        fn excess_attribute() {
+            let data: (f32, String) =
+                from_str(r#"<root excess="attribute">42</root><root>answer</root>"#).unwrap();
+            assert_eq!(data, (42.0, "answer".into()));
+        }
     }
 
-    #[test]
-    fn tuple_struct() {
+    mod tuple_struct {
+        use super::*;
+
         #[derive(Debug, Deserialize, PartialEq)]
         struct Tuple(f32, String);
 
-        let data: Tuple = from_str("<root>42</root><root>answer</root>").unwrap();
-        assert_eq!(data, Tuple(42.0, "answer".into()));
+        #[test]
+        fn simple() {
+            let data: Tuple = from_str("<root>42</root><root>answer</root>").unwrap();
+            assert_eq!(data, Tuple(42.0, "answer".into()));
+        }
+
+        #[test]
+        fn excess_attribute() {
+            let data: Tuple =
+                from_str(r#"<root excess="attribute">42</root><root>answer</root>"#).unwrap();
+            assert_eq!(data, Tuple(42.0, "answer".into()));
+        }
     }
 
     mod struct_ {
@@ -926,8 +986,45 @@ mod tests {
         }
 
         #[test]
+        fn excess_elements() {
+            let data: Struct = from_str(
+                r#"
+                <root>
+                    <before/>
+                    <float>42</float>
+                    <in-the-middle/>
+                    <string>answer</string>
+                    <after/>
+                </root>"#,
+            )
+            .unwrap();
+            assert_eq!(
+                data,
+                Struct {
+                    float: 42.0,
+                    string: "answer".into()
+                }
+            );
+        }
+
+        #[test]
         fn attributes() {
             let data: Struct = from_str(r#"<root float="42" string="answer"/>"#).unwrap();
+            assert_eq!(
+                data,
+                Struct {
+                    float: 42.0,
+                    string: "answer".into()
+                }
+            );
+        }
+
+        #[test]
+        fn excess_attributes() {
+            let data: Struct = from_str(
+                r#"<root before="1" float="42" in-the-middle="2" string="answer" after="3"/>"#,
+            )
+            .unwrap();
             assert_eq!(
                 data,
                 Struct {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -699,25 +699,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn simple_struct_from_attribute_and_child() {
-        let s = r##"
-	    <item name="hello">
-            <source>world.rs</source>
-            </item>
-        "##;
-
-        let item: Item = from_str(s).unwrap();
-
-        assert_eq!(
-            item,
-            Item {
-                name: "hello".to_string(),
-                source: "world.rs".to_string(),
-            }
-        );
-    }
-
     #[derive(Debug, Deserialize, PartialEq)]
     struct Project {
         name: String,
@@ -947,6 +928,26 @@ mod tests {
         #[test]
         fn attributes() {
             let data: Struct = from_str(r#"<root float="42" string="answer"/>"#).unwrap();
+            assert_eq!(
+                data,
+                Struct {
+                    float: 42.0,
+                    string: "answer".into()
+                }
+            );
+        }
+
+        #[test]
+        fn attribute_and_element() {
+            let data: Struct = from_str(
+                r#"
+                <root float="42">
+                    <string>answer</string>
+                </root>
+            "#,
+            )
+            .unwrap();
+
             assert_eq!(
                 data,
                 Struct {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -578,7 +578,7 @@ mod tests {
                 break;
             }
 
-            assert_eq!(format!("{:?}", event1), format!("{:?}", event2));
+            assert_eq!(event1, event2);
         }
     }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -676,23 +676,6 @@ mod tests {
     }
 
     #[test]
-    fn simple_struct_from_attributes() {
-        let s = r##"
-	    <item name="hello" source="world.rs" />
-	"##;
-
-        let item: Item = from_reader(s.as_bytes()).unwrap();
-
-        assert_eq!(
-            item,
-            Item {
-                name: "hello".to_string(),
-                source: "world.rs".to_string(),
-            }
-        );
-    }
-
-    #[test]
     fn multiple_roots_attributes() {
         let s = r##"
 	    <item name="hello" source="world.rs" />

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -281,12 +281,12 @@ impl<'a> Attribute<'a> {
 
 impl<'a> std::fmt::Debug for Attribute<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use crate::utils::write_byte_string;
+        use crate::utils::{write_byte_string, write_cow_string};
 
         write!(f, "Attribute {{ key: ")?;
         write_byte_string(f, self.key)?;
         write!(f, ", value: ")?;
-        write_byte_string(f, &self.value)?;
+        write_cow_string(f, &self.value)?;
         write!(f, " }}")
     }
 }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -13,7 +13,7 @@ use std::{borrow::Cow, collections::HashMap, io::BufRead, ops::Range};
 /// The duplicate check can be turned off by calling [`with_checks(false)`].
 ///
 /// [`with_checks(false)`]: #method.with_checks
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Attributes<'a> {
     /// slice of `Element` corresponding to attributes
     bytes: &'a [u8],

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -365,10 +365,10 @@ impl<'a> BytesStart<'a> {
 
 impl<'a> std::fmt::Debug for BytesStart<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use crate::utils::write_byte_string;
+        use crate::utils::write_cow_string;
 
         write!(f, "BytesStart {{ buf: ")?;
-        write_byte_string(f, &self.buf)?;
+        write_cow_string(f, &self.buf)?;
         write!(f, ", name_len: {} }}", self.name_len)
     }
 }
@@ -548,10 +548,10 @@ impl<'a> BytesEnd<'a> {
 
 impl<'a> std::fmt::Debug for BytesEnd<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use crate::utils::write_byte_string;
+        use crate::utils::write_cow_string;
 
         write!(f, "BytesEnd {{ name: ")?;
-        write_byte_string(f, &self.name)?;
+        write_cow_string(f, &self.name)?;
         write!(f, " }}")
     }
 }
@@ -852,10 +852,10 @@ impl<'a> BytesText<'a> {
 
 impl<'a> std::fmt::Debug for BytesText<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use crate::utils::write_byte_string;
+        use crate::utils::write_cow_string;
 
         write!(f, "BytesText {{ content: ")?;
-        write_byte_string(f, &self.content)?;
+        write_cow_string(f, &self.content)?;
         write!(f, " }}")
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1568,12 +1568,12 @@ impl NamespaceBufferIndex {
 
 /// Utf8 Decoder
 #[cfg(not(feature = "encoding"))]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Decoder;
 
 /// Utf8 Decoder
 #[cfg(feature = "encoding")]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Decoder {
     encoding: &'static Encoding,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,21 @@
-pub fn write_byte_string(f: &mut std::fmt::Formatter<'_>, byte_string: &[u8]) -> std::fmt::Result {
+use std::borrow::Cow;
+use std::fmt::{Formatter, Result};
+
+pub fn write_cow_string(f: &mut Formatter<'_>, cow_string: &Cow<[u8]>) -> Result {
+    match cow_string {
+        Cow::Owned(s) => {
+            write!(f, "Owned(")?;
+            write_byte_string(f, &s)?;
+        }
+        Cow::Borrowed(s) => {
+            write!(f, "Borrowed(")?;
+            write_byte_string(f, s)?;
+        }
+    }
+    write!(f, ")")
+}
+
+pub fn write_byte_string(f: &mut Formatter<'_>, byte_string: &[u8]) -> Result {
     write!(f, "\"")?;
     for b in byte_string {
         match *b {


### PR DESCRIPTION
Added tests for parsing maps and structs from malformed inputs:
- unclosed tags
- mismatched tags

Add tests that ensures that excess attributes/elements do not break deserialization of complex structures (unis/newtypes/tuples/structs).