### PR TITLE
Remove BufferedInput::input_borrowed because it's unused 

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -131,16 +131,16 @@ pub(crate) const UNFLATTEN_PREFIX: &str = "$unflatten=";
 
 /// Simplified event which contains only these variants that used by deserializer
 #[derive(Debug, PartialEq)]
-pub enum DeEvent<'a> {
+pub enum DeEvent<'bf> {
     /// Start tag (with attributes) `<tag attr="value">`.
-    Start(BytesStart<'a>),
+    Start(BytesStart<'bf>),
     /// End tag `</tag>`.
-    End(BytesEnd<'a>),
+    End(BytesEnd<'bf>),
     /// Escaped character data between `Start` and `End` element.
-    Text(BytesText<'a>),
+    Text(BytesText<'bf>),
     /// Unescaped character data between `Start` and `End` element,
     /// stored in `<![CDATA[...]]>`.
-    CData(BytesText<'a>),
+    CData(BytesText<'bf>),
     /// End of XML document.
     Eof,
 }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -92,7 +92,7 @@ impl<'a> Attribute<'a> {
     /// This will allocate if the value contains any escape sequences.
     ///
     /// See also [`unescaped_value_with_custom_entities()`](#method.unescaped_value_with_custom_entities)
-    pub fn unescaped_value(&self) -> Result<Cow<[u8]>> {
+    pub fn unescaped_value(&self) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped_value(None)
     }
 
@@ -112,14 +112,14 @@ impl<'a> Attribute<'a> {
     pub fn unescaped_value_with_custom_entities(
         &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
-    ) -> Result<Cow<[u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped_value(Some(custom_entities))
     }
 
     fn make_unescaped_value(
         &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
-    ) -> Result<Cow<[u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         do_unescape(&self.value, custom_entities).map_err(Error::EscapeError)
     }
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -120,7 +120,7 @@ impl<'a> Attribute<'a> {
         &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<[u8]>> {
-        do_unescape(&*self.value, custom_entities).map_err(Error::EscapeError)
+        do_unescape(&self.value, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Decode then unescapes the value
@@ -167,8 +167,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -179,8 +179,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -261,8 +261,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -273,8 +273,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -191,7 +191,7 @@ impl<'a> BytesStart<'a> {
     ///
     /// See also [`unescaped_with_custom_entities()`](#method.unescaped_with_custom_entities)
     #[inline]
-    pub fn unescaped(&self) -> Result<Cow<[u8]>> {
+    pub fn unescaped(&self) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(None)
     }
 
@@ -207,18 +207,18 @@ impl<'a> BytesStart<'a> {
     ///
     /// See also [`unescaped()`](#method.unescaped)
     #[inline]
-    pub fn unescaped_with_custom_entities<'s>(
-        &'s self,
+    pub fn unescaped_with_custom_entities(
+        &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(Some(custom_entities))
     }
 
     #[inline]
-    fn make_unescaped<'s>(
-        &'s self,
+    fn make_unescaped(
+        &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         do_unescape(&self.buf, custom_entities).map_err(Error::EscapeError)
     }
 
@@ -618,7 +618,7 @@ impl<'a> BytesText<'a> {
     /// returns Malformed error with index within element if '&' is not followed by ';'
     ///
     /// See also [`unescaped_with_custom_entities()`](#method.unescaped_with_custom_entities)
-    pub fn unescaped(&self) -> Result<Cow<[u8]>> {
+    pub fn unescaped(&self) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(None)
     }
 
@@ -633,17 +633,17 @@ impl<'a> BytesText<'a> {
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     ///
     /// See also [`unescaped()`](#method.unescaped)
-    pub fn unescaped_with_custom_entities<'s>(
-        &'s self,
+    pub fn unescaped_with_custom_entities(
+        &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(Some(custom_entities))
     }
 
-    fn make_unescaped<'s>(
-        &'s self,
+    fn make_unescaped(
+        &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         do_unescape(&self.content, custom_entities).map_err(Error::EscapeError)
     }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -219,7 +219,7 @@ impl<'a> BytesStart<'a> {
         &'s self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
-        do_unescape(&*self.buf, custom_entities).map_err(Error::EscapeError)
+        do_unescape(&self.buf, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Returns an iterator over the attributes of this tag.
@@ -301,8 +301,7 @@ impl<'a> BytesStart<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -314,8 +313,8 @@ impl<'a> BytesStart<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -645,7 +644,7 @@ impl<'a> BytesText<'a> {
         &'s self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
-        do_unescape(self, custom_entities).map_err(Error::EscapeError)
+        do_unescape(&self.content, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Gets content of this text buffer in the specified encoding
@@ -681,8 +680,8 @@ impl<'a> BytesText<'a> {
     ) -> Result<Cow<'a, str>> {
         match self.decode(decoder)? {
             Cow::Borrowed(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
+                let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), None)
+                    .map_err(Error::EscapeError)?;
                 match unescaped {
                     Cow::Borrowed(unescaped) => {
                         from_utf8(unescaped).map(|s| s.into()).map_err(Error::Utf8)
@@ -693,8 +692,8 @@ impl<'a> BytesText<'a> {
                 }
             }
             Cow::Owned(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
+                let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), None)
+                    .map_err(Error::EscapeError)?;
                 String::from_utf8(unescaped.into_owned())
                     .map(|s| s.into())
                     .map_err(|e| Error::Utf8(e.utf8_error()))
@@ -791,8 +790,8 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -843,8 +842,8 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 


### PR DESCRIPTION
Closes https://github.com/tafia/quick-xml/issues/334. Based on another MR, only last commit matters. If you want me to rebase this, let me know.