### PR TITLE
Fix an error in reading `<!doctype >` definition from `&[u8]` (in lower case)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
   from the attribute and element names and attribute values
 - fix: allow to deserialize `unit`s from text and CDATA content.
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
+- fix: allow lowercase `<!doctype >` definition (used in HTML 5) when parse document from `&[u8]`
 
 ## 0.23.0-alpha3
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1280,7 +1280,7 @@ impl<'a> BufferedInput<'a, 'a, ()> for &'a [u8] {
         let bang_type = match &self[1..].first() {
             Some(b'[') => BangType::CData,
             Some(b'-') => BangType::Comment,
-            Some(b'D') => BangType::DocType,
+            Some(b'D') | Some(b'd') => BangType::DocType,
             Some(_) => return Err(Error::UnexpectedBang),
             None => return Err(Error::UnexpectedEof("Bang".to_string())),
         };


### PR DESCRIPTION
Bug was since merging 8d3cf19df74f143a15822a5723cb5bd361fb4310 (zero-copy parsing)
Lowercased `doctype` was introduced in 3c3a82cdae6db29003e065dc368e7e62a28286f4 (html5 support)