### PR TITLE
Add tests for `BufferedInput` and fix couple of bugs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,9 @@
 - fix: allow to deserialize `unit`s from text and CDATA content.
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
 - fix: allow lowercase `<!doctype >` definition (used in HTML 5) when parse document from `&[u8]`
+  ([#357](https://github.com/tafia/quick-xml/pull/357))
+- test: add tests for consistence behavior of buffered and borrowed readers
+  ([#367](https://github.com/tafia/quick-xml/pull/367))
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@
   ([#357](https://github.com/tafia/quick-xml/pull/357))
 - test: add tests for consistence behavior of buffered and borrowed readers
   ([#367](https://github.com/tafia/quick-xml/pull/367))
+- fix: produce consistent error positions in buffered and borrowed readers
+  ([#367](https://github.com/tafia/quick-xml/pull/367))
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,8 @@
   ([#367](https://github.com/tafia/quick-xml/pull/367))
 - refactor: unify code for buffered and borrowed readers
   ([#367](https://github.com/tafia/quick-xml/pull/367))
+- fix: fix internal panic message when parse malformed XML
+  ([#344](https://github.com/tafia/quick-xml/issues/344), [#367](https://github.com/tafia/quick-xml/pull/367))
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
   from the attribute and element names and attribute values
 - fix: allow to deserialize `unit`s from text and CDATA content.
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
+- fix: allow lowercase `<!doctype >` definition (used in HTML 5) when parse document from `&[u8]`
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,8 @@
   ([#367](https://github.com/tafia/quick-xml/pull/367))
 - fix: produce consistent error positions in buffered and borrowed readers
   ([#367](https://github.com/tafia/quick-xml/pull/367))
+- refactor: unify code for buffered and borrowed readers
+  ([#367](https://github.com/tafia/quick-xml/pull/367))
 
 ## 0.23.0-alpha3
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,7 +22,7 @@ pub enum Error {
     /// Unexpected token
     UnexpectedToken(String),
     /// Unexpected <!>
-    UnexpectedBang,
+    UnexpectedBang(u8),
     /// Text not found, expected `Event::Text`
     TextNotFound,
     /// `Event::XmlDecl` must start with *version* attribute
@@ -78,9 +78,10 @@ impl std::fmt::Display for Error {
                 write!(f, "Expecting </{}> found </{}>", expected, found)
             }
             Error::UnexpectedToken(e) => write!(f, "Unexpected token '{}'", e),
-            Error::UnexpectedBang => write!(
+            Error::UnexpectedBang(b) => write!(
                 f,
-                "Only Comment, CDATA and DOCTYPE nodes can start with a '!'"
+                "Only Comment (`--`), CDATA (`[CDATA[`) and DOCTYPE (`DOCTYPE`) nodes can start with a '!', but symbol `{}` found",
+                *b as char
             ),
             Error::TextNotFound => write!(f, "Cannot read text, expecting Event::Text"),
             Error::XmlDeclWithoutVersion(e) => write!(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1154,7 +1154,6 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
 
                 let mut find = |end_byte| -> usize {
                     let mut memiter = memchr::memchr3_iter(end_byte, b'\'', b'"', available);
-                    let used: usize;
                     loop {
                         match memiter.next() {
                             Some(i) => {
@@ -1163,8 +1162,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                                         // only allowed to match `end_byte` while we are in state `Elem`
                                         buf.extend_from_slice(&available[..i]);
                                         done = true;
-                                        used = i + 1;
-                                        break;
+                                        return i + 1;
                                     }
                                     (State::Elem, b'\'') => State::SingleQ,
                                     (State::Elem, b'\"') => State::DoubleQ,
@@ -1178,12 +1176,10 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                             }
                             None => {
                                 buf.extend_from_slice(available);
-                                used = available.len();
-                                break;
+                                return available.len();
                             }
                         }
                     }
-                    used
                 };
                 find(b'>')
             };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1378,7 +1378,7 @@ impl BangType {
             Some(b'[') => Self::CData,
             Some(b'-') => Self::Comment,
             Some(b'D') | Some(b'd') => Self::DocType,
-            Some(_) => return Err(Error::UnexpectedBang),
+            Some(b) => return Err(Error::UnexpectedBang(b)),
             None => return Err(Error::UnexpectedEof("Bang".to_string())),
         })
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1153,29 +1153,23 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                 };
 
                 let mut find = |end_byte| -> usize {
-                    let mut memiter = memchr::memchr3_iter(end_byte, b'\'', b'"', available);
-                    loop {
-                        match memiter.next() {
-                            Some(i) => {
-                                state = match (state, available[i]) {
-                                    (State::Elem, b) if b == end_byte => {
-                                        // only allowed to match `end_byte` while we are in state `Elem`
-                                        buf.extend_from_slice(&available[..i]);
-                                        done = true;
-                                        return i + 1;
-                                    }
-                                    (State::Elem, b'\'') => State::SingleQ,
-                                    (State::Elem, b'\"') => State::DoubleQ,
-
-                                    // the only end_byte that gets us out if the same character
-                                    (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
-
-                                    // all other bytes: no state change
-                                    _ => state,
-                                };
+                    for i in memchr::memchr3_iter(end_byte, b'\'', b'"', available) {
+                        state = match (state, available[i]) {
+                            (State::Elem, b) if b == end_byte => {
+                                // only allowed to match `end_byte` while we are in state `Elem`
+                                buf.extend_from_slice(&available[..i]);
+                                done = true;
+                                return i + 1;
                             }
-                            None => break,
-                        }
+                            (State::Elem, b'\'') => State::SingleQ,
+                            (State::Elem, b'\"') => State::DoubleQ,
+
+                            // the only end_byte that gets us out if the same character
+                            (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
+
+                            // all other bytes: no state change
+                            _ => state,
+                        };
                     }
                     buf.extend_from_slice(available);
                     return available.len();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1280,7 +1280,7 @@ impl<'a> BufferedInput<'a, 'a, ()> for &'a [u8] {
         let bang_type = match &self[1..].first() {
             Some(b'[') => BangType::CData,
             Some(b'-') => BangType::Comment,
-            Some(b'D') => BangType::DocType,
+            Some(b'D') | Some(b'd') => BangType::DocType,
             Some(_) => return Err(Error::UnexpectedBang),
             None => return Err(Error::UnexpectedEof("Bang".to_string())),
         };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1129,6 +1129,27 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
             /// Inside a double-quoted attribute value
             DoubleQ,
         }
+        impl State {
+            fn find<'b>(&mut self, end_byte: u8, bytes: &'b [u8]) -> Option<(&'b [u8], usize)> {
+                for i in memchr::memchr3_iter(end_byte, b'\'', b'"', bytes) {
+                    *self = match (*self, bytes[i]) {
+                        (State::Elem, b) if b == end_byte => {
+                            // only allowed to match `end_byte` while we are in state `Elem`
+                            return Some((&bytes[..i], i + 1));
+                        }
+                        (State::Elem, b'\'') => State::SingleQ,
+                        (State::Elem, b'\"') => State::DoubleQ,
+
+                        // the only end_byte that gets us out if the same character
+                        (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
+
+                        // all other bytes: no state change
+                        _ => *self,
+                    };
+                }
+                None
+            }
+        }
         let mut state = State::Elem;
         let mut read = 0;
         let mut done = false;
@@ -1152,26 +1173,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                     }
                 };
 
-                let mut find = |end_byte, bytes| -> Option<(&[u8], usize)> {
-                    for i in memchr::memchr3_iter(end_byte, b'\'', b'"', bytes) {
-                        state = match (state, bytes[i]) {
-                            (State::Elem, b) if b == end_byte => {
-                                // only allowed to match `end_byte` while we are in state `Elem`
-                                return Some((&bytes[..i], i + 1));
-                            }
-                            (State::Elem, b'\'') => State::SingleQ,
-                            (State::Elem, b'\"') => State::DoubleQ,
-
-                            // the only end_byte that gets us out if the same character
-                            (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
-
-                            // all other bytes: no state change
-                            _ => state,
-                        };
-                    }
-                    None
-                };
-                if let Some((consumed, used)) = find(b'>', available) {
+                if let Some((consumed, used)) = state.find(b'>', available) {
                     done = true;
                     buf.extend_from_slice(consumed);
                     used

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1126,30 +1126,28 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
 
         let start = buf.len();
         while !done {
-            let used = {
-                let available = match self.fill_buf() {
-                    Ok(n) if n.is_empty() => {
-                        if read == 0 {
-                            return Ok(None);
-                        } else {
-                            return Ok(Some(&buf[start..]));
-                        }
+            let used = match self.fill_buf() {
+                Ok(n) if n.is_empty() => {
+                    if read == 0 {
+                        return Ok(None);
+                    } else {
+                        return Ok(Some(&buf[start..]));
                     }
-                    Ok(n) => n,
-                    Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                    Err(e) => {
-                        *position += read;
-                        return Err(Error::Io(e));
+                }
+                Ok(available) => {
+                    if let Some((consumed, used)) = state.change(available) {
+                        done = true;
+                        buf.extend_from_slice(consumed);
+                        used
+                    } else {
+                        buf.extend_from_slice(available);
+                        available.len()
                     }
-                };
-
-                if let Some((consumed, used)) = state.change(available) {
-                    done = true;
-                    buf.extend_from_slice(consumed);
-                    used
-                } else {
-                    buf.extend_from_slice(available);
-                    available.len()
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    *position += read;
+                    return Err(Error::Io(e));
                 }
             };
             self.consume(used);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1053,16 +1053,9 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
 
         loop {
             let available = match self.fill_buf() {
-                Ok(n) if n.is_empty() => {
-                    // Note: Do not update position, so the error points to
-                    // somewhere sane rather than at the EOF
-                    let bang_str = match bang_type {
-                        BangType::CData => "CData",
-                        BangType::Comment => "Comment",
-                        BangType::DocType => "DOCTYPE",
-                    };
-                    return Err(Error::UnexpectedEof(bang_str.to_string()));
-                }
+                // Note: Do not update position, so the error points to
+                // somewhere sane rather than at the EOF
+                Ok(n) if n.is_empty() => return Err(bang_type.to_err()),
                 Ok(n) => n,
                 Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
                 Err(e) => {
@@ -1291,12 +1284,7 @@ impl<'a> BufferedInput<'a, 'a, ()> for &'a [u8] {
 
         // Note: Do not update position, so the error points to
         // somewhere sane rather than at the EOF
-        let bang_str = match bang_type {
-            BangType::CData => "CData",
-            BangType::Comment => "Comment",
-            BangType::DocType => "DOCTYPE",
-        };
-        Err(Error::UnexpectedEof(bang_str.to_string()))
+        Err(bang_type.to_err())
     }
 
     fn read_element(&mut self, _buf: (), position: &mut usize) -> Result<Option<&'a [u8]>> {
@@ -1415,6 +1403,15 @@ impl BangType {
                     == 0
             }
         }
+    }
+    #[inline]
+    fn to_err(self) -> Error {
+        let bang_str = match self {
+            Self::CData => "CData",
+            Self::Comment => "Comment",
+            Self::DocType => "DOCTYPE",
+        };
+        Error::UnexpectedEof(bang_str.to_string())
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1126,13 +1126,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
         let start = buf.len();
         loop {
             match self.fill_buf() {
-                Ok(n) if n.is_empty() => {
-                    if read == 0 {
-                        return Ok(None);
-                    } else {
-                        return Ok(Some(&buf[start..]));
-                    }
-                }
+                Ok(n) if n.is_empty() => break,
                 Ok(available) => {
                     if let Some((consumed, used)) = state.change(available) {
                         buf.extend_from_slice(consumed);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1135,12 +1135,12 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                 for i in memchr::memchr3_iter(b'>', b'\'', b'"', bytes) {
                     *self = match (*self, bytes[i]) {
                         // only allowed to match `>` while we are in state `Elem`
-                        (State::Elem, b'>') => return Some((&bytes[..i], i + 1)),
-                        (State::Elem, b'\'') => State::SingleQ,
-                        (State::Elem, b'\"') => State::DoubleQ,
+                        (Self::Elem, b'>') => return Some((&bytes[..i], i + 1)),
+                        (Self::Elem, b'\'') => Self::SingleQ,
+                        (Self::Elem, b'\"') => Self::DoubleQ,
 
                         // the only end_byte that gets us out if the same character
-                        (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
+                        (Self::SingleQ, b'\'') | (Self::DoubleQ, b'\"') => Self::Elem,
 
                         // all other bytes: no state change
                         _ => *self,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1063,6 +1063,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                         self.consume(used);
                         read += used;
 
+                        *position += read;
                         break;
                     } else {
                         buf.extend_from_slice(available);
@@ -1079,7 +1080,6 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                 }
             }
         }
-        *position += read;
 
         if read == 0 {
             Ok(None)

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1132,7 +1132,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
         let mut state = State::Elem;
         let mut read = 0;
         let mut done = false;
-        let end_byte = b'>';
+
         let start = buf.len();
         while !done {
             let used = {
@@ -1152,37 +1152,40 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                     }
                 };
 
-                let mut memiter = memchr::memchr3_iter(end_byte, b'\'', b'"', available);
-                let used: usize;
-                loop {
-                    match memiter.next() {
-                        Some(i) => {
-                            state = match (state, available[i]) {
-                                (State::Elem, b) if b == end_byte => {
-                                    // only allowed to match `end_byte` while we are in state `Elem`
-                                    buf.extend_from_slice(&available[..i]);
-                                    done = true;
-                                    used = i + 1;
-                                    break;
-                                }
-                                (State::Elem, b'\'') => State::SingleQ,
-                                (State::Elem, b'\"') => State::DoubleQ,
+                let mut find = |end_byte| -> usize {
+                    let mut memiter = memchr::memchr3_iter(end_byte, b'\'', b'"', available);
+                    let used: usize;
+                    loop {
+                        match memiter.next() {
+                            Some(i) => {
+                                state = match (state, available[i]) {
+                                    (State::Elem, b) if b == end_byte => {
+                                        // only allowed to match `end_byte` while we are in state `Elem`
+                                        buf.extend_from_slice(&available[..i]);
+                                        done = true;
+                                        used = i + 1;
+                                        break;
+                                    }
+                                    (State::Elem, b'\'') => State::SingleQ,
+                                    (State::Elem, b'\"') => State::DoubleQ,
 
-                                // the only end_byte that gets us out if the same character
-                                (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
+                                    // the only end_byte that gets us out if the same character
+                                    (State::SingleQ, b'\'') | (State::DoubleQ, b'\"') => State::Elem,
 
-                                // all other bytes: no state change
-                                _ => state,
-                            };
-                        }
-                        None => {
-                            buf.extend_from_slice(available);
-                            used = available.len();
-                            break;
+                                    // all other bytes: no state change
+                                    _ => state,
+                                };
+                            }
+                            None => {
+                                buf.extend_from_slice(available);
+                                used = available.len();
+                                break;
+                            }
                         }
                     }
-                }
-                used
+                    used
+                };
+                find(b'>')
             };
             self.consume(used);
             read += used;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1152,12 +1152,12 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                     }
                 };
 
-                let mut find = |end_byte| -> Option<(&[u8], usize)> {
-                    for i in memchr::memchr3_iter(end_byte, b'\'', b'"', available) {
-                        state = match (state, available[i]) {
+                let mut find = |end_byte, bytes| -> Option<(&[u8], usize)> {
+                    for i in memchr::memchr3_iter(end_byte, b'\'', b'"', bytes) {
+                        state = match (state, bytes[i]) {
                             (State::Elem, b) if b == end_byte => {
                                 // only allowed to match `end_byte` while we are in state `Elem`
-                                return Some((&available[..i], i + 1));
+                                return Some((&bytes[..i], i + 1));
                             }
                             (State::Elem, b'\'') => State::SingleQ,
                             (State::Elem, b'\"') => State::DoubleQ,
@@ -1171,7 +1171,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                     }
                     None
                 };
-                if let Some((consumed, used)) = find(b'>') {
+                if let Some((consumed, used)) = find(b'>', available) {
                     done = true;
                     buf.extend_from_slice(consumed);
                     used

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1174,12 +1174,11 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                                     _ => state,
                                 };
                             }
-                            None => {
-                                buf.extend_from_slice(available);
-                                return available.len();
-                            }
+                            None => break,
                         }
                     }
+                    buf.extend_from_slice(available);
+                    return available.len();
                 };
                 find(b'>')
             };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -360,21 +360,19 @@ impl<R: BufRead> Reader<R> {
                 if let Some(p) =
                     memchr::memchr_iter(b'-', &buf[3..len - 2]).position(|p| buf[3 + p + 1] == b'-')
                 {
-                    self.buf_position += buf.len() - p;
+                    self.buf_position += len - p;
                     return Err(Error::UnexpectedToken("--".to_string()));
                 }
             }
             Ok(Event::Comment(BytesText::from_escaped(&buf[3..len - 2])))
         } else if uncased_starts_with(buf, b"![CDATA[") {
-            debug_assert!(len >= 10, "Minimum length guaranteed by read_bang_element");
-            Ok(Event::CData(BytesText::from_plain(&buf[8..buf.len() - 2])))
+            Ok(Event::CData(BytesText::from_plain(&buf[8..])))
         } else if uncased_starts_with(buf, b"!DOCTYPE") {
-            debug_assert!(len >= 8, "Minimum length guaranteed by read_bang_element");
             let start = buf[8..]
                 .iter()
                 .position(|b| !is_whitespace(*b))
-                .unwrap_or_else(|| buf.len() - 8);
-            debug_assert!(start < buf.len() - 8, "DocType must have a name");
+                .unwrap_or_else(|| len - 8);
+            debug_assert!(start < len - 8, "DocType must have a name");
             Ok(Event::DocType(BytesText::from_escaped(&buf[8 + start..])))
         } else {
             unreachable!("Proper bang start guaranteed by read_bang_element");
@@ -1372,35 +1370,38 @@ impl BangType {
         })
     }
 
-    /// Checks that element is finished
-    ///
-    /// # Parameters
-    /// - `buf`: data from the `!` symbol
-    /// - `index`: position of the `>` symbol
-    #[inline(always)]
-    fn check_finished(&self, buf: &[u8], index: usize) -> bool {
-        match self {
-            // Need to read at least 6 symbols (`!---->`) for properly finished comment
-            // <!----> - XML comment
-            //  012345 - index
-            Self::Comment => index > 5 && buf.ends_with(b"--"),
-            Self::CData => buf.ends_with(b"]]"),
-            Self::DocType => {
-                memchr::memchr2_iter(b'<', b'>', buf)
-                    .map(|p| if buf[p] == b'<' { 1i32 } else { -1 })
-                    .sum::<i32>()
-                    == 0
-            }
-        }
-    }
     /// If element is finished, returns its content up to `>` symbol and
     /// an index of this symbol, otherwise returns `None`
     #[inline(always)]
     fn parse<'b>(&self, chunk: &'b [u8], offset: usize) -> Option<(&'b [u8], usize)> {
         for i in memchr::memchr_iter(b'>', chunk) {
-            let result = &chunk[..i];
-            if self.check_finished(result, i + 1 + offset) {
-                return Some((result, i + 1)); // +1 for `>`
+            match self {
+                // Need to read at least 6 symbols (`!---->`) for properly finished comment
+                // <!----> - XML comment
+                //  012345 - i
+                Self::Comment => {
+                    if offset + i > 4 && chunk[..i].ends_with(b"--") {
+                        // We cannot strip last `--` from the buffer because we need it in case of
+                        // check_comments enabled option. XML standard requires that comment
+                        // will not end with `--->` sequence because this is a special case of
+                        // `--` in the comment (https://www.w3.org/TR/xml11/#sec-comments)
+                        return Some((&chunk[..i], i + 1)); // +1 for `>`
+                    }
+                }
+                Self::CData => {
+                    if chunk[..i].ends_with(b"]]") {
+                        return Some((&chunk[..i - 2], i + 1)); // +1 for `>`
+                    }
+                }
+                Self::DocType => {
+                    let content = &chunk[..i];
+                    let balance = memchr::memchr2_iter(b'<', b'>', content)
+                        .map(|p| if content[p] == b'<' { 1i32 } else { -1 })
+                        .sum::<i32>();
+                    if balance == 0 {
+                        return Some((content, i + 1)); // +1 for `>`
+                    }
+                }
             }
         }
         None
@@ -1772,7 +1773,7 @@ mod test {
 
                         assert_eq!(
                             input.read_bang_element(buf, &mut position).unwrap(),
-                            Some(b"![CDATA[]]".as_ref())
+                            Some(b"![CDATA[".as_ref())
                         );
                         assert_eq!(position, 11);
                     }
@@ -1789,7 +1790,7 @@ mod test {
 
                         assert_eq!(
                             input.read_bang_element(buf, &mut position).unwrap(),
-                            Some(b"![CDATA[cdata]] ]>content]]".as_ref())
+                            Some(b"![CDATA[cdata]] ]>content".as_ref())
                         );
                         assert_eq!(position, 28);
                     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1122,10 +1122,9 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
     ) -> Result<Option<&'b [u8]>> {
         let mut state = ReadElementState::Elem;
         let mut read = 0;
-        let mut done = false;
 
         let start = buf.len();
-        while !done {
+        loop {
             match self.fill_buf() {
                 Ok(n) if n.is_empty() => {
                     if read == 0 {
@@ -1136,11 +1135,11 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                 }
                 Ok(available) => {
                     if let Some((consumed, used)) = state.change(available) {
-                        done = true;
                         buf.extend_from_slice(consumed);
 
                         self.consume(used);
                         read += used;
+                        break;
                     } else {
                         buf.extend_from_slice(available);
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -354,7 +354,7 @@ impl<R: BufRead> Reader<R> {
         let len = buf.len();
         if buf.starts_with(b"!--") {
             // FIXME: actually, isn't, it misses <!-->
-            debug_assert!(len >= 5, "Minimum length guaranteed by read_bang_elem");
+            debug_assert!(len >= 5, "Minimum length guaranteed by read_bang_element");
             if self.check_comments {
                 // search if '--' not in comments
                 if let Some(p) =
@@ -366,10 +366,10 @@ impl<R: BufRead> Reader<R> {
             }
             Ok(Event::Comment(BytesText::from_escaped(&buf[3..len - 2])))
         } else if uncased_starts_with(buf, b"![CDATA[") {
-            debug_assert!(len >= 10, "Minimum length guaranteed by read_bang_elem");
+            debug_assert!(len >= 10, "Minimum length guaranteed by read_bang_element");
             Ok(Event::CData(BytesText::from_plain(&buf[8..buf.len() - 2])))
         } else if uncased_starts_with(buf, b"!DOCTYPE") {
-            debug_assert!(len >= 8, "Minimum length guaranteed by read_bang_elem");
+            debug_assert!(len >= 8, "Minimum length guaranteed by read_bang_element");
             let start = buf[8..]
                 .iter()
                 .position(|b| !is_whitespace(*b))
@@ -377,7 +377,7 @@ impl<R: BufRead> Reader<R> {
             debug_assert!(start < buf.len() - 8, "DocType must have a name");
             Ok(Event::DocType(BytesText::from_escaped(&buf[8 + start..])))
         } else {
-            unreachable!("Proper bang start guaranteed by read_bang_elem");
+            unreachable!("Proper bang start guaranteed by read_bang_element");
         }
     }
 
@@ -960,6 +960,21 @@ where
         position: &mut usize,
     ) -> Result<Option<&'r [u8]>>;
 
+    /// Read input until comment, CDATA or processing instruction is finished.
+    ///
+    /// This method expect that `<` already was read.
+    ///
+    /// Returns a slice of data read up to end of comment, CDATA or processing
+    /// instruction (`>`), which does not include into result.
+    ///
+    /// If input (`Self`) is exhausted and nothing was read, returns `None`.
+    ///
+    /// # Parameters
+    /// - `buf`: Buffer that could be filled from an input (`Self`) and
+    ///   from which [events] could borrow their data
+    /// - `position`: Will be increased by amount of bytes consumed
+    ///
+    /// [events]: crate::events::Event
     fn read_bang_element(&mut self, buf: B, position: &mut usize) -> Result<Option<&'r [u8]>>;
 
     fn read_element(&mut self, buf: B, position: &mut usize) -> Result<Option<&'r [u8]>>;
@@ -1707,6 +1722,376 @@ mod test {
                         Some(b"abcdef".as_ref())
                     );
                     assert_eq!(position, 7); // position after the symbol matched
+                }
+            }
+
+            mod read_bang_element {
+                /// Checks that reading CDATA content works correctly
+                mod cdata {
+                    use crate::errors::Error;
+                    use crate::reader::BufferedInput;
+
+                    /// Checks that if input begins like CDATA element, but CDATA start sequence
+                    /// is not finished, parsing ends with an error
+                    #[test]
+                    #[ignore = "start CDATA sequence fully checked outside of `read_bang_element`"]
+                    fn not_properly_start() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"![]]>other content".as_ref();
+                        //                ^= 0
+
+                        match input.read_bang_element(buf, &mut position) {
+                            Err(Error::UnexpectedEof(s)) if s == "CData" => {}
+                            x => assert!(
+                                false,
+                                r#"Expected `UnexpectedEof("CData")`, but result is: {:?}"#,
+                                x
+                            ),
+                        }
+                        assert_eq!(position, 0);
+                    }
+
+                    /// Checks that if CDATA startup sequence was matched, but an end sequence
+                    /// is not found, parsing ends with an error
+                    #[test]
+                    fn not_closed() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"![CDATA[other content".as_ref();
+                        //                ^= 0
+
+                        match input.read_bang_element(buf, &mut position) {
+                            Err(Error::UnexpectedEof(s)) if s == "CData" => {}
+                            x => assert!(
+                                false,
+                                r#"Expected `UnexpectedEof("CData")`, but result is: {:?}"#,
+                                x
+                            ),
+                        }
+                        assert_eq!(position, 0);
+                    }
+
+                    /// Checks that CDATA element without content inside parsed successfully
+                    #[test]
+                    fn empty() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"![CDATA[]]>other content".as_ref();
+                        //                           ^= 11
+
+                        assert_eq!(
+                            input.read_bang_element(buf, &mut position).unwrap(),
+                            Some(b"![CDATA[]]".as_ref())
+                        );
+                        assert_eq!(position, 11);
+                    }
+
+                    /// Checks that CDATA element with content parsed successfully.
+                    /// Additionally checks that sequences inside CDATA that may look like
+                    /// a CDATA end sequence do not interrupt CDATA parsing
+                    #[test]
+                    fn with_content() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"![CDATA[cdata]] ]>content]]>other content]]>".as_ref();
+                        //                                            ^= 28
+
+                        assert_eq!(
+                            input.read_bang_element(buf, &mut position).unwrap(),
+                            Some(b"![CDATA[cdata]] ]>content]]".as_ref())
+                        );
+                        assert_eq!(position, 28);
+                    }
+                }
+
+                /// Checks that reading XML comments works correctly. According to the [specification],
+                /// comment data can contain any sequence except `--`:
+                ///
+                /// ```peg
+                /// comment = '<--' (!'--' char)* '-->';
+                /// char = [#x1-#x2C]
+                ///      / [#x2E-#xD7FF]
+                ///      / [#xE000-#xFFFD]
+                ///      / [#x10000-#x10FFFF]
+                /// ```
+                ///
+                /// The presence of this limitation, however, is simply a poorly thought out specification
+                /// (maybe for purpose of building of LL(1) XML parser) and quick-xml does not check for
+                /// presence of these sequences by default. This tests allow such content.
+                ///
+                /// [specification]: https://www.w3.org/TR/xml11/#dt-comment
+                mod comment {
+                    use crate::errors::Error;
+                    use crate::reader::BufferedInput;
+
+                    #[test]
+                    #[ignore = "start comment sequence fully checked outside of `read_bang_element`"]
+                    fn not_properly_start() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"!- -->other content".as_ref();
+                        //                ^= 0
+
+                        match input.read_bang_element(buf, &mut position) {
+                            Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
+                            x => assert!(
+                                false,
+                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                                x
+                            ),
+                        }
+                        assert_eq!(position, 0);
+                    }
+
+                    #[test]
+                    fn not_properly_end() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"!->other content".as_ref();
+                        //                ^= 0
+
+                        match input.read_bang_element(buf, &mut position) {
+                            Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
+                            x => assert!(
+                                false,
+                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                                x
+                            ),
+                        }
+                        assert_eq!(position, 0);
+                    }
+
+                    #[test]
+                    fn not_closed1() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"!--other content".as_ref();
+                        //                ^= 0
+
+                        match input.read_bang_element(buf, &mut position) {
+                            Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
+                            x => assert!(
+                                false,
+                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                                x
+                            ),
+                        }
+                        assert_eq!(position, 0);
+                    }
+
+                    #[test]
+                    fn not_closed2() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"!-->other content".as_ref();
+                        //                ^= 0
+
+                        match input.read_bang_element(buf, &mut position) {
+                            Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
+                            x => assert!(
+                                false,
+                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                                x
+                            ),
+                        }
+                        assert_eq!(position, 0);
+                    }
+
+                    #[test]
+                    fn not_closed3() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"!--->other content".as_ref();
+                        //                ^= 0
+
+                        match input.read_bang_element(buf, &mut position) {
+                            Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
+                            x => assert!(
+                                false,
+                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                                x
+                            ),
+                        }
+                        assert_eq!(position, 0);
+                    }
+
+                    #[test]
+                    fn empty() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"!---->other content".as_ref();
+                        //                      ^= 6
+
+                        assert_eq!(
+                            input.read_bang_element(buf, &mut position).unwrap(),
+                            Some(b"!----".as_ref())
+                        );
+                        assert_eq!(position, 6);
+                    }
+
+                    #[test]
+                    fn with_content() {
+                        let buf = $buf;
+                        let mut position = 0;
+                        let mut input = b"!--->comment<--->other content".as_ref();
+                        //                                 ^= 17
+
+                        assert_eq!(
+                            input.read_bang_element(buf, &mut position).unwrap(),
+                            Some(b"!--->comment<---".as_ref())
+                        );
+                        assert_eq!(position, 17);
+                    }
+                }
+
+                /// Checks that reading DOCTYPE definition works correctly
+                mod doctype {
+                    mod uppercase {
+                        use crate::errors::Error;
+                        use crate::reader::BufferedInput;
+
+                        #[test]
+                        fn not_properly_start() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!D other content".as_ref();
+                            //                ^= 0
+
+                            match input.read_bang_element(buf, &mut position) {
+                                Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                                x => assert!(
+                                    false,
+                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                    x
+                                ),
+                            }
+                            assert_eq!(position, 0);
+                        }
+
+                        #[test]
+                        fn without_space() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!DOCTYPEother content".as_ref();
+                            //                ^= 0
+
+                            match input.read_bang_element(buf, &mut position) {
+                                Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                                x => assert!(
+                                    false,
+                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                    x
+                                ),
+                            }
+                            assert_eq!(position, 0);
+                        }
+
+                        #[test]
+                        fn empty() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!DOCTYPE>other content".as_ref();
+                            //                         ^= 9
+
+                            assert_eq!(
+                                input.read_bang_element(buf, &mut position).unwrap(),
+                                Some(b"!DOCTYPE".as_ref())
+                            );
+                            assert_eq!(position, 9);
+                        }
+
+                        #[test]
+                        fn not_closed() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!DOCTYPE other content".as_ref();
+                            //                ^= 0
+
+                            match input.read_bang_element(buf, &mut position) {
+                                Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                                x => assert!(
+                                    false,
+                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                    x
+                                ),
+                            }
+                            assert_eq!(position, 0);
+                        }
+                    }
+
+                    mod lowercase {
+                        use crate::errors::Error;
+                        use crate::reader::BufferedInput;
+
+                        #[test]
+                        fn not_properly_start() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!d other content".as_ref();
+                            //                ^= 0
+
+                            match input.read_bang_element(buf, &mut position) {
+                                Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                                x => assert!(
+                                    false,
+                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                    x
+                                ),
+                            }
+                            assert_eq!(position, 0);
+                        }
+
+                        #[test]
+                        fn without_space() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!doctypeother content".as_ref();
+                            //                ^= 0
+
+                            match input.read_bang_element(buf, &mut position) {
+                                Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                                x => assert!(
+                                    false,
+                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                    x
+                                ),
+                            }
+                            assert_eq!(position, 0);
+                        }
+
+                        #[test]
+                        fn empty() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!doctype>other content".as_ref();
+                            //                         ^= 9
+
+                            assert_eq!(
+                                input.read_bang_element(buf, &mut position).unwrap(),
+                                Some(b"!doctype".as_ref())
+                            );
+                            assert_eq!(position, 9);
+                        }
+
+                        #[test]
+                        fn not_closed() {
+                            let buf = $buf;
+                            let mut position = 0;
+                            let mut input = b"!doctype other content".as_ref();
+                            //                ^= 0
+
+                            match input.read_bang_element(buf, &mut position) {
+                                Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                                x => assert!(
+                                    false,
+                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                    x
+                                ),
+                            }
+                            assert_eq!(position, 0);
+                        }
+                    }
                 }
             }
         };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1132,14 +1132,10 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
         impl State {
             #[inline(always)]
             fn change<'b>(&mut self, bytes: &'b [u8]) -> Option<(&'b [u8], usize)> {
-                const END_BYTE: u8 = b'>';
-
-                for i in memchr::memchr3_iter(END_BYTE, b'\'', b'"', bytes) {
+                for i in memchr::memchr3_iter(b'>', b'\'', b'"', bytes) {
                     *self = match (*self, bytes[i]) {
-                        (State::Elem, b) if b == END_BYTE => {
-                            // only allowed to match `end_byte` while we are in state `Elem`
-                            return Some((&bytes[..i], i + 1));
-                        }
+                        // only allowed to match `>` while we are in state `Elem`
+                        (State::Elem, b'>') => return Some((&bytes[..i], i + 1)),
                         (State::Elem, b'\'') => State::SingleQ,
                         (State::Elem, b'\"') => State::DoubleQ,
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1130,10 +1130,13 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
             DoubleQ,
         }
         impl State {
-            fn find<'b>(&mut self, end_byte: u8, bytes: &'b [u8]) -> Option<(&'b [u8], usize)> {
-                for i in memchr::memchr3_iter(end_byte, b'\'', b'"', bytes) {
+            #[inline(always)]
+            fn change<'b>(&mut self, bytes: &'b [u8]) -> Option<(&'b [u8], usize)> {
+                const END_BYTE: u8 = b'>';
+
+                for i in memchr::memchr3_iter(END_BYTE, b'\'', b'"', bytes) {
                     *self = match (*self, bytes[i]) {
-                        (State::Elem, b) if b == end_byte => {
+                        (State::Elem, b) if b == END_BYTE => {
                             // only allowed to match `end_byte` while we are in state `Elem`
                             return Some((&bytes[..i], i + 1));
                         }
@@ -1173,7 +1176,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                     }
                 };
 
-                if let Some((consumed, used)) = state.find(b'>', available) {
+                if let Some((consumed, used)) = state.change(available) {
                     done = true;
                     buf.extend_from_slice(consumed);
                     used

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -64,7 +64,7 @@ enum TagState {
 pub struct Reader<R: BufRead> {
     /// reader
     pub(crate) reader: R,
-    /// current buffer position, useful for debuging errors
+    /// current buffer position, useful for debugging errors
     buf_position: usize,
     /// current state Open/Close
     tag_state: TagState,
@@ -928,6 +928,32 @@ trait BufferedInput<'r, 'i, B>
 where
     Self: 'i,
 {
+    /// Read input until `byte` is found or end of input is reached.
+    ///
+    /// Returns a slice of data read up to `byte`, which does not include into result.
+    /// If input (`Self`) is exhausted, returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let mut position = 0;
+    /// let mut input = b"abc*def".as_ref();
+    /// //                    ^= 4
+    ///
+    /// assert_eq!(
+    ///     input.read_bytes_until(b'*', (), &mut position).unwrap(),
+    ///     Some(b"abc".as_ref())
+    /// );
+    /// assert_eq!(position, 4); // position after the symbol matched
+    /// ```
+    ///
+    /// # Parameters
+    /// - `byte`: Byte for search
+    /// - `buf`: Buffer that could be filled from an input (`Self`) and
+    ///   from which [events] could borrow their data
+    /// - `position`: Will be increased by amount of bytes consumed
+    ///
+    /// [events]: crate::events::Event
     fn read_bytes_until(
         &mut self,
         byte: u8,
@@ -951,8 +977,6 @@ where
 /// Implementation of BufferedInput for any BufRead reader using a user-given
 /// Vec<u8> as buffer that will be borrowed by events.
 impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
-    /// read until `byte` is found or end of file
-    /// return the position of byte
     #[inline]
     fn read_bytes_until(
         &mut self,
@@ -1597,5 +1621,108 @@ impl Decoder {
     #[cfg(feature = "encoding")]
     pub fn decode<'c>(&self, bytes: &'c [u8]) -> Cow<'c, str> {
         self.encoding.decode(bytes).0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    macro_rules! check {
+        ($buf:expr) => {
+            mod read_bytes_until {
+                use crate::reader::BufferedInput;
+
+                /// Checks that search in the empty buffer returns `None`
+                #[test]
+                fn empty() {
+                    let buf = $buf;
+                    let mut position = 0;
+                    let mut input = b"".as_ref();
+                    //                ^= 0
+
+                    assert_eq!(
+                        input.read_bytes_until(b'*', buf, &mut position).unwrap(),
+                        None
+                    );
+                    assert_eq!(position, 0);
+                }
+
+                /// Checks that search in the buffer non-existent value returns entire buffer
+                /// as a result and set `position` to `len()`
+                #[test]
+                fn non_existent() {
+                    let buf = $buf;
+                    let mut position = 0;
+                    let mut input = b"abcdef".as_ref();
+                    //                      ^= 6
+
+                    assert_eq!(
+                        input.read_bytes_until(b'*', buf, &mut position).unwrap(),
+                        Some(b"abcdef".as_ref())
+                    );
+                    assert_eq!(position, 6);
+                }
+
+                /// Checks that search in the buffer an element that is located in the front of
+                /// buffer returns empty slice as a result and set `position` to one symbol
+                /// after match (`1`)
+                #[test]
+                fn at_the_start() {
+                    let buf = $buf;
+                    let mut position = 0;
+                    let mut input = b"*abcdef".as_ref();
+                    //                 ^= 1
+
+                    assert_eq!(
+                        input.read_bytes_until(b'*', buf, &mut position).unwrap(),
+                        Some(b"".as_ref())
+                    );
+                    assert_eq!(position, 1); // position after the symbol matched
+                }
+
+                /// Checks that search in the buffer an element that is located in the middle of
+                /// buffer returns slice before that symbol as a result and set `position` to one
+                /// symbol after match
+                #[test]
+                fn inside() {
+                    let buf = $buf;
+                    let mut position = 0;
+                    let mut input = b"abc*def".as_ref();
+                    //                    ^= 4
+
+                    assert_eq!(
+                        input.read_bytes_until(b'*', buf, &mut position).unwrap(),
+                        Some(b"abc".as_ref())
+                    );
+                    assert_eq!(position, 4); // position after the symbol matched
+                }
+
+                /// Checks that search in the buffer an element that is located in the end of
+                /// buffer returns slice before that symbol as a result and set `position` to one
+                /// symbol after match (`len()`)
+                #[test]
+                fn in_the_end() {
+                    let buf = $buf;
+                    let mut position = 0;
+                    let mut input = b"abcdef*".as_ref();
+                    //                       ^= 7
+
+                    assert_eq!(
+                        input.read_bytes_until(b'*', buf, &mut position).unwrap(),
+                        Some(b"abcdef".as_ref())
+                    );
+                    assert_eq!(position, 7); // position after the symbol matched
+                }
+            }
+        };
+    }
+
+    /// Tests for reader that generates events that borrow from the provided buffer
+    mod buffered {
+        check!(&mut Vec::new());
+    }
+
+    /// Tests for reader that generates events that borrow from the input
+    mod borrowed {
+        check!(());
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1139,6 +1139,8 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
 
                         self.consume(used);
                         read += used;
+
+                        *position += read;
                         break;
                     } else {
                         buf.extend_from_slice(available);
@@ -1155,7 +1157,6 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
                 }
             };
         }
-        *position += read;
 
         if read == 0 {
             Ok(None)

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -255,7 +255,8 @@ impl<R: BufRead> Reader<R> {
         }
     }
 
-    /// private function to read until '>' is found
+    /// Private function to read until `>` is found. This function expects that
+    /// it was called just after encounter a `<` symbol.
     fn read_until_close<'i, 'r, B>(&mut self, buf: B) -> Result<Event<'i>>
     where
         R: BufferedInput<'i, 'r, B>,
@@ -2082,6 +2083,70 @@ mod test {
                             }
                             assert_eq!(position, 0);
                         }
+                    }
+                }
+            }
+
+            mod issue_344 {
+                use crate::errors::Error;
+
+                #[test]
+                fn cdata() {
+                    let doc = "![]]>";
+                    let mut reader = crate::Reader::from_str(doc);
+
+                    match reader.read_until_close($buf) {
+                        Err(Error::UnexpectedEof(s)) if s == "CData" => {}
+                        x => assert!(
+                            false,
+                            r#"Expected `UnexpectedEof("CData")`, but result is: {:?}"#,
+                            x
+                        ),
+                    }
+                }
+
+                #[test]
+                fn comment() {
+                    let doc = "!- -->";
+                    let mut reader = crate::Reader::from_str(doc);
+
+                    match reader.read_until_close($buf) {
+                        Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
+                        x => assert!(
+                            false,
+                            r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                            x
+                        ),
+                    }
+                }
+
+                #[test]
+                fn doctype_uppercase() {
+                    let doc = "!D>";
+                    let mut reader = crate::Reader::from_str(doc);
+
+                    match reader.read_until_close($buf) {
+                        Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                        x => assert!(
+                            false,
+                            r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                            x
+                        ),
+                    }
+                }
+
+                #[test]
+                fn doctype_lowercase() {
+                    let doc = "!d>";
+                    let mut reader = crate::Reader::from_str(doc);
+
+                    match reader.read_until_close($buf) {
+                        Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
+                        x => assert!(
+                            false,
+                            r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                            x
+                        ),
                     }
                 }
             }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1049,22 +1049,7 @@ impl<'b, 'i, R: BufRead + 'i> BufferedInput<'b, 'i, &'b mut Vec<u8>> for R {
         buf.push(b'!');
         self.consume(1);
 
-        enum BangType {
-            // <![CDATA[...]]>
-            CData,
-            // <!--...-->
-            Comment,
-            // <!DOCTYPE...>
-            DocType,
-        }
-
-        let bang_type = match self.peek_one()? {
-            Some(b'[') => BangType::CData,
-            Some(b'-') => BangType::Comment,
-            Some(b'D') | Some(b'd') => BangType::DocType,
-            Some(_) => return Err(Error::UnexpectedBang),
-            None => return Err(Error::UnexpectedEof("Bang".to_string())),
-        };
+        let bang_type = BangType::new(self.peek_one()?)?;
 
         loop {
             let available = match self.fill_buf() {
@@ -1303,22 +1288,7 @@ impl<'a> BufferedInput<'a, 'a, ()> for &'a [u8] {
         // start with it.
         debug_assert_eq!(self[0], b'!');
 
-        enum BangType {
-            // <![CDATA[...]]>
-            CData,
-            // <!--...-->
-            Comment,
-            // <!DOCTYPE...>
-            DocType,
-        }
-
-        let bang_type = match &self[1..].first() {
-            Some(b'[') => BangType::CData,
-            Some(b'-') => BangType::Comment,
-            Some(b'D') | Some(b'd') => BangType::DocType,
-            Some(_) => return Err(Error::UnexpectedBang),
-            None => return Err(Error::UnexpectedEof("Bang".to_string())),
-        };
+        let bang_type = BangType::new(self[1..].first().copied())?;
 
         for i in memchr::memchr_iter(b'>', self) {
             let finished = match bang_type {
@@ -1423,6 +1393,28 @@ impl<'a> BufferedInput<'a, 'a, ()> for &'a [u8] {
 
     fn input_borrowed(event: Event<'a>) -> Event<'a> {
         return event;
+    }
+}
+
+/// Possible elements started with `<!`
+enum BangType {
+    /// <![CDATA[...]]>
+    CData,
+    /// <!--...-->
+    Comment,
+    /// <!DOCTYPE...>
+    DocType,
+}
+impl BangType {
+    #[inline(always)]
+    fn new(byte: Option<u8>) -> Result<Self> {
+        Ok(match byte {
+            Some(b'[') => Self::CData,
+            Some(b'-') => Self::Comment,
+            Some(b'D') | Some(b'd') => Self::DocType,
+            Some(_) => return Err(Error::UnexpectedBang),
+            None => return Err(Error::UnexpectedEof("Bang".to_string())),
+        })
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -91,7 +91,10 @@ fn test_comment_starting_with_gt() {
     let mut buf = Vec::new();
     loop {
         match r.read_event(&mut buf) {
-            Ok(Comment(ref e)) if &**e == b">" => break,
+            Ok(Comment(e)) => {
+                assert_eq!(e.as_ref(), b">");
+                break;
+            }
             Ok(Eof) => panic!("Expecting Comment"),
             _ => (),
         }

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -194,6 +194,17 @@ fn dashes_in_comments() {
         "#,
         true,
     );
+
+    // Canary test for correct comments
+    test(
+        r#"<!-- comment --><hello/>"#,
+        r#"
+        |Comment( comment )
+        |EmptyElement(hello)
+        |EndDocument
+        "#,
+        true,
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR supersedes #357 because it refactors corresponding place.

This PR:
- fixes #344 by replacing panic handler by returning an error because it is possible to get there as not of preconditions is checked in the `BufferedInput` implementations
- closes #334 by removing unused method
- unify some code for parsing from buffered reader and borrowed reader (`&[u8]`)
- add tests that proves that both readers behaves the same way
- as a result of tests fixes positions reported by borrowed reader (I assume that positions from buffered reader are correct because it was introduced earlier)

Number of commits a bit more that I could prefered in the PRs, but most of them are intended to show refactoring process in order to anybody could check that behavior is not changed -- I suppose it is obvious from the commits. Therefore, I recommend review PR by commit basis. Also, each commit in a fully buildable state except 9582fe504abe32ae9de1642b3110315478398efe which is fixed by the following commit and failed by design.