### PR TITLE
Fix CDATA handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
   from the attribute and element names and attribute values
 - fix: allow to deserialize `unit`s from text and CDATA content.
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
+- test: add tests for trivial documents (empty / only comment / `<root>...</root>` -- one tag with content)
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,13 @@
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
 - test: add tests for trivial documents (empty / only comment / `<root>...</root>` -- one tag with content)
 - fix: CDATA was not handled in many cases where it should
+- fix: do not unescape CDATA content because it never escaped by design
+  ([#311](https://github.com/tafia/quick-xml/issues/311)).
+
+  NOTE: now text content when deserialized into bytes (`Vec<u8>` / `&[u8]`), also unescaped.
+  It is impossible to get a raw XML data in bytes buffer. Actually, deserializing of bytes
+  should be prohibited, because XML cannot store raw byte data. You should store binary
+  data in a string hex- or base64- or any-other-schema-encoded.
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - fix: allow to deserialize `unit`s from text and CDATA content.
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
 - test: add tests for trivial documents (empty / only comment / `<root>...</root>` -- one tag with content)
+- fix: CDATA was not handled in many cases where it should
 
 ## 0.23.0-alpha3
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -225,7 +225,7 @@ fn bench_quick_xml_one_cdata_event_trimmed(b: &mut Bencher) {
             .check_comments(false)
             .trim_text(true);
         match r.read_event(&mut buf) {
-            Ok(Event::CData(ref e)) => nbtxt += e.unescaped().unwrap().len(),
+            Ok(Event::CData(ref e)) => nbtxt += e.len(),
             something_else => panic!("Did not expect {:?}", something_else),
         };
 

--- a/src/de/byte_buf.rs
+++ b/src/de/byte_buf.rs
@@ -1,11 +1,12 @@
 //! Helper types for tests
 
+use crate::utils::write_byte_string;
 use serde::de::{self, Deserialize, Deserializer, Error};
 use std::fmt;
 
 /// Wrapper around `Vec<u8>` that deserialized using `deserialize_byte_buf`
 /// instead of vector's generic `deserialize_seq`
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct ByteBuf(pub Vec<u8>);
 
 impl<'de> Deserialize<'de> for ByteBuf {
@@ -35,9 +36,15 @@ impl<'de> Deserialize<'de> for ByteBuf {
     }
 }
 
+impl fmt::Debug for ByteBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_byte_string(f, &self.0)
+    }
+}
+
 /// Wrapper around `&[u8]` that deserialized using `deserialize_bytes`
 /// instead of vector's generic `deserialize_seq`
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct Bytes<'de>(pub &'de [u8]);
 
 impl<'de> Deserialize<'de> for Bytes<'de> {
@@ -60,5 +67,11 @@ impl<'de> Deserialize<'de> for Bytes<'de> {
         }
 
         Ok(d.deserialize_bytes(Visitor)?)
+    }
+}
+
+impl<'de> fmt::Debug for Bytes<'de> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_byte_string(f, self.0)
     }
 }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -100,7 +100,7 @@ impl<'de, 'a, R: BorrowingReader<'de>> de::MapAccess<'de> for MapAccess<'de, 'a,
         } else {
             // try getting from events (<key>value</key>)
             match self.de.peek()? {
-                DeEvent::Text(_) => {
+                DeEvent::Text(_) | DeEvent::CData(_) => {
                     self.state = State::InnerValue;
                     // Deserialize `key` from special attribute name which means
                     // that value should be taken from the text content of the

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -560,7 +560,7 @@ where
         V: Visitor<'de>,
     {
         match self.peek()? {
-            DeEvent::Text(t) if t.is_empty() => visitor.visit_none(),
+            DeEvent::Text(t) | DeEvent::CData(t) if t.is_empty() => visitor.visit_none(),
             DeEvent::Eof => visitor.visit_none(),
             _ => visitor.visit_some(self),
         }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -406,13 +406,12 @@ where
         deserialize_bool(txt.as_ref(), self.reader.decoder(), visitor)
     }
 
+    /// Representation of owned strings the same as [non-owned](#method.deserialize_str).
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DeError>
     where
         V: Visitor<'de>,
     {
-        let text = self.next_text()?;
-        let string = text.decode_and_escape(self.reader.decoder())?;
-        visitor.visit_string(string.into_owned())
+        self.deserialize_str(visitor)
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -36,6 +36,8 @@ where
         let decoder = self.de.reader.decoder();
         let de = match self.de.peek()? {
             DeEvent::Text(t) => EscapedDeserializer::new(Cow::Borrowed(t), decoder, true),
+            // Escape sequences does not processed inside CDATA section
+            DeEvent::CData(t) => EscapedDeserializer::new(Cow::Borrowed(t), decoder, false),
             DeEvent::Start(e) => EscapedDeserializer::new(Cow::Borrowed(e.name()), decoder, false),
             _ => {
                 return Err(DeError::Unsupported(
@@ -64,7 +66,7 @@ where
     fn unit_variant(self) -> Result<(), DeError> {
         match self.de.next()? {
             DeEvent::Start(e) => self.de.read_to_end(e.name()),
-            DeEvent::Text(_) => Ok(()),
+            DeEvent::Text(_) | DeEvent::CData(_) => Ok(()),
             _ => unreachable!(),
         }
     }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -40,10 +40,13 @@ pub mod attributes;
 use encoding_rs::Encoding;
 use std::{borrow::Cow, collections::HashMap, io::BufRead, ops::Deref, str::from_utf8};
 
-use crate::escape::{do_unescape, escape};
+use crate::escape::{do_unescape, escape, partial_escape};
 use crate::utils::write_cow_string;
 use crate::{errors::Error, errors::Result, reader::Reader};
 use attributes::{Attribute, Attributes};
+
+#[cfg(feature = "serialize")]
+use crate::escape::EscapeError;
 
 use memchr;
 
@@ -604,11 +607,17 @@ impl<'a> BytesText<'a> {
         }
     }
 
-    /// Extracts the inner `Cow` from the `BytesText` event container.
+    /// Returns unescaped version of the text content, that can be written
+    /// as CDATA in XML
     #[cfg(feature = "serialize")]
-    #[inline]
-    pub(crate) fn into_inner(self) -> Cow<'a, [u8]> {
-        self.content
+    pub(crate) fn unescape(self) -> std::result::Result<BytesCData<'a>, EscapeError> {
+        //TODO: need to think about better API instead of dozens similar functions
+        // Maybe use builder pattern. After that expose function as public API
+        //FIXME: need to take into account entities defined in the document
+        Ok(BytesCData::new(match do_unescape(&self.content, None)? {
+            Cow::Borrowed(_) => self.content,
+            Cow::Owned(unescaped) => Cow::Owned(unescaped),
+        }))
     }
 
     /// gets escaped content
@@ -644,60 +653,6 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
         do_unescape(self, custom_entities).map_err(Error::EscapeError)
-    }
-
-    /// Gets content of this text buffer in the specified encoding
-    #[cfg(feature = "serialize")]
-    pub(crate) fn decode(&self, decoder: crate::reader::Decoder) -> Result<Cow<'a, str>> {
-        Ok(match &self.content {
-            Cow::Borrowed(bytes) => {
-                #[cfg(feature = "encoding")]
-                {
-                    decoder.decode(bytes)
-                }
-                #[cfg(not(feature = "encoding"))]
-                {
-                    decoder.decode(bytes)?.into()
-                }
-            }
-            Cow::Owned(bytes) => {
-                #[cfg(feature = "encoding")]
-                let decoded = decoder.decode(bytes).into_owned();
-
-                #[cfg(not(feature = "encoding"))]
-                let decoded = decoder.decode(bytes)?.to_string();
-
-                decoded.into()
-            }
-        })
-    }
-
-    #[cfg(feature = "serialize")]
-    pub(crate) fn decode_and_escape(
-        &self,
-        decoder: crate::reader::Decoder,
-    ) -> Result<Cow<'a, str>> {
-        match self.decode(decoder)? {
-            Cow::Borrowed(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
-                match unescaped {
-                    Cow::Borrowed(unescaped) => {
-                        from_utf8(unescaped).map(|s| s.into()).map_err(Error::Utf8)
-                    }
-                    Cow::Owned(unescaped) => String::from_utf8(unescaped)
-                        .map(|s| s.into())
-                        .map_err(|e| Error::Utf8(e.utf8_error())),
-                }
-            }
-            Cow::Owned(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
-                String::from_utf8(unescaped.into_owned())
-                    .map(|s| s.into())
-                    .map_err(|e| Error::Utf8(e.utf8_error()))
-            }
-        }
     }
 
     /// helper method to unescape then decode self using the reader encoding
@@ -860,6 +815,117 @@ impl<'a> std::fmt::Debug for BytesText<'a> {
     }
 }
 
+/// CDATA content contains unescaped data from the reader. If you want to write them as a text,
+/// [convert](Self::escape) it to [`BytesText`]
+#[derive(Clone, Eq, PartialEq)]
+pub struct BytesCData<'a> {
+    content: Cow<'a, [u8]>,
+}
+
+impl<'a> BytesCData<'a> {
+    /// Creates a new `BytesCData` from a byte sequence.
+    #[inline]
+    pub fn new<C: Into<Cow<'a, [u8]>>>(content: C) -> Self {
+        Self {
+            content: content.into(),
+        }
+    }
+
+    /// Creates a new `BytesCData` from a string
+    #[inline]
+    pub fn from_str(content: &'a str) -> Self {
+        Self::new(content.as_bytes())
+    }
+
+    /// Extracts the inner `Cow` from the `BytesCData` event container.
+    #[inline]
+    pub fn into_inner(self) -> Cow<'a, [u8]> {
+        self.content
+    }
+
+    /// Ensures that all data is owned to extend the object's lifetime if
+    /// necessary.
+    #[inline]
+    pub fn into_owned(self) -> BytesCData<'static> {
+        BytesCData {
+            content: self.content.into_owned().into(),
+        }
+    }
+
+    /// Converts this CDATA content to an escaped version, that can be written
+    /// as an usual text in XML.
+    ///
+    /// This function performs following replacements:
+    ///
+    /// | Character | Replacement
+    /// |-----------|------------
+    /// | `<`       | `&lt;`
+    /// | `>`       | `&gt;`
+    /// | `&`       | `&amp;`
+    /// | `'`       | `&apos;`
+    /// | `"`       | `&quot;`
+    pub fn escape(self) -> BytesText<'a> {
+        BytesText::from_escaped(match escape(&self.content) {
+            Cow::Borrowed(_) => self.content,
+            Cow::Owned(escaped) => Cow::Owned(escaped),
+        })
+    }
+
+    /// Converts this CDATA content to an escaped version, that can be written
+    /// as an usual text in XML.
+    ///
+    /// In XML text content, it is allowed (though not recommended) to leave
+    /// the quote special characters `"` and `'` unescaped.
+    ///
+    /// This function performs following replacements:
+    ///
+    /// | Character | Replacement
+    /// |-----------|------------
+    /// | `<`       | `&lt;`
+    /// | `>`       | `&gt;`
+    /// | `&`       | `&amp;`
+    pub fn partial_escape(self) -> BytesText<'a> {
+        BytesText::from_escaped(match partial_escape(&self.content) {
+            Cow::Borrowed(_) => self.content,
+            Cow::Owned(escaped) => Cow::Owned(escaped),
+        })
+    }
+
+    /// Gets content of this text buffer in the specified encoding
+    #[cfg(feature = "serialize")]
+    pub(crate) fn decode(&self, decoder: crate::reader::Decoder) -> Result<Cow<'a, str>> {
+        Ok(match &self.content {
+            Cow::Borrowed(bytes) => {
+                #[cfg(feature = "encoding")]
+                {
+                    decoder.decode(bytes)
+                }
+                #[cfg(not(feature = "encoding"))]
+                {
+                    decoder.decode(bytes)?.into()
+                }
+            }
+            Cow::Owned(bytes) => {
+                #[cfg(feature = "encoding")]
+                let decoded = decoder.decode(bytes).into_owned();
+
+                #[cfg(not(feature = "encoding"))]
+                let decoded = decoder.decode(bytes)?.to_string();
+
+                decoded.into()
+            }
+        })
+    }
+}
+
+impl<'a> std::fmt::Debug for BytesCData<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "BytesCData {{ content: ")?;
+        write_cow_string(f, &self.content)?;
+        write!(f, " }}")
+    }
+}
+
 /// Event emitted by [`Reader::read_event`].
 ///
 /// [`Reader::read_event`]: ../reader/struct.Reader.html#method.read_event
@@ -876,7 +942,7 @@ pub enum Event<'a> {
     /// Comment `<!-- ... -->`.
     Comment(BytesText<'a>),
     /// CData `<![CDATA[...]]>`.
-    CData(BytesText<'a>),
+    CData(BytesCData<'a>),
     /// XML declaration `<?xml ...?>`.
     Decl(BytesDecl<'a>),
     /// Processing instruction `<?...?>`.
@@ -929,6 +995,14 @@ impl<'a> Deref for BytesEnd<'a> {
 
 impl<'a> Deref for BytesText<'a> {
     type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &*self.content
+    }
+}
+
+impl<'a> Deref for BytesCData<'a> {
+    type Target = [u8];
+
     fn deref(&self) -> &[u8] {
         &*self.content
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,7 +9,8 @@ use std::{fs::File, path::Path, str::from_utf8};
 use encoding_rs::{Encoding, UTF_16BE, UTF_16LE};
 
 use crate::errors::{Error, Result};
-use crate::events::{attributes::Attribute, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use crate::events::attributes::Attribute;
+use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 
 use memchr;
 
@@ -368,7 +369,7 @@ impl<R: BufRead> Reader<R> {
             Ok(Event::Comment(BytesText::from_escaped(&buf[3..len - 2])))
         } else if uncased_starts_with(buf, b"![CDATA[") {
             debug_assert!(len >= 10, "Minimum length guaranteed by read_bang_elem");
-            Ok(Event::CData(BytesText::from_plain(&buf[8..buf.len() - 2])))
+            Ok(Event::CData(BytesCData::new(&buf[8..buf.len() - 2])))
         } else if uncased_starts_with(buf, b"!DOCTYPE") {
             debug_assert!(len >= 8, "Minimum length guaranteed by read_bang_elem");
             let start = buf[8..]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,7 +1,7 @@
 //! A module to handle `Writer`
 
 use crate::errors::{Error, Result};
-use crate::events::{attributes::Attribute, BytesStart, BytesText, Event};
+use crate::events::{attributes::Attribute, BytesCData, BytesStart, BytesText, Event};
 use std::io::Write;
 
 /// XML writer.
@@ -261,7 +261,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write a CData event `<![CDATA[...]]>` inside the current element.
-    pub fn write_cdata_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
+    pub fn write_cdata_content(self, text: BytesCData) -> Result<&'a mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.to_borrowed()))?;
         self.writer.write_event(Event::CData(text))?;

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -180,7 +180,7 @@ fn test_cdata() {
 fn test_cdata_open_close() {
     let mut r = Reader::from_str("<![CDATA[test <> test]]>");
     r.trim_text(true);
-    next_eq!(r, CData, b"test &lt;&gt; test");
+    next_eq!(r, CData, b"test <> test");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #311, closes #370.

Now `CData` event has its own dedicated type `BytesCData` instead of `BytesText`. New type can be converted to `BytesText` by calling `.escape()` method, so migrating should be easy, but it is better to review usages, because usually you want to have _unescaped_ data and CDATA section already provide them.

The API a bit dangerous because it not checked for forbidden sequence `]]>` -- you can create a `BytesCData` containing it. Because this is general problem with other event content types, I leaved it now as is. This API should be fixed in another PR.

This PR changes how raw bytes are deserialized, for example, to a `Vec<u8>`. Before such field always get a unmodified content from the reader -- it means that you can consider raw bytes types as a way to access to raw reader content in your structs. This is dangerous practice, because other formats do not behave like this. Actually, I would prefer to prohibit (de)serializing (into) `Vec<u8>` and similar at all. This is conceptually right, but maybe unpractical. So now bytes deserialized similarly to strings -- text content unescaped, CDATA content remained unchanged.

I'm thinking about providing encoding handler to a (de)serializer, that should be used to encode / decode binary data to strings, that will be stored in XML, for example, hex, or base64, and by default (`handler == None`) emit an error on attempt (de)serializing binary data. But this is for another PR.

Unescaping takes into account only default XML entities, namely `&lt;`, `&gt;`, `&amp;`, `&apos;`, and `&quot;`. Adding support for document-defined entities is the purpose for another PR.