### PR TITLE
Fix bang parsing and unexpected EOFs

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -670,6 +670,25 @@ mod tests {
     }
 
     #[derive(Debug, Deserialize, PartialEq)]
+    struct BorrowedCow<'a> {
+        #[serde(rename = "$value")]
+        #[serde(borrow)]
+        cow: Cow<'a, str>,
+    }
+
+    #[test]
+    fn cow_borrow() {
+        let s = "<cow>Bessie</cow>";
+
+        let borrowed_item: BorrowedCow = from_str(s).unwrap();
+
+        match borrowed_item.cow {
+            Cow::Borrowed(_) => (), // Ok!
+            Cow::Owned(_) => panic!("Expected borrowed Cow, not owned"),
+        }
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
     struct Item {
         name: String,
         source: String,


### PR DESCRIPTION
Addressed a couple of FIXMEs I left behind in the borrowing implementation.

To do that, I also refactored a large part of the parsing code, because the buffer-reading code was repeated too much and causing too much indentation. All reading functions now use a `read_until_done()`, which takes a couple of lambdas that tell it when to stop reading and how much to consume from the BufReader.

The first commit is mostly just the refactoring. I had to use a range, so the performance decreased somewhat, but not by much:

```diff
- bench_quick_xml_escaped                    364,349           370,246             5,897   1.62%   x 0.98 
+ bench_quick_xml_escaped_trimmed            316,926           318,250             1,324   0.42%   x 1.00 
- bench_quick_xml_namespaced                 411,397           424,069            12,672   3.08%   x 0.97 
+ bench_quick_xml_namespaced_trimmed         395,336           395,102              -234  -0.06%   x 1.00 
+ bench_quick_xml_normal                     291,601           291,554               -47  -0.02%   x 1.00 
+ bench_quick_xml_normal_trimmed             286,892           274,359           -12,533  -4.37%   x 1.05 
+ bench_quick_xml_one_cdata_event_trimmed    462               451                   -11  -2.38%   x 1.02 
- bench_quick_xml_one_comment_event_trimmed  63                65                      2   3.17%   x 0.97 
- bench_quick_xml_one_start_event_trimmed    80                81                      1   1.25%   x 0.99 
- bench_quick_xml_one_text_event             50                55                      5  10.00%   x 0.91 
```

The second and third commit fix a few flaws I saw in the bang parser, and also adds both buffered and unbuffered variants to all the xml file tests, to exercise the unbuffered reader too.

This one made the performance drop across the board, but I think it's not much and it's worth it:

```diff
- bench_quick_xml_escaped                    364,349           378,836            14,487   3.98%   x 0.96 
- bench_quick_xml_escaped_trimmed            316,926           330,333            13,407   4.23%   x 0.96 
- bench_quick_xml_namespaced                 411,397           426,585            15,188   3.69%   x 0.96 
- bench_quick_xml_namespaced_trimmed         395,336           413,747            18,411   4.66%   x 0.96 
- bench_quick_xml_normal                     291,601           300,412             8,811   3.02%   x 0.97 
- bench_quick_xml_normal_trimmed             286,892           291,228             4,336   1.51%   x 0.99 
- bench_quick_xml_one_cdata_event_trimmed    462               494                    32   6.93%   x 0.94 
- bench_quick_xml_one_comment_event_trimmed  63                65                      2   3.17%   x 0.97 
- bench_quick_xml_one_start_event_trimmed    80                84                      4   5.00%   x 0.95 
- bench_quick_xml_one_text_event             50                57                      7  14.00%   x 0.88 
```
