### PR TITLE
Add documentation for mapping from XML to Rust used by deserializer

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -220,8 +220,8 @@
 //! ```ignore
 //! # type T = ();
 //! # type U = ();
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct AnyName {
 //!   #[xml(attribute = "field")]
 //!   attribute: T,
@@ -470,8 +470,8 @@
 //!   One,
 //!   Two,
 //! }
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct AnyName {
 //!   # field: (),
 //!   # /*
@@ -587,8 +587,8 @@
 //! type Item = ...;
 //! # */
 //!
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct AnyName {
 //!   #[xml(flatten)]
 //!   seq: Vec<Item>,
@@ -773,8 +773,8 @@
 //! type One = ...;
 //! type Two = ...;
 //! # */
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct AnyName {
 //! # attribute: (),
 //! # /*
@@ -809,8 +809,8 @@
 //! # */
 //! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct NamedTuple(One, String, String, Two, One);
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct AnyName {
 //! # attribute: (),
 //! # /*
@@ -874,8 +874,8 @@
 //!   #[serde(rename = "$value")]
 //!   Other(String),
 //! }
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct AnyName {
 //! # attribute: (),
 //! # /*
@@ -916,8 +916,8 @@
 //!   #[serde(rename = "$value")]
 //!   Other(String),
 //! }
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! struct AnyName {
 //! # attribute: (),
 //! # /*
@@ -955,11 +955,9 @@
 //!
 //! # Advanced Mapping
 //!
-//! For implementing some specific XML features `quick_xml` provides its own
-//! `Deserialize` derive macro with some useful attributes, that all have
-//! a form `#[xml(...)]`. You should use that derive instead of the `serde`
-//! one. It is just thin wrapper that processes `#[xml(...)]` attributes and
-//! pass all other to the original `serde` derive macro.
+//! For implementing some specific XML features `quick_xml` provides a helper
+//! macro `#[quick_xml::xml]` that, when applied on `struct`s or `enum`s, process
+//! some useful attributes on fields, that all have a form of `#[xml(...)]`.
 //!
 //! Because `serde` has no interface that would allow to pass hints from the
 //! type to a deserializer, all helper attributes are implemented as renames
@@ -997,7 +995,7 @@
 //!   the same name will not be deserialized into that Rust field. The
 //!   ```ignore
 //!   # type Type = ();
-//!   # #[derive(quick_xml::Deserialize)] struct S {
+//!   # #[quick_xml::xml] #[derive(serde::Deserialize)] struct S {
 //!   #[xml(attribute = "attribute")]
 //!   field: Type,
 //!   # }
@@ -1018,7 +1016,7 @@
 //!   this field should be deserialized from an attribute. The
 //!   ```ignore
 //!   # type Type = ();
-//!   # #[derive(quick_xml::Deserialize)] struct S {
+//!   # #[quick_xml::xml] #[derive(serde::Deserialize)] struct S {
 //!   #[xml(attribute)]
 //!   field: Type,
 //!   # }
@@ -1052,7 +1050,8 @@
 //! for a field that allows extract that content:
 //!
 //! ```ignore
-//! #[derive(quick_xml::Deserialize)]
+//! #[quick_xml::xml]
+//! #[derive(serde::Deserialize)]
 //! struct Xml {
 //!   attribute: String,
 //!
@@ -1099,7 +1098,7 @@
 //!
 //! ```ignore
 //! # type Type = ();
-//! # #[derive(quick_xml::Deserialize)] struct S {
+//! # #[quick_xml::xml] #[derive(serde::Deserialize)] struct S {
 //! #[xml(namespace = "namespace1")]
 //! field: Type,
 //!
@@ -1144,7 +1143,7 @@
 //!
 //! ```ignore
 //! # type Type = ();
-//! # #[derive(quick_xml::Deserialize)] struct S {
+//! # #[quick_xml::xml] #[derive(serde::Deserialize)] struct S {
 //! #[xml(flatten)]
 //! field: Type,
 //! # }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -502,6 +502,116 @@
 //! <!-- ======================================================================================== -->
 //! <tr>
 //! <td>
+//! A sequence inside tag with a dedicated name:
+//!
+//! ```xml
+//! <any-tag>
+//!   <seq/>
+//! </any-tag>
+//! ```
+//! ```xml
+//! <any-tag>
+//!   <seq>
+//!     <item/>
+//!   </seq>
+//! </any-tag>
+//! ```
+//! ```xml
+//! <any-tag>
+//!   <seq>
+//!     <item/>
+//!     <item/>
+//!     <item/>
+//!   </seq>
+//! </any-tag>
+//! ```
+//! </td>
+//! <td>
+//!
+//! A struct with a field which have a sequence type, for example, [`Vec`]:
+//!
+//! ```
+//! # type Item = ();
+//! # /*
+//! type Item = ...;
+//! # */
+//!
+//! # #[derive(Debug, PartialEq, serde::Deserialize)]
+//! struct AnyName {
+//!   seq: Vec<Item>,
+//! }
+//! # assert_eq!(
+//! #   quick_xml::de::from_str::<AnyName>(r#"<any-tag><seq/></any-tag>"#).unwrap(),
+//! #   AnyName { seq: vec![] },
+//! # );
+//! # assert_eq!(
+//! #   quick_xml::de::from_str::<AnyName>(r#"<any-tag><seq><item/></seq></any-tag>"#).unwrap(),
+//! #   AnyName { seq: vec![()] },
+//! # );
+//! # assert_eq!(
+//! #   quick_xml::de::from_str::<AnyName>(r#"<any-tag><seq><item/><item/><item/></seq></any-tag>"#).unwrap(),
+//! #   AnyName { seq: vec![(), (), ()] },
+//! # );
+//! ```
+//! </td>
+//! </tr>
+//! <!-- ======================================================================================== -->
+//! <tr>
+//! <td>
+//! A sequence inside tag without a dedicated name:
+//!
+//! ```xml
+//! <any-tag/>
+//! ```
+//! ```xml
+//! <any-tag>
+//!   <item/>
+//! </any-tag>
+//! ```
+//! ```xml
+//! <any-tag>
+//!   <item/>
+//!   <item/>
+//!   <item/>
+//! </any-tag>
+//! ```
+//! </td>
+//! <td>
+//!
+//! A struct with a field which have a sequence type, for example, [`Vec`],
+//! and marked with an `#[xml(flatten)]` attribute.
+//! See the [Advanced Mapping](#advanced-mapping) section for details:
+//!
+//! ```
+//! # type Item = ();
+//! # /*
+//! type Item = ...;
+//! # */
+//!
+//! # #[derive(Debug, PartialEq)]
+//! #[derive(quick_xml::Deserialize)]
+//! struct AnyName {
+//!   #[xml(flatten)]
+//!   seq: Vec<Item>,
+//! }
+//! # assert_eq!(
+//! #   quick_xml::de::from_str::<AnyName>(r#"<any-tag/>"#).unwrap(),
+//! #   AnyName { seq: vec![] },
+//! # );
+//! # assert_eq!(
+//! #   quick_xml::de::from_str::<AnyName>(r#"<any-tag><item/></any-tag>"#).unwrap(),
+//! #   AnyName { seq: vec![()] },
+//! # );
+//! # assert_eq!(
+//! #   quick_xml::de::from_str::<AnyName>(r#"<any-tag><item/><item/><item/></any-tag>"#).unwrap(),
+//! #   AnyName { seq: vec![(), (), ()] },
+//! # );
+//! ```
+//! </td>
+//! </tr>
+//! <!-- ======================================================================================== -->
+//! <tr>
+//! <td>
 //! A sequence with a strict order, probably with a mixed content
 //! (text and tags):
 //!

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -63,7 +63,6 @@
 //!   enum Language {
 //!     Rust,
 //!     Cpp,
-//!     #[serde(other)]
 //!     Other(String),
 //!   }
 //!   ```
@@ -402,7 +401,7 @@
 //!
 //! Names of the enum and struct does not matter.
 //!
-//! ```
+//! ```ignore
 //! # #[derive(Debug, PartialEq, serde::Deserialize)]
 //! #[serde(rename_all = "snake_case")]
 //! enum Choice {
@@ -530,7 +529,7 @@
 //!
 //! A struct with a field which have a sequence type, for example, [`Vec`]:
 //!
-//! ```
+//! ```ignore
 //! # type Item = ();
 //! # /*
 //! type Item = ...;
@@ -582,7 +581,7 @@
 //! and marked with an `#[xml(flatten)]` attribute.
 //! See the [Advanced Mapping](#advanced-mapping) section for details:
 //!
-//! ```
+//! ```ignore
 //! # type Item = ();
 //! # /*
 //! type Item = ...;
@@ -996,7 +995,8 @@
 //! - `#[xml(attribute = "attribute")]` -- when applied to a field, changes its XML
 //!   representation to an attribute with the name `attribute`. An XML element with
 //!   the same name will not be deserialized into that Rust field. The
-//!   ```no_run
+//!   ```ignore
+//!   # type Type = ();
 //!   # #[derive(quick_xml::Deserialize)] struct S {
 //!   #[xml(attribute = "attribute")]
 //!   field: Type,
@@ -1004,6 +1004,7 @@
 //!   ```
 //!   is fully equivalent to
 //!   ```no_run
+//!   # type Type = ();
 //!   # #[derive(serde::Deserialize)] struct S {
 //!   #[serde(rename = "@attribute")]
 //!   field: Type,
@@ -1015,7 +1016,8 @@
 //! - `#[xml(attribute)]` -- the shorten version of the previous one, when attribute
 //!   and element names already do not clash, but you want to explicitly mark that
 //!   this field should be deserialized from an attribute. The
-//!   ```no_run
+//!   ```ignore
+//!   # type Type = ();
 //!   # #[derive(quick_xml::Deserialize)] struct S {
 //!   #[xml(attribute)]
 //!   field: Type,
@@ -1023,6 +1025,7 @@
 //!   ```
 //!   is fully equivalent to
 //!   ```no_run
+//!   # type Type = ();
 //!   # #[derive(serde::Deserialize)] struct S {
 //!   #[serde(rename = "@field")]
 //!   field: Type,
@@ -1048,7 +1051,7 @@
 //! an XML node named `#text`. `quick_xml` provides a `#[xml(content)]` attribute
 //! for a field that allows extract that content:
 //!
-//! ```no_run
+//! ```ignore
 //! #[derive(quick_xml::Deserialize)]
 //! struct Xml {
 //!   attribute: String,
@@ -1094,7 +1097,8 @@
 //! be written as `{namespace}tag`. That is how the fields with an attribute
 //! `#[xml(namespace = ...)]` is represented. The
 //!
-//! ```no_run
+//! ```ignore
+//! # type Type = ();
 //! # #[derive(quick_xml::Deserialize)] struct S {
 //! #[xml(namespace = "namespace1")]
 //! field: Type,
@@ -1105,6 +1109,7 @@
 //! ```
 //! is fully equivalent to
 //! ```no_run
+//! # type Type = ();
 //! # #[derive(serde::Deserialize)] struct S {
 //! #[serde(rename = "{namespace1}field")]
 //! field: Type,
@@ -1137,7 +1142,8 @@
 //! and protect from misprints, `#[xml(flatten)]` can be used instead of
 //! `#[serde(flatten)]`:
 //!
-//! ```no_run
+//! ```ignore
+//! # type Type = ();
 //! # #[derive(quick_xml::Deserialize)] struct S {
 //! #[xml(flatten)]
 //! field: Type,
@@ -1145,6 +1151,7 @@
 //! ```
 //! is fully equivalent to
 //! ```no_run
+//! # type Type = ();
 //! # #[derive(serde::Deserialize)] struct S {
 //! #[serde(rename = "$flatten")]
 //! field: Type,


### PR DESCRIPTION
This is the my vision of further evolution of the serde integration in this crate. Some parts of this is discussible or maybe even impossible to implement -- this is the first iteration of what I would like to see. For now I'm making this draft PR to:
- share my vision
- invitation to discussion
- creating a roadmap for necessary fixes (marked with `FIXME` in doctests)

You can get a rustdoc documentation by running
```console
cargo doc --features serialize --open
```
in the crate root an navigate to `quick_xml::de` module.

Below the (approximately) rendered version of this proposal:


# Mapping XML to Rust types

Type names are never considered when deserializing, so you could name your
types as you wish. Other general rules:
- `struct` field name could be represented in XML only as attribute name or
  element name.
- `enum` variant name could be represented in XML only as attribute name or
  element name.
- the unit struct, unit type `()` and unit enum variant can be deserialized
  from any valid XML content:
  - attribute and element names
  - attribute and element values
  - text or CDATA content
- when deserializing attribute names have precedence over element names.
  So if your XML have both attribute and element named equally, the Rust
  field/variant will be deserialized from the attribute.

> NOTE: examples, marked with `FIXME:` do not work yet -- any PRs that fixes
> that are welcome! The message after marker is a test failure message.
> Also, all that tests are marked with an `ignore` option, although their
> compiles. This is by intention, because rustdoc marks such blocks with
> an exclamation mark unlike `no_run` blocks.

<table>
<thead>
<tr><th>To parse all these XML's...</th><th>...use that Rust type</th></tr>
</thead>
<tbody>
<tr>
<td>
Root tag name do not matter

```xml
<any-tag one="..." two="..."/>
```
```xml
<any-tag>
  <one>...</one>
  <two>...</two>
</any-tag>
```
```xml
<any-tag one="...">
  <two>...</two>
</any-tag>
```
> NOTE: such XML's are NOT supported because deserializer will always
> report a duplicated field error:
> ```xml
> <any-tag field="...">
>   <field>...</field>
> </any-tag>
> ```
</td>
<td>

All these struct can be used to deserialize from specified XML depending on
amount of information that you want to get:

```rust
// Get both elements/attributes
struct AnyName {
  one: T,
  two: U,
}
```
```rust
// Get only one element/attribute, ignore other
struct AnyName {
  one: T,
}
```
```rust
// Ignore all attributes/elements
// You can also use the `()` type (unit type)
struct AnyName;
```

A structure where each XML attribute or child element mapped to the field.
Each attribute or element name becomes a name of field. Name of the struct
itself does not matter.

> NOTE: XML allowing you to have an attribute and an element with the
> same name inside the one element. Such XML's can't be deserialized because
> serde does not allow you to pass custom properties to the fields and we
> cannot tell the field on the Rust side, should it be deserialized from the
> attribute or from the element
</td>
</tr>

<tr>
<td>
An optional XML attributes/elements that you want to capture.
The root tag name do not matter.

```xml
<any-tag optional="..."/>
```
```xml
<any-tag/>
  <optional>...</optional>
</any-tag>
```
```xml
<any-tag/>
```
</td>
<td>

A structure with an optional field.

```rust
struct AnyName {
  optional: Option<T>,
}
```
When the XML attribute or element is present, type `T` will be deserialized
from an attribute value (which is a string) or an element (which is a string
or a multi-mapping -- i.e. mapping which can have duplicated keys).
</td>
</tr>

<tr>
<td>Text content, CDATA content</td>
<td>

Text content and CDATA mapped to any Rust type that could be deserialized
from a string, for example, `String`, `&str` and so on.

> NOTE: deserialization to non-owned types (i.e. borrow from the input),
> such as `&str`, is possible only if you parse document in the UTF-8
> encoding and text content do not contains escape sequences.
</td>
</tr>

<tr>
<td>
An XML with different root tag names.

```xml
<one field1="...">...</one>
```
```xml
<two field2="...">...</two>
```
```xml
<one>
  <field1>...</field1>
</one>
```
```xml
<two>
  <field2>...</field2>
</two>
```
</td>
<td>

An enum where each variant have a name of the root tag. Name of the enum
itself does not matter.

All these types can be used to deserialize from specified XML depending on
amount of information that you want to get:

```rust
#[serde(rename_all = "snake_case")]
enum AnyName {
  One { field1: T },
  Two { field2: U },
}
```
```rust
type OtherType = ...;
#[serde(rename_all = "snake_case")]
enum AnyName {
  // `field1` contend discarded
  One,
  // OtherType deserialized from the `field2` content
  Two(OtherType),
}
```
```rust
#[serde(rename_all = "snake_case")]
enum AnyName {
  One,
  // the <two> will be mapped to this
  #[serde(other)]
  Other,
}
```
You should have variants for all possible tag names in your enum or have
an `#[serde(other)]` variant.
</td>
</tr>

<tr>
<td>

`<xs:choice>` inside of the other element.

```xml
<any-tag field="...">
  <one>...</one>
</any-tag>
```
```xml
<any-tag field="...">
  <two>...</two>
</any-tag>
```
```xml
<any-tag>
  <field>...</field>
  <one>...</one>
</any-tag>
```
```xml
<any-tag>
  <two>...</two>
  <field>...</field>
</any-tag>
```
</td>
<td>
Names of the enum, struct, and struct field does not matter.

```rust
// FIXME: Custom("missing field `$flatten`")
#[serde(rename_all = "snake_case")]
enum Choice {
  One,
  Two,
}
struct AnyName {
  field: ...,

  // Creates problems while deserializing inner
  // types in many cases due to
  // https://github.com/serde-rs/serde/issues/1183
  // #[serde(flatten)]
  /// Field name is ignored if it is renamed to
  /// `$flatten`
  #[serde(rename = "$flatten")]
  any_name: Choice,
}
```
> Due to selected workaround you can have only one `flatten` field
> in your structure. That will be checked at the compile time by the
> serde derive macro.
</td>
</tr>

<tr>
<td>
A sequence with a strict order, probably with a mixed content
(text and tags).

```xml
<one>...</one>
text
<![CDATA[cdata]]>
<two>...</two>
<one>...</one>
```
</td>
<td>

All elements mapped to the heterogeneous sequential type: tuple or named tuple.
Each element of the tuple should be able to be deserialized from the nested
element content (`...`), except the enum types which would be deserialized
from the full element (`<one>...</one>`), so they could use the element name to
choose the right variant:

```rust
// FIXME: Custom("invalid length 3, expected tuple
//                struct AnyName with 5 elements")
type One = ...;
type Two = ...;
# #[derive(Debug, PartialEq, serde::Deserialize)]
struct AnyName(One, String, String, Two, One);
```
```rust
// FIXME: Custom("invalid length 3, expected
//                a tuple of size 5")
#[serde(rename_all = "snake_case")]
enum Choice {
  One,
}
type Two = ...;
type AnyName = (Choice, String, String, Two, Choice);
```
</td>
</tr>

<tr>
<td>
A sequence with a non-strict order, probably with a mixed content
(text and tags).

```xml
<one>...</one>
text
<![CDATA[cdata]]>
<two>...</two>
<one>...</one>
```
</td>
<td>
A homogeneous sequence of elements with a fixed or dynamic size.

```rust
// FIXME: Unsupported("Invalid event for Enum,
//                     expecting `Text` or `Start`")
#[serde(rename_all = "snake_case")]
enum Choice {
  One,
  Two,
  #[serde(other)]
  Other,
}
type AnyName = [Choice; 5];
```
```rust
// FIXME: Custom("unknown variant `text`, expected
//                one of `one`, `two`, `$value`")
#[serde(rename_all = "snake_case")]
enum Choice {
  One,
  Two,
  #[serde(rename = "$value")]
  Other(String),
}
type AnyName = Vec<Choice>;
```
</td>
</tr>

<tr>
<td>
A sequence with a strict order, probably with a mixed content,
(text and tags) inside of the other element.

```xml
<any-tag>
  <one>...</one>
  text
  <![CDATA[cdata]]>
  <two>...</two>
  <one>...</one>
</any-tag>
```
</td>
<td>

A structure where all child elements mapped to the one field which have
a heterogeneous sequential type: tuple or named tuple. Each element of the
tuple should be able to be deserialized from the nested element content
(`...`), except the enum types which would be deserialized from the full
element (`<one>...</one>`):

```rust
// FIXME: Custom("missing field `$flatten`")
type One = ...;
type Two = ...;
struct AnyName {
  // Does not (yet?) supported by the serde
  // https://github.com/serde-rs/serde/issues/1905
  // #[serde(flatten)]
  /// Field name is ignored if it is renamed to
  /// `$flatten`
  #[serde(rename = "$flatten")]
  any_name: (One, String, String, Two, One),
}
```
```rust
// FIXME: Custom("missing field `$flatten`")
type One = ...;
type Two = ...;
struct NamedTuple(One, String, String, Two, One);
struct AnyName {
  // Does not (yet?) supported by the serde
  // https://github.com/serde-rs/serde/issues/1905
  // #[serde(flatten)]
  /// Field name is ignored if it is renamed to
  /// `$flatten`
  #[serde(rename = "$flatten")]
  any_name: NamedTuple,
}
```
</td>
</tr>

<tr>
<td>
A sequence with a non-strict order, probably with a mixed content
(text and tags) inside of the other element.

```xml
<any-tag>
  <one>...</one>
  text
  <![CDATA[cdata]]>
  <two>...</two>
  <one>...</one>
</any-tag>
```
</td>
<td>

A structure where all child elements mapped to the one field which have
a homogeneous sequential type: array-like container. A container type `T`
should be able to be deserialized from the nested element content (`...`),
except if it is an enum type which would be deserialized from the full
element (`<one>...</one>`):

```rust
// FIXME: Custom("missing field `$flatten`")
#[serde(rename_all = "snake_case")]
enum Choice {
  One,
  Two,
  #[serde(rename = "$value")]
  Other(String),
}
struct AnyName {
  // Does not (yet?) supported by the serde
  // https://github.com/serde-rs/serde/issues/1905
  // #[serde(flatten)]
  /// Field name is ignored if it is renamed to
  /// `$flatten`
  #[serde(rename = "$flatten")]
  any_name: [Choice; 5],
}
```
```rust
// FIXME: Custom("missing field `$flatten`")
#[serde(rename_all = "snake_case")]
enum Choice {
  One,
  Two,
  #[serde(rename = "$value")]
  Other(String),
}
struct AnyName {
  // Does not (yet?) supported by the serde
  // https://github.com/serde-rs/serde/issues/1905
  // #[serde(flatten)]
  /// Field name is ignored if it is renamed to
  /// `$flatten`
  #[serde(rename = "$flatten")]
  any_name: Vec<Choice>,
}
```
</td>
</tr>
</tbody>
</table>