### PR TITLE
Update dependencies: memchr and encoding_rs and allow changing patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ license = "MIT"
 travis-ci = { repository = "tafia/quick-xml" }
 
 [dependencies]
-encoding_rs = { version = "0.8.26", optional = true }
+encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }
-memchr = "2.3.4"
+memchr = "2.4"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
MSRV increased, but I think this is acceptable.

|Crate      |Changes|MSRV|
|-----------|-------|----|
|encoding_rs|[v0.8.26...v0.8.30](https://github.com/hsivonen/encoding_rs/compare/v0.8.26...v0.8.30)|1.36.0 (_not changed_)|
|memchr     |[2.3.4...2.4.1](https://github.com/BurntSushi/memchr/compare/2.3.4...2.4.1)|1.28.0 -> 1.41.1|

(_Rust stable at PR creation: 1.59.0_)