### PR TITLE
Added '$struct' tag to identify structs in newtype enum variants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ fn crates_io() -> Result<Html, DeError> {
 
 ### Credits
 
-This has largely been inspired by [serde-xml-rs](https://github.com/RReverser/serde-xml-rs). 
-quick-xml follows its convention for deserialization, including the 
+This has largely been inspired by [serde-xml-rs](https://github.com/RReverser/serde-xml-rs).
+quick-xml follows its convention for deserialization, including the
 [`$value`](https://github.com/RReverser/serde-xml-rs#parsing-the-value-of-a-tag) special name.
 
 ### Parsing the "value" of a tag
@@ -259,6 +259,25 @@ struct Root {
 ```
 
 Serializing `Root { foo: Foo::Bar }` will then yield `<Root foo="Bar"/>` instead of `<Root><Bar/></Root>`.
+
+### Serializing newtype variants
+The `$struct` tag is an experimental feature that allows serializing newtype variants where the newtype is a struct.
+Please note that this feature will only work for serialization, therefore serde rename should be called only for serialize, unlike in the other features described before.
+See here:
+
+```rust, ignore
+struct Foo {
+    a: String
+}
+
+enum Bar {
+    #[serde(rename(serialize = "$struct"))]
+    x(Foo)
+}
+```
+
+This is only necessary for structs passed in newtype variants.
+In the case of struct variants or when the newtype is a primitive adding this tag should be avoided.
 
 ### Performance
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -127,8 +127,10 @@ use std::borrow::Cow;
 use std::io::BufRead;
 
 pub(crate) const INNER_VALUE: &str = "$value";
+pub(crate) const STRUCT_TAG: &str = "$struct";
 pub(crate) const UNFLATTEN_PREFIX: &str = "$unflatten=";
 pub(crate) const PRIMITIVE_PREFIX: &str = "$primitive=";
+pub(crate) const DOCUMENT_PREFIX: &str = "$root=";
 
 /// Simplified event which contains only these variants that used by deserializer
 #[derive(Debug, PartialEq)]

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -262,7 +262,13 @@ impl<'r, 'w, W: Write> ser::Serializer for &'w mut Serializer<'r, W> {
         // (`variant`), we need to clear root tag before writing content and restore
         // it after
         let root = self.root_tag.take();
-        let result = self.write_paired(variant, value);
+        let result;
+        if variant == "$struct" {
+            result = value.serialize(&mut *self);
+        }
+        else {
+            result = self.write_paired(variant, value)
+        }
         self.root_tag = root;
         result
     }


### PR DESCRIPTION
Trying out the serialization options included in quick-xml I came across an issue with the serialization of newtype variants in enums, where structs would have duplicated nodes when serialized. This relates to open issues like #183 and #346.

I believe there might be a better way to do this, but a very basic concept I came up with is to simply mark which enum variants contain a struct, and then skip adding an extra node for such variant.

This makes it for me for now, and maybe some others could benefit from it until we find the right way to do it.
I would like to look into an automatic way of doing this if someone has any ideas of how I could detect automatically if the given newvariant is a struct.

Let me know what you think, any feedback is welcome :)