### PR TITLE
Correctly use Cow for attribute values to return useful lifetimes

### DIFF
--- a/src/de/escape.rs
+++ b/src/de/escape.rs
@@ -14,16 +14,16 @@ use std::borrow::Cow;
 /// when converting to float, we don't expect any escapable character
 /// anyway
 #[derive(Clone, Debug)]
-pub struct EscapedDeserializer<'a> {
+pub struct EscapedDeserializer<'bf> {
     decoder: Decoder,
     /// Possible escaped value of text/CDATA or attribute value
-    escaped_value: Cow<'a, [u8]>,
+    escaped_value: Cow<'bf, [u8]>,
     /// If `true`, value requires unescaping before using
     escaped: bool,
 }
 
-impl<'a> EscapedDeserializer<'a> {
-    pub fn new(escaped_value: Cow<'a, [u8]>, decoder: Decoder, escaped: bool) -> Self {
+impl<'bf> EscapedDeserializer<'bf> {
+    pub fn new(escaped_value: Cow<'bf, [u8]>, decoder: Decoder, escaped: bool) -> Self {
         EscapedDeserializer {
             decoder,
             escaped_value,
@@ -56,7 +56,7 @@ macro_rules! deserialize_num {
     };
 }
 
-impl<'de, 'a> serde::Deserializer<'de> for EscapedDeserializer<'a> {
+impl<'de, 'bf> serde::Deserializer<'de> for EscapedDeserializer<'bf> {
     type Error = DeError;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -172,7 +172,7 @@ impl<'de, 'a> serde::Deserializer<'de> for EscapedDeserializer<'a> {
     }
 }
 
-impl<'de, 'a> EnumAccess<'de> for EscapedDeserializer<'a> {
+impl<'de, 'bf> EnumAccess<'de> for EscapedDeserializer<'bf> {
     type Error = DeError;
     type Variant = Self;
 
@@ -185,7 +185,7 @@ impl<'de, 'a> EnumAccess<'de> for EscapedDeserializer<'a> {
     }
 }
 
-impl<'de, 'a> VariantAccess<'de> for EscapedDeserializer<'a> {
+impl<'de, 'bf> VariantAccess<'de> for EscapedDeserializer<'bf> {
     type Error = DeError;
 
     fn unit_variant(self) -> Result<(), Self::Error> {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -131,16 +131,16 @@ pub(crate) const UNFLATTEN_PREFIX: &str = "$unflatten=";
 
 /// Simplified event which contains only these variants that used by deserializer
 #[derive(Debug, PartialEq)]
-pub enum DeEvent<'a> {
+pub enum DeEvent<'bf> {
     /// Start tag (with attributes) `<tag attr="value">`.
-    Start(BytesStart<'a>),
+    Start(BytesStart<'bf>),
     /// End tag `</tag>`.
-    End(BytesEnd<'a>),
+    End(BytesEnd<'bf>),
     /// Escaped character data between `Start` and `End` element.
-    Text(BytesText<'a>),
+    Text(BytesText<'bf>),
     /// Unescaped character data between `Start` and `End` element,
     /// stored in `<![CDATA[...]]>`.
-    CData(BytesText<'a>),
+    CData(BytesText<'bf>),
     /// End of XML document.
     Eof,
 }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -92,7 +92,7 @@ impl<'a> Attribute<'a> {
     /// This will allocate if the value contains any escape sequences.
     ///
     /// See also [`unescaped_value_with_custom_entities()`](#method.unescaped_value_with_custom_entities)
-    pub fn unescaped_value(&self) -> Result<Cow<[u8]>> {
+    pub fn unescaped_value(&self) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped_value(None)
     }
 
@@ -112,14 +112,14 @@ impl<'a> Attribute<'a> {
     pub fn unescaped_value_with_custom_entities(
         &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
-    ) -> Result<Cow<[u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped_value(Some(custom_entities))
     }
 
     fn make_unescaped_value(
         &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
-    ) -> Result<Cow<[u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         do_unescape(&self.value, custom_entities).map_err(Error::EscapeError)
     }
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -120,7 +120,7 @@ impl<'a> Attribute<'a> {
         &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<[u8]>> {
-        do_unescape(&*self.value, custom_entities).map_err(Error::EscapeError)
+        do_unescape(&self.value, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Decode then unescapes the value
@@ -167,8 +167,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -179,8 +179,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self.value)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -261,8 +261,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -273,8 +273,8 @@ impl<'a> Attribute<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self.value)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -191,7 +191,7 @@ impl<'a> BytesStart<'a> {
     ///
     /// See also [`unescaped_with_custom_entities()`](#method.unescaped_with_custom_entities)
     #[inline]
-    pub fn unescaped(&self) -> Result<Cow<[u8]>> {
+    pub fn unescaped(&self) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(None)
     }
 
@@ -207,18 +207,18 @@ impl<'a> BytesStart<'a> {
     ///
     /// See also [`unescaped()`](#method.unescaped)
     #[inline]
-    pub fn unescaped_with_custom_entities<'s>(
-        &'s self,
+    pub fn unescaped_with_custom_entities(
+        &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(Some(custom_entities))
     }
 
     #[inline]
-    fn make_unescaped<'s>(
-        &'s self,
+    fn make_unescaped(
+        &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         do_unescape(&self.buf, custom_entities).map_err(Error::EscapeError)
     }
 
@@ -618,7 +618,7 @@ impl<'a> BytesText<'a> {
     /// returns Malformed error with index within element if '&' is not followed by ';'
     ///
     /// See also [`unescaped_with_custom_entities()`](#method.unescaped_with_custom_entities)
-    pub fn unescaped(&self) -> Result<Cow<[u8]>> {
+    pub fn unescaped(&self) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(None)
     }
 
@@ -633,17 +633,17 @@ impl<'a> BytesText<'a> {
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     ///
     /// See also [`unescaped()`](#method.unescaped)
-    pub fn unescaped_with_custom_entities<'s>(
-        &'s self,
+    pub fn unescaped_with_custom_entities(
+        &self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         self.make_unescaped(Some(custom_entities))
     }
 
-    fn make_unescaped<'s>(
-        &'s self,
+    fn make_unescaped(
+        &self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
-    ) -> Result<Cow<'s, [u8]>> {
+    ) -> Result<Cow<'a, [u8]>> {
         do_unescape(&self.content, custom_entities).map_err(Error::EscapeError)
     }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -223,12 +223,12 @@ impl<'bf> BytesStart<'bf> {
     }
 
     /// Returns an iterator over the attributes of this tag.
-    pub fn attributes(&self) -> Attributes {
+    pub fn attributes(&self) -> Attributes<'a> {
         Attributes::new(&self.buf, self.name_len)
     }
 
     /// Returns an iterator over the HTML-like attributes of this tag (no mandatory quotes or `=`).
-    pub fn html_attributes(&self) -> Attributes {
+    pub fn html_attributes(&self) -> Attributes<'a> {
         Attributes::html(self, self.name_len)
     }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -219,7 +219,7 @@ impl<'a> BytesStart<'a> {
         &'s self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
-        do_unescape(&*self.buf, custom_entities).map_err(Error::EscapeError)
+        do_unescape(&self.buf, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Returns an iterator over the attributes of this tag.
@@ -301,8 +301,7 @@ impl<'a> BytesStart<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self);
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities).map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -314,8 +313,8 @@ impl<'a> BytesStart<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -645,7 +644,7 @@ impl<'a> BytesText<'a> {
         &'s self,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
-        do_unescape(self, custom_entities).map_err(Error::EscapeError)
+        do_unescape(&self.content, custom_entities).map_err(Error::EscapeError)
     }
 
     /// Gets content of this text buffer in the specified encoding
@@ -681,8 +680,8 @@ impl<'a> BytesText<'a> {
     ) -> Result<Cow<'a, str>> {
         match self.decode(decoder)? {
             Cow::Borrowed(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
+                let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), None)
+                    .map_err(Error::EscapeError)?;
                 match unescaped {
                     Cow::Borrowed(unescaped) => {
                         from_utf8(unescaped).map(|s| s.into()).map_err(Error::Utf8)
@@ -693,8 +692,8 @@ impl<'a> BytesText<'a> {
                 }
             }
             Cow::Owned(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
+                let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), None)
+                    .map_err(Error::EscapeError)?;
                 String::from_utf8(unescaped.into_owned())
                     .map(|s| s.into())
                     .map_err(|e| Error::Utf8(e.utf8_error()))
@@ -791,8 +790,8 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode_without_bom(&*self)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 
@@ -843,8 +842,8 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<String> {
         let decoded = reader.decode(&*self)?;
-        let unescaped =
-            do_unescape(decoded.as_bytes(), custom_entities).map_err(Error::EscapeError)?;
+        let unescaped = do_unescape(&Cow::Borrowed(decoded.as_bytes()), custom_entities)
+            .map_err(Error::EscapeError)?;
         String::from_utf8(unescaped.into_owned()).map_err(|e| Error::Utf8(e.utf8_error()))
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,7 +9,7 @@ use std::{fs::File, path::Path, str::from_utf8};
 use encoding_rs::{Encoding, UTF_16BE, UTF_16LE};
 
 use crate::errors::{Error, Result};
-use crate::events::{attributes::Attribute, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use crate::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 
 use memchr;
 
@@ -1503,28 +1503,28 @@ impl NamespaceBufferIndex {
         let level = self.nesting_level;
         // adds new namespaces for attributes starting with 'xmlns:' and for the 'xmlns'
         // (default namespace) attribute.
-        for a in e.attributes().with_checks(false) {
-            if let Ok(Attribute { key: k, value: v }) = a {
-                if k.starts_with(b"xmlns") {
-                    match k.get(5) {
+        for attribute in e.attributes().with_checks(false) {
+            if let Ok(attr) = attribute {
+                if attr.key.starts_with(b"xmlns") {
+                    match attr.key.get(5) {
                         None => {
                             let start = buffer.len();
-                            buffer.extend_from_slice(&*v);
+                            buffer.extend_from_slice(&attr.value);
                             self.slices.push(Namespace {
                                 start,
                                 prefix_len: 0,
-                                value_len: v.len(),
+                                value_len: attr.value.len(),
                                 level,
                             });
                         }
                         Some(&b':') => {
                             let start = buffer.len();
-                            buffer.extend_from_slice(&k[6..]);
-                            buffer.extend_from_slice(&*v);
+                            buffer.extend_from_slice(&attr.key[6..]);
+                            buffer.extend_from_slice(&attr.value);
                             self.slices.push(Namespace {
                                 start,
-                                prefix_len: k.len() - 6,
-                                value_len: v.len(),
+                                prefix_len: attr.key.len() - 6,
+                                value_len: attr.value.len(),
                                 level,
                             });
                         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,19 @@
 use std::borrow::Cow;
 use std::fmt::{Formatter, Result};
+use std::ops::Index;
+
+/// Index a range from a [Cow]. This will re-allocate on owned Cow's,
+/// but use the underlying borrow for borrowed Cows.
+pub fn index_cow<'a, I, T>(cow: &Cow<'a, T>, range: I) -> Cow<'a, T>
+where
+    T: Index<I, Output = T> + ToOwned + ?Sized,
+    <T as ToOwned>::Owned: Index<I, Output = T>,
+{
+    match cow {
+        Cow::Borrowed(v) => Cow::Borrowed(&v[range]),
+        Cow::Owned(v) => Cow::Owned(v[range].to_owned()),
+    }
+}
 
 pub fn write_cow_string(f: &mut Formatter<'_>, cow_string: &Cow<[u8]>) -> Result {
     match cow_string {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -221,12 +221,12 @@ impl<W: Write> Writer<W> {
     }
 }
 
-pub struct ElementWriter<'a, W: Write> {
-    writer: &'a mut Writer<W>,
-    start_tag: BytesStart<'a>,
+pub struct ElementWriter<'wr, W: Write> {
+    writer: &'wr mut Writer<W>,
+    start_tag: BytesStart<'wr>,
 }
 
-impl<'a, W: Write> ElementWriter<'a, W> {
+impl<'wr, W: Write> ElementWriter<'wr, W> {
     /// Adds an attribute to this element.
     pub fn with_attribute<'b, I>(mut self, attr: I) -> Self
     where
@@ -251,7 +251,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write some text inside the current element.
-    pub fn write_text_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
+    pub fn write_text_content(self, text: BytesText) -> Result<&'wr mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.to_borrowed()))?;
         self.writer.write_event(Event::Text(text))?;
@@ -261,7 +261,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write a CData event `<![CDATA[...]]>` inside the current element.
-    pub fn write_cdata_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
+    pub fn write_cdata_content(self, text: BytesText) -> Result<&'wr mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.to_borrowed()))?;
         self.writer.write_event(Event::CData(text))?;
@@ -271,7 +271,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write a processing instruction `<?...?>` inside the current element.
-    pub fn write_pi_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
+    pub fn write_pi_content(self, text: BytesText) -> Result<&'wr mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.to_borrowed()))?;
         self.writer.write_event(Event::PI(text))?;
@@ -281,13 +281,13 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write an empty (self-closing) tag.
-    pub fn write_empty(self) -> Result<&'a mut Writer<W>> {
+    pub fn write_empty(self) -> Result<&'wr mut Writer<W>> {
         self.writer.write_event(Event::Empty(self.start_tag))?;
         Ok(self.writer)
     }
 
     /// Create a new scope for writing XML inside the current element.
-    pub fn write_inner_content<F>(mut self, closure: F) -> Result<&'a mut Writer<W>>
+    pub fn write_inner_content<F>(mut self, closure: F) -> Result<&'wr mut Writer<W>>
     where
         F: Fn(&mut Writer<W>) -> Result<()>,
     {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -228,9 +228,9 @@ pub struct ElementWriter<'wr, W: Write> {
 
 impl<'wr, W: Write> ElementWriter<'wr, W> {
     /// Adds an attribute to this element.
-    pub fn with_attribute<'b, I>(mut self, attr: I) -> Self
+    pub fn with_attribute<'a, I>(mut self, attr: I) -> Self
     where
-        I: Into<Attribute<'b>>,
+        I: Into<Attribute<'a>>,
     {
         self.start_tag.push_attribute(attr);
         self
@@ -241,10 +241,10 @@ impl<'wr, W: Write> ElementWriter<'wr, W> {
     /// The yielded items must be convertible to [`Attribute`] using `Into`.
     ///
     /// [`Attribute`]: attributes/struct.Attributes.html
-    pub fn with_attributes<'b, I>(mut self, attributes: I) -> Self
+    pub fn with_attributes<'a, I>(mut self, attributes: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Into<Attribute<'b>>,
+        I::Item: Into<Attribute<'a>>,
     {
         self.start_tag.extend_attributes(attributes);
         self

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -37,14 +37,14 @@ fn test_attributes_empty() {
             let mut atts = e.attributes();
             match atts.next() {
                 Some(Ok(Attribute {
-                    key: b"att1",
+                    key: Cow::Borrowed(b"att1"),
                     value: Cow::Borrowed(b"a"),
                 })) => (),
                 e => panic!("Expecting att1='a' attribute, found {:?}", e),
             }
             match atts.next() {
                 Some(Ok(Attribute {
-                    key: b"att2",
+                    key: Cow::Borrowed(b"att2"),
                     value: Cow::Borrowed(b"b"),
                 })) => (),
                 e => panic!("Expecting att2='b' attribute, found {:?}", e),
@@ -69,7 +69,7 @@ fn test_attribute_equal() {
             let mut atts = e.attributes();
             match atts.next() {
                 Some(Ok(Attribute {
-                    key: b"att1",
+                    key: Cow::Borrowed(b"att1"),
                     value: Cow::Borrowed(b"a=b"),
                 })) => (),
                 e => panic!("Expecting att1=\"a=b\" attribute, found {:?}", e),
@@ -120,8 +120,12 @@ fn test_attributes_empty_ns() {
         .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
         // we don't care about xmlns attributes for this test
         .filter(|kv| !kv.key.starts_with(b"xmlns"))
-        .map(|Attribute { key: name, value }| {
-            let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+        .map(|Attribute { key, value }| {
+            let name = match key {
+                Cow::Borrowed(k) => k,
+                _ => panic!("should be borrowed"),
+            };
+            let (opt_ns, local_name) = r.attribute_namespace(&name, &ns_buf);
             (opt_ns, local_name, value)
         });
     match atts.next() {
@@ -165,8 +169,12 @@ fn test_attributes_empty_ns_expanded() {
             .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
             // we don't care about xmlns attributes for this test
             .filter(|kv| !kv.key.starts_with(b"xmlns"))
-            .map(|Attribute { key: name, value }| {
-                let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+            .map(|Attribute { key, value }| {
+                let name = match key {
+                    Cow::Borrowed(k) => k,
+                    _ => panic!("should be borrowed"),
+                };
+                let (opt_ns, local_name) = r.attribute_namespace(&name, &ns_buf);
                 (opt_ns, local_name, value)
             });
         match atts.next() {
@@ -230,8 +238,12 @@ fn test_default_ns_shadowing_empty() {
             .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
             // we don't care about xmlns attributes for this test
             .filter(|kv| !kv.key.starts_with(b"xmlns"))
-            .map(|Attribute { key: name, value }| {
-                let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+            .map(|Attribute { key, value }| {
+                let name = match key {
+                    Cow::Borrowed(k) => k,
+                    _ => panic!("should be borrowed"),
+                };
+                let (opt_ns, local_name) = r.attribute_namespace(&name, &ns_buf);
                 (opt_ns, local_name, value)
             });
         // the attribute should _not_ have a namespace name. The default namespace does not
@@ -292,8 +304,12 @@ fn test_default_ns_shadowing_expanded() {
             .map(|ar| ar.expect("Expecting attribute parsing to succeed."))
             // we don't care about xmlns attributes for this test
             .filter(|kv| !kv.key.starts_with(b"xmlns"))
-            .map(|Attribute { key: name, value }| {
-                let (opt_ns, local_name) = r.attribute_namespace(name, &ns_buf);
+            .map(|Attribute { key, value }| {
+                let name = match key {
+                    Cow::Borrowed(k) => k,
+                    _ => panic!("should be borrowed"),
+                };
+                let (opt_ns, local_name) = r.attribute_namespace(&name, &ns_buf);
                 (opt_ns, local_name, value)
             });
         // the attribute should _not_ have a namespace name. The default namespace does not

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -336,7 +336,9 @@ fn test_write_attrs() -> Result<()> {
     }
 
     let result = writer.into_inner().into_inner();
-    assert_eq!(result, expected.as_bytes());
+    assert_eq!(result, expected.as_bytes(),
+        "{} != {}", from_utf8(&result).unwrap(), from_utf8(expected.as_bytes()).unwrap(),
+    );
 
     Ok(())
 }

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -432,7 +432,7 @@ fn make_attrs(e: &BytesStart) -> ::std::result::Result<String, String> {
                 if a.key.len() < 5 || !a.key.starts_with(b"xmlns") {
                     atts.push(format!(
                         "{}=\"{}\"",
-                        from_utf8(a.key).unwrap(),
+                        from_utf8(&a.key).unwrap(),
                         from_utf8(&*a.unescaped_value().unwrap()).unwrap()
                     ));
                 }


### PR DESCRIPTION
Closes https://github.com/tafia/quick-xml/issues/332.

Based on other MRs, only last 2 commits are relevant here. Can be rebased if needed.

This implementation unfortunately means a bit more allocations in the case of data that needed unescaping or decoding or so, but I think in general it's ok. It allows to get attributes that borrow into the underlying input slice.

I'm thinking about how we could use the Bytes crate to optimize these allocations. I'm not sure if having an extra `BufferedInput` impl for Bytes would be enough. You can't `Cow` a `Bytes` unfortunately. So I think it'd need some kind of other construction.