### PR TITLE
Add support for XML Schema `xs:list` type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,12 +22,8 @@
 - test: add tests for trivial documents (empty / only comment / `<root>...</root>` -- one tag with content)
 - fix: CDATA was not handled in many cases where it should
 - fix: do not unescape CDATA content because it never escaped by design
-  ([#311](https://github.com/tafia/quick-xml/issues/311)).
-
-  NOTE: now text content when deserialized into bytes (`Vec<u8>` / `&[u8]`), also unescaped.
-  It is impossible to get a raw XML data in bytes buffer. Actually, deserializing of bytes
-  should be prohibited, because XML cannot store raw byte data. You should store binary
-  data in a string hex- or base64- or any-other-schema-encoded.
+  ([#311](https://github.com/tafia/quick-xml/issues/311))
+- feat: add support for XML Schema `xs:list` ([#376](https://github.com/tafia/quick-xml/pull/376))
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
   from the attribute and element names and attribute values
 - fix: allow to deserialize `unit`s from text and CDATA content.
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
+- test: add tests for trivial documents (empty / only comment / `<root>...</root>` -- one tag with content)
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,13 @@
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
 - test: add tests for trivial documents (empty / only comment / `<root>...</root>` -- one tag with content)
 - fix: CDATA was not handled in many cases where it should
+- fix: do not unescape CDATA content because it never escaped by design
+  ([#311](https://github.com/tafia/quick-xml/issues/311)).
+
+  NOTE: now text content when deserialized into bytes (`Vec<u8>` / `&[u8]`), also unescaped.
+  It is impossible to get a raw XML data in bytes buffer. Actually, deserializing of bytes
+  should be prohibited, because XML cannot store raw byte data. You should store binary
+  data in a string hex- or base64- or any-other-schema-encoded.
 
 ## 0.23.0-alpha3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - fix: allow to deserialize `unit`s from text and CDATA content.
   `DeError::InvalidUnit` variant is removed, because after fix it is no longer used
 - test: add tests for trivial documents (empty / only comment / `<root>...</root>` -- one tag with content)
+- fix: CDATA was not handled in many cases where it should
 
 ## 0.23.0-alpha3
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -225,7 +225,7 @@ fn bench_quick_xml_one_cdata_event_trimmed(b: &mut Bencher) {
             .check_comments(false)
             .trim_text(true);
         match r.read_event(&mut buf) {
-            Ok(Event::CData(ref e)) => nbtxt += e.unescaped().unwrap().len(),
+            Ok(Event::CData(ref e)) => nbtxt += e.len(),
             something_else => panic!("Did not expect {:?}", something_else),
         };
 

--- a/src/de/byte_buf.rs
+++ b/src/de/byte_buf.rs
@@ -1,11 +1,12 @@
 //! Helper types for tests
 
+use crate::utils::write_byte_string;
 use serde::de::{self, Deserialize, Deserializer, Error};
 use std::fmt;
 
 /// Wrapper around `Vec<u8>` that deserialized using `deserialize_byte_buf`
 /// instead of vector's generic `deserialize_seq`
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct ByteBuf(pub Vec<u8>);
 
 impl<'de> Deserialize<'de> for ByteBuf {
@@ -35,9 +36,15 @@ impl<'de> Deserialize<'de> for ByteBuf {
     }
 }
 
+impl fmt::Debug for ByteBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_byte_string(f, &self.0)
+    }
+}
+
 /// Wrapper around `&[u8]` that deserialized using `deserialize_bytes`
 /// instead of vector's generic `deserialize_seq`
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct Bytes<'de>(pub &'de [u8]);
 
 impl<'de> Deserialize<'de> for Bytes<'de> {
@@ -60,5 +67,11 @@ impl<'de> Deserialize<'de> for Bytes<'de> {
         }
 
         Ok(d.deserialize_bytes(Visitor)?)
+    }
+}
+
+impl<'de> fmt::Debug for Bytes<'de> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_byte_string(f, self.0)
     }
 }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -100,7 +100,7 @@ impl<'de, 'a, R: BorrowingReader<'de>> de::MapAccess<'de> for MapAccess<'de, 'a,
         } else {
             // try getting from events (<key>value</key>)
             match self.de.peek()? {
-                DeEvent::Text(_) => {
+                DeEvent::Text(_) | DeEvent::CData(_) => {
                     self.state = State::InnerValue;
                     // Deserialize `key` from special attribute name which means
                     // that value should be taken from the text content of the

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1031,7 +1031,11 @@ mod tests {
                 in_struct!(char_: char = "<root>r</root>", 'r');
 
                 in_struct!(string:   String  = "<root>escaped&#x20;string</root>", "escaped string".into());
-                in_struct!(byte_buf: ByteBuf = "<root>escaped&#x20;byte_buf</root>", ByteBuf(r"escaped byte_buf".into()));
+                // Byte buffers give access to raw data from the input, so never deserialized
+                // TODO: It is a bit unusual and it would be better comletely forbid deserialization
+                // into bytes, because XML cannot store any bytes natively. User should use some sort
+                // of encoding to string, for example, hex or base64
+                in_struct!(byte_buf: ByteBuf = "<root>escaped&#x20;byte_buf</root>", ByteBuf(r"escaped&#x20;byte_buf".into()));
             }
 
             /// Tests deserialization from CDATA content in a tag.
@@ -2325,6 +2329,169 @@ mod tests {
                         }
                     );
                 }
+            }
+        }
+    }
+
+    /// https://www.w3schools.com/xml/el_list.asp
+    mod xml_schema_lists {
+        use super::*;
+
+        macro_rules! list {
+            ($name:ident: $type:ty = $xml:literal => $result:expr) => {
+                #[test]
+                fn $name() {
+                    let data: List<$type> = from_str($xml).unwrap();
+
+                    assert_eq!(data, List { list: $result });
+                }
+            };
+        }
+
+        macro_rules! err {
+            ($name:ident: $type:ty = $xml:literal => $kind:ident($err:literal)) => {
+                #[test]
+                fn $name() {
+                    let err = from_str::<List<$type>>($xml).unwrap_err();
+
+                    match err {
+                        DeError::$kind(e) => assert_eq!(e, $err),
+                        _ => panic!(
+                            "Expected `{}({})`, found `{:?}`",
+                            stringify!($kind),
+                            $err,
+                            err
+                        ),
+                    }
+                }
+            };
+        }
+
+        /// Checks that sequences can be deserialized from an XML attribute content
+        /// according to the `xs:list` XML Schema type
+        mod attribute {
+            use super::*;
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct List<T> {
+                list: Vec<T>,
+            }
+
+            list!(i8_:  i8  = r#"<root list="1 -2  3"/>"# => vec![1, -2, 3]);
+            list!(i16_: i16 = r#"<root list="1 -2  3"/>"# => vec![1, -2, 3]);
+            list!(i32_: i32 = r#"<root list="1 -2  3"/>"# => vec![1, -2, 3]);
+            list!(i64_: i64 = r#"<root list="1 -2  3"/>"# => vec![1, -2, 3]);
+
+            list!(u8_:  u8  = r#"<root list="1 2  3"/>"# => vec![1, 2, 3]);
+            list!(u16_: u16 = r#"<root list="1 2  3"/>"# => vec![1, 2, 3]);
+            list!(u32_: u32 = r#"<root list="1 2  3"/>"# => vec![1, 2, 3]);
+            list!(u64_: u64 = r#"<root list="1 2  3"/>"# => vec![1, 2, 3]);
+
+            serde_if_integer128! {
+                list!(i128_: i128 = r#"<root list="1 -2  3"/>"# => vec![1, -2, 3]);
+                list!(u128_: u128 = r#"<root list="1 2  3"/>"# => vec![1, 2, 3]);
+            }
+
+            list!(f32_: f32 = r#"<root list="1.23 -4.56  7.89"/>"# => vec![1.23, -4.56, 7.89]);
+            list!(f64_: f64 = r#"<root list="1.23 -4.56  7.89"/>"# => vec![1.23, -4.56, 7.89]);
+
+            list!(bool_: bool = r#"<root list="true false  true"/>"# => vec![true, false, true]);
+            list!(char_: char = r#"<root list="4 2  j"/>"# => vec!['4', '2', 'j']);
+
+            list!(string: String = r#"<root list="first second  third&#x20;3"/>"# => vec![
+                "first".to_string(),
+                "second".to_string(),
+                "third 3".to_string(),
+            ]);
+            err!(byte_buf: ByteBuf = r#"<root list="first second  third&#x20;3"/>"#
+                 => Unsupported("byte arrays are not supported as `xs:list` items"));
+
+            list!(unit: () = r#"<root list="1 second  false"/>"# => vec![(), (), ()]);
+        }
+
+        /// Checks that sequences can be deserialized from an XML text content
+        /// according to the `xs:list` XML Schema type
+        mod element {
+            use super::*;
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct List<T> {
+                // Give it a special name that means text content of the XML node
+                #[serde(rename = "$value")]
+                list: Vec<T>,
+            }
+
+            mod text {
+                use super::*;
+
+                list!(i8_:  i8  = "<root>1 -2  3</root>" => vec![1, -2, 3]);
+                list!(i16_: i16 = "<root>1 -2  3</root>" => vec![1, -2, 3]);
+                list!(i32_: i32 = "<root>1 -2  3</root>" => vec![1, -2, 3]);
+                list!(i64_: i64 = "<root>1 -2  3</root>" => vec![1, -2, 3]);
+
+                list!(u8_:  u8  = "<root>1 2  3</root>" => vec![1, 2, 3]);
+                list!(u16_: u16 = "<root>1 2  3</root>" => vec![1, 2, 3]);
+                list!(u32_: u32 = "<root>1 2  3</root>" => vec![1, 2, 3]);
+                list!(u64_: u64 = "<root>1 2  3</root>" => vec![1, 2, 3]);
+
+                serde_if_integer128! {
+                    list!(i128_: i128 = "<root>1 -2  3</root>" => vec![1, -2, 3]);
+                    list!(u128_: u128 = "<root>1 2  3</root>" => vec![1, 2, 3]);
+                }
+
+                list!(f32_: f32 = "<root>1.23 -4.56  7.89</root>" => vec![1.23, -4.56, 7.89]);
+                list!(f64_: f64 = "<root>1.23 -4.56  7.89</root>" => vec![1.23, -4.56, 7.89]);
+
+                list!(bool_: bool = "<root>true false  true</root>" => vec![true, false, true]);
+                list!(char_: char = "<root>4 2  j</root>" => vec!['4', '2', 'j']);
+
+                list!(string: String = "<root>first second  third&#x20;3</root>" => vec![
+                    "first".to_string(),
+                    "second".to_string(),
+                    "third 3".to_string(),
+                ]);
+                err!(byte_buf: ByteBuf = "<root>first second  third&#x20;3</root>"
+                    => Unsupported("byte arrays are not supported as `xs:list` items"));
+
+                list!(unit: () = "<root>1 second  false</root>" => vec![(), (), ()]);
+            }
+
+            mod cdata {
+                use super::*;
+
+                list!(i8_:  i8  = "<root><![CDATA[1 -2  3]]></root>" => vec![1, -2, 3]);
+                list!(i16_: i16 = "<root><![CDATA[1 -2  3]]></root>" => vec![1, -2, 3]);
+                list!(i32_: i32 = "<root><![CDATA[1 -2  3]]></root>" => vec![1, -2, 3]);
+                list!(i64_: i64 = "<root><![CDATA[1 -2  3]]></root>" => vec![1, -2, 3]);
+
+                list!(u8_:  u8  = "<root><![CDATA[1 2  3]]></root>" => vec![1, 2, 3]);
+                list!(u16_: u16 = "<root><![CDATA[1 2  3]]></root>" => vec![1, 2, 3]);
+                list!(u32_: u32 = "<root><![CDATA[1 2  3]]></root>" => vec![1, 2, 3]);
+                list!(u64_: u64 = "<root><![CDATA[1 2  3]]></root>" => vec![1, 2, 3]);
+
+                serde_if_integer128! {
+                    list!(i128_: i128 = "<root><![CDATA[1 -2  3]]></root>" => vec![1, -2, 3]);
+                    list!(u128_: u128 = "<root><![CDATA[1 2  3]]></root>" => vec![1, 2, 3]);
+                }
+
+                list!(f32_: f32 = "<root><![CDATA[1.23 -4.56  7.89]]></root>" => vec![1.23, -4.56, 7.89]);
+                list!(f64_: f64 = "<root><![CDATA[1.23 -4.56  7.89]]></root>" => vec![1.23, -4.56, 7.89]);
+
+                list!(bool_: bool = "<root><![CDATA[true false  true]]></root>" => vec![true, false, true]);
+                list!(char_: char = "<root><![CDATA[4 2  j]]></root>" => vec!['4', '2', 'j']);
+
+                // Cannot get whitespace in the value in any way if CDATA used:
+                // - literal spaces means list item delimiters
+                // - escaped sequences are not decoded in CDATA
+                list!(string: String = "<root><![CDATA[first second  third&#x20;3]]></root>" => vec![
+                    "first".to_string(),
+                    "second".to_string(),
+                    "third&#x20;3".to_string(),
+                ]);
+                err!(byte_buf: ByteBuf = "<root>first second  third&#x20;3</root>"
+                    => Unsupported("byte arrays are not supported as `xs:list` items"));
+
+                list!(unit: () = "<root>1 second  false</root>" => vec![(), (), ()]);
             }
         }
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -733,21 +733,15 @@ mod tests {
     fn read_to_end() {
         use crate::de::DeEvent::*;
 
-        let mut reader = Reader::from_bytes(
-            r#"
+        let mut de = Deserializer::from_bytes(
+            br#"
             <root>
                 <tag a="1"><tag>text</tag>content</tag>
                 <tag a="2"><![CDATA[cdata content]]></tag>
                 <self-closed/>
             </root>
-            "#
-            .as_bytes(),
+            "#,
         );
-        reader
-            .expand_empty_elements(true)
-            .check_end_names(true)
-            .trim_text(true);
-        let mut de = Deserializer::new(SliceReader { reader });
 
         assert_eq!(
             de.next().unwrap(),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -199,7 +199,7 @@ where
         .expand_empty_elements(true)
         .check_end_names(true)
         .trim_text(true);
-    let mut de = Deserializer::from_borrowing_reader(IoReader {
+    let mut de = Deserializer::new(IoReader {
         reader,
         buf: Vec::new(),
     });
@@ -253,11 +253,6 @@ where
             peek: None,
             has_value_field: false,
         }
-    }
-
-    /// Get a new deserializer from a regular BufRead
-    pub fn from_borrowing_reader(reader: R) -> Self {
-        Self::new(reader)
     }
 
     fn peek(&mut self) -> Result<&DeEvent<'de>, DeError> {
@@ -352,7 +347,7 @@ impl<'de> Deserializer<'de, SliceReader<'de>> {
             .expand_empty_elements(true)
             .check_end_names(true)
             .trim_text(true);
-        Self::from_borrowing_reader(SliceReader { reader })
+        Self::new(SliceReader { reader })
     }
 }
 
@@ -752,7 +747,7 @@ mod tests {
             .expand_empty_elements(true)
             .check_end_names(true)
             .trim_text(true);
-        let mut de = Deserializer::from_borrowing_reader(SliceReader { reader });
+        let mut de = Deserializer::new(SliceReader { reader });
 
         assert_eq!(
             de.next().unwrap(),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -560,7 +560,7 @@ where
         V: Visitor<'de>,
     {
         match self.peek()? {
-            DeEvent::Text(t) if t.is_empty() => visitor.visit_none(),
+            DeEvent::Text(t) | DeEvent::CData(t) if t.is_empty() => visitor.visit_none(),
             DeEvent::Eof => visitor.visit_none(),
             _ => visitor.visit_some(self),
         }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -627,10 +627,7 @@ where
 /// A trait that borrows an XML reader that borrows from the input. For a &[u8]
 /// input the events will borrow from that input, whereas with a BufRead input
 /// all events will be converted to 'static, allocating whenever necessary.
-pub trait BorrowingReader<'i>
-where
-    Self: 'i,
-{
+pub trait BorrowingReader<'i> {
     /// Return an input-borrowing event.
     fn next(&mut self) -> Result<DeEvent<'i>, DeError>;
 
@@ -647,7 +644,7 @@ struct IoReader<R: BufRead> {
     buf: Vec<u8>,
 }
 
-impl<'i, R: BufRead + 'i> BorrowingReader<'i> for IoReader<R> {
+impl<'i, R: BufRead> BorrowingReader<'i> for IoReader<R> {
     fn next(&mut self) -> Result<DeEvent<'static>, DeError> {
         let event = loop {
             let e = self.reader.read_event(&mut self.buf)?;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -406,13 +406,12 @@ where
         deserialize_bool(txt.as_ref(), self.reader.decoder(), visitor)
     }
 
+    /// Representation of owned strings the same as [non-owned](#method.deserialize_str).
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DeError>
     where
         V: Visitor<'de>,
     {
-        let text = self.next_text()?;
-        let string = text.decode_and_escape(self.reader.decoder())?;
-        visitor.visit_string(string.into_owned())
+        self.deserialize_str(visitor)
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -1,0 +1,542 @@
+//! Contains Serde `Deserializer` for XML [simple types] [as defined] in the XML Schema.
+//!
+//! [simple types]: https://www.w3schools.com/xml/el_simpletype.asp
+//! [as defined]: https://www.w3.org/TR/xmlschema11-1/#Simple_Type_Definition
+
+use crate::de::str2bool;
+use crate::errors::serialize::DeError;
+use crate::escape::unescape;
+use serde::de::{DeserializeSeed, Deserializer, EnumAccess, VariantAccess, Visitor};
+use serde::{self, serde_if_integer128};
+use std::borrow::Cow;
+
+macro_rules! deserialize_num {
+    ($method:ident, $visit:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.$visit(self.content.as_str().parse()?)
+        }
+    };
+}
+
+macro_rules! unsupported {
+    (
+        $deserialize:ident
+        $(
+            ($($type:ty),*)
+        )?
+        => $message:literal
+    ) => {
+        #[inline]
+        fn $deserialize<V: Visitor<'de>>(
+            self,
+            $($(_: $type,)*)?
+            _visitor: V
+        ) -> Result<V::Value, Self::Error> {
+            Err(DeError::Unsupported($message))
+        }
+    };
+}
+
+//-----------------------------------------------------------------------------
+
+/// A version of [`Cow`] that can borrow from two different buffers, one of them
+/// is a deserializer input
+#[derive(Clone)]
+enum Content<'de, 'a> {
+    /// An input borrowed from the parsed data
+    Input(&'de str),
+    /// An input borrowed from the buffer owned by another deserializer
+    Slice(&'a str),
+    /// An input taken from an external deserializer, owned by that deserializer.
+    /// Only part of this data, located after offset represented by `usize`, used
+    /// to deserialize data, the other is a garbage that can't be dropped because
+    /// we do not want to make reallocations if they will not required.
+    Owned(String, usize),
+}
+impl<'de, 'a> Content<'de, 'a> {
+    /// Returns string representation of the content
+    fn as_str(&self) -> &str {
+        match self {
+            Content::Input(s) => s,
+            Content::Slice(s) => s,
+            Content::Owned(s, offset) => s.split_at(*offset).1,
+        }
+    }
+
+    /// Supply to the visitor borrowed string, string slice, or owned string
+    /// depending on the kind of input. Unlike [`Self::deserialize_item`],
+    /// the whole [`Self::Owned`] string will be passed to the visitor.
+    ///
+    /// Calls
+    /// - `visitor.visit_borrowed_str` if data borrowed from the input
+    /// - `visitor.visit_str` if data borrowed from another source
+    /// - `visitor.visit_string` if data owned by this type
+    #[inline]
+    fn deserialize_all<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Content::Input(s) => visitor.visit_borrowed_str(s),
+            Content::Slice(s) => visitor.visit_str(s),
+            Content::Owned(s, _) => visitor.visit_string(s),
+        }
+    }
+
+    /// Supply to the visitor borrowed string, string slice, or owned string
+    /// depending on the kind of input. Unlike [`Self::deserialize_all`],
+    /// only part of [`Self::Owned`] string will be passed to the visitor.
+    ///
+    /// Calls
+    /// - `visitor.visit_borrowed_str` if data borrowed from the input
+    /// - `visitor.visit_str` if data borrowed from another source
+    /// - `visitor.visit_string` if data owned by this type
+    #[inline]
+    fn deserialize_item<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Content::Input(s) => visitor.visit_borrowed_str(s),
+            Content::Slice(s) => visitor.visit_str(s),
+            Content::Owned(s, 0) => visitor.visit_string(s),
+            Content::Owned(s, offset) => visitor.visit_str(s.split_at(offset).1),
+        }
+    }
+}
+
+/// A deserializer that handles ordinary [simple type definition][item] with
+/// `{variety} = atomic`, or an ordinary [simple type] definition with
+/// `{variety} = union` whose basic members are all atomic.
+///
+/// This deserializer can deserialize only primitive types:
+/// - numbers
+/// - booleans
+/// - strings
+/// - units
+/// - options
+/// - unit variants of enums
+///
+/// Identifiers represented as strings and deserialized accordingly.
+///
+/// Deserialization of all other types returns [`Unsupported`][DeError::Unsupported] error.
+///
+/// [item]: https://www.w3.org/TR/xmlschema11-1/#std-item_type_definition
+/// [simple type]: https://www.w3.org/TR/xmlschema11-1/#Simple_Type_Definition
+#[derive(Clone)]
+struct AtomicDeserializer<'de, 'a> {
+    /// Content of the attribute value, text content or CDATA content
+    content: Content<'de, 'a>,
+    /// If `true`, `content` in an escaped form and should be unescaped before use
+    escaped: bool,
+}
+
+impl<'de, 'a> Deserializer<'de> for AtomicDeserializer<'de, 'a> {
+    type Error = DeError;
+
+    /// Forwards deserialization to the [`Self::deserialize_str`]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    /// According to the <https://www.w3.org/TR/xmlschema-2/#boolean>,
+    /// valid boolean representations are only `"true"`, `"false"`, `"1"`,
+    /// and `"0"`. But this method also handles following:
+    ///
+    /// |`bool` |XML content
+    /// |-------|-------------------------------------------------------------
+    /// |`true` |`"True"`,  `"TRUE"`,  `"t"`, `"Yes"`, `"YES"`, `"yes"`, `"y"`
+    /// |`false`|`"False"`, `"FALSE"`, `"f"`, `"No"`,  `"NO"`,  `"no"`,  `"n"`
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        str2bool(self.content.as_str(), visitor)
+    }
+
+    deserialize_num!(deserialize_i8, visit_i8);
+    deserialize_num!(deserialize_i16, visit_i16);
+    deserialize_num!(deserialize_i32, visit_i32);
+    deserialize_num!(deserialize_i64, visit_i64);
+
+    deserialize_num!(deserialize_u8, visit_u8);
+    deserialize_num!(deserialize_u16, visit_u16);
+    deserialize_num!(deserialize_u32, visit_u32);
+    deserialize_num!(deserialize_u64, visit_u64);
+
+    serde_if_integer128! {
+        deserialize_num!(deserialize_i128, visit_i128);
+        deserialize_num!(deserialize_u128, visit_u128);
+    }
+
+    deserialize_num!(deserialize_f32, visit_f32);
+    deserialize_num!(deserialize_f64, visit_f64);
+
+    /// Forwards deserialization to the [`Self::deserialize_str`]
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    /// Supply to the visitor borrowed string, string slice, or owned string
+    /// depending on the kind of input and presence of the escaped data.
+    ///
+    /// If string requires unescaping, then calls [`Visitor::visit_string`] with
+    /// new allocated buffer with unescaped data.
+    ///
+    /// Otherwise calls
+    /// - [`Visitor::visit_borrowed_str`] if data borrowed from the input
+    /// - [`Visitor::visit_str`] if data borrowed from other deserializer
+    /// - [`Visitor::visit_string`] if data owned by this deserializer
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.escaped {
+            match unescape(self.content.as_str().as_bytes())? {
+                Cow::Borrowed(_) => self.content.deserialize_item(visitor),
+                Cow::Owned(buf) => visitor.visit_string(String::from_utf8(buf)?),
+            }
+        } else {
+            self.content.deserialize_item(visitor)
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    /// If `content` is an empty string then calls [`Visitor::visit_none`],
+    /// otherwise calls [`Visitor::visit_some`] with itself
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.content.as_str().is_empty() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    /// Forwards deserialization to the [`Self::deserialize_unit`]
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_enum(self)
+    }
+
+    /// Forwards deserialization to the [`Self::deserialize_str`]
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    unsupported!(deserialize_bytes        => "byte arrays are not supported as `xs:list` items");
+    unsupported!(deserialize_byte_buf     => "byte arrays are not supported as `xs:list` items");
+    unsupported!(deserialize_seq          => "sequences are not supported as `xs:list` items");
+    unsupported!(deserialize_tuple(usize) => "tuples are not supported as `xs:list` items");
+    unsupported!(deserialize_tuple_struct(&'static str, usize) => "tuples are not supported as `xs:list` items");
+    unsupported!(deserialize_map          => "maps are not supported as `xs:list` items");
+    unsupported!(deserialize_struct(&'static str, &'static [&'static str]) => "structures are not supported as `xs:list` items");
+}
+
+impl<'de, 'a> EnumAccess<'de> for AtomicDeserializer<'de, 'a> {
+    type Error = DeError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self), DeError>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let name = seed.deserialize(self.clone())?;
+        Ok((name, self))
+    }
+}
+
+impl<'de, 'a> VariantAccess<'de> for AtomicDeserializer<'de, 'a> {
+    type Error = DeError;
+
+    #[inline]
+    fn unit_variant(self) -> Result<(), DeError> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, DeError>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        Err(DeError::Unsupported(
+            "enum newtype variants are not supported as `xs:list` items",
+        ))
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(DeError::Unsupported(
+            "enum tuple variants are not supported as `xs:list` items",
+        ))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(DeError::Unsupported(
+            "enum struct variants are not supported as `xs:list` items",
+        ))
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::de::byte_buf::{ByteBuf, Bytes};
+    use serde::de::IgnoredAny;
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Unit;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Newtype(String);
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct BorrowedNewtype<'a>(&'a str);
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Struct {
+        key: String,
+        val: usize,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Enum {
+        Unit,
+        Newtype(String),
+        Tuple(String, usize),
+        Struct { key: String, val: usize },
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(field_identifier)]
+    enum Id {
+        Field,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Any(IgnoredAny);
+    impl PartialEq for Any {
+        fn eq(&self, _other: &Any) -> bool {
+            true
+        }
+    }
+
+    /// Tests for deserialize atomic and union values, as defined in XSD specification
+    mod atomic {
+        use super::*;
+
+        /// Checks that given `$input` successfully deserializing into given `$result`
+        macro_rules! deserialized_to {
+            ($name:ident: $type:ty = $input:literal => $result:expr) => {
+                #[test]
+                fn $name() {
+                    let de = AtomicDeserializer {
+                        content: Content::Input($input),
+                        escaped: true,
+                    };
+                    let data: $type = Deserialize::deserialize(de).unwrap();
+
+                    assert_eq!(data, $result);
+                }
+            };
+        }
+
+        /// Checks that attempt to deserialize given `$input` as a `$type` results to a
+        /// deserialization error `$kind` with `$reason`
+        macro_rules! err {
+            ($name:ident: $type:ty = $input:literal => $kind:ident($reason:literal)) => {
+                #[test]
+                fn $name() {
+                    let de = AtomicDeserializer {
+                        content: Content::Input($input),
+                        escaped: true,
+                    };
+                    let err = <$type as Deserialize>::deserialize(de).unwrap_err();
+
+                    match err {
+                        DeError::$kind(e) => assert_eq!(e, $reason),
+                        _ => panic!(
+                            "Expected `{}({})`, found `{:?}`",
+                            stringify!($kind),
+                            $reason,
+                            err
+                        ),
+                    }
+                }
+            };
+        }
+
+        deserialized_to!(any_owned: String = "&lt;escaped&#x20;string" => "<escaped string");
+        deserialized_to!(any_borrowed: &str = "non-escaped string" => "non-escaped string");
+
+        deserialized_to!(false_: bool = "false" => false);
+        deserialized_to!(true_: bool  = "true" => true);
+
+        deserialized_to!(i8_:  i8  = "-2" => -2);
+        deserialized_to!(i16_: i16 = "-2" => -2);
+        deserialized_to!(i32_: i32 = "-2" => -2);
+        deserialized_to!(i64_: i64 = "-2" => -2);
+
+        deserialized_to!(u8_:  u8  = "3" => 3);
+        deserialized_to!(u16_: u16 = "3" => 3);
+        deserialized_to!(u32_: u32 = "3" => 3);
+        deserialized_to!(u64_: u64 = "3" => 3);
+
+        serde_if_integer128! {
+            deserialized_to!(i128_: i128 = "-2" => -2);
+            deserialized_to!(u128_: u128 = "2" => 2);
+        }
+
+        deserialized_to!(f32_: f32 = "1.23" => 1.23);
+        deserialized_to!(f64_: f64 = "1.23" => 1.23);
+
+        deserialized_to!(char_unescaped: char = "h" => 'h');
+        deserialized_to!(char_escaped: char = "&lt;" => '<');
+
+        deserialized_to!(string: String = "&lt;escaped&#x20;string" => "<escaped string");
+        deserialized_to!(borrowed_str: &str = "non-escaped string" => "non-escaped string");
+        err!(escaped_str: &str = "escaped&#x20;string"
+                => Custom("invalid type: string \"escaped string\", expected a borrowed string"));
+
+        err!(byte_buf: ByteBuf = "&lt;escaped&#x20;string"
+                => Unsupported("byte arrays are not supported as `xs:list` items"));
+        err!(borrowed_bytes: Bytes = "non-escaped string"
+                => Unsupported("byte arrays are not supported as `xs:list` items"));
+
+        deserialized_to!(option_none: Option<&str> = "" => None);
+        deserialized_to!(option_some: Option<&str> = "non-escaped string" => Some("non-escaped string"));
+
+        deserialized_to!(unit: () = "<root>anything</root>" => ());
+        deserialized_to!(unit_struct: Unit = "<root>anything</root>" => Unit);
+
+        deserialized_to!(newtype_owned: Newtype = "&lt;escaped&#x20;string" => Newtype("<escaped string".into()));
+        deserialized_to!(newtype_borrowed: BorrowedNewtype = "non-escaped string" => BorrowedNewtype("non-escaped string"));
+
+        err!(seq: Vec<()> = "non-escaped string"
+                => Unsupported("sequences are not supported as `xs:list` items"));
+        err!(tuple: ((), ()) = "non-escaped string"
+                => Unsupported("tuples are not supported as `xs:list` items"));
+        err!(tuple_struct: ((), ()) = "non-escaped string"
+                => Unsupported("tuples are not supported as `xs:list` items"));
+
+        err!(map: HashMap<(), ()> = "non-escaped string"
+                => Unsupported("maps are not supported as `xs:list` items"));
+        err!(struct_: Struct = "non-escaped string"
+                => Unsupported("structures are not supported as `xs:list` items"));
+
+        deserialized_to!(enum_unit: Enum = "Unit" => Enum::Unit);
+        err!(enum_newtype: Enum = "Newtype"
+                => Unsupported("enum newtype variants are not supported as `xs:list` items"));
+        err!(enum_tuple: Enum = "Tuple"
+                => Unsupported("enum tuple variants are not supported as `xs:list` items"));
+        err!(enum_struct: Enum = "Struct"
+                => Unsupported("enum struct variants are not supported as `xs:list` items"));
+        err!(enum_other: Enum = "any data"
+                => Custom("unknown variant `any data`, expected one of `Unit`, `Newtype`, `Tuple`, `Struct`"));
+
+        deserialized_to!(identifier: Id = "Field" => Id::Field);
+        deserialized_to!(ignored_any: Any = "any data" => Any(IgnoredAny));
+
+        /// Checks that deserialization from an owned content is working
+        #[test]
+        fn owned_data() {
+            let de = AtomicDeserializer {
+                content: Content::Owned("string slice".into(), 7),
+                escaped: true,
+            };
+            assert_eq!(de.content.as_str(), "slice");
+
+            let data: String = Deserialize::deserialize(de).unwrap();
+            assert_eq!(data, "slice");
+        }
+
+        /// Checks that deserialization from a content borrowed from some
+        /// buffer other that input is working
+        #[test]
+        fn borrowed_from_deserializer() {
+            let de = AtomicDeserializer {
+                content: Content::Slice("string slice"),
+                escaped: true,
+            };
+            assert_eq!(de.content.as_str(), "string slice");
+
+            let data: String = Deserialize::deserialize(de).unwrap();
+            assert_eq!(data, "string slice");
+        }
+    }
+}

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -36,6 +36,8 @@ where
         let decoder = self.de.reader.decoder();
         let de = match self.de.peek()? {
             DeEvent::Text(t) => EscapedDeserializer::new(Cow::Borrowed(t), decoder, true),
+            // Escape sequences does not processed inside CDATA section
+            DeEvent::CData(t) => EscapedDeserializer::new(Cow::Borrowed(t), decoder, false),
             DeEvent::Start(e) => EscapedDeserializer::new(Cow::Borrowed(e.name()), decoder, false),
             _ => {
                 return Err(DeError::Unsupported(
@@ -64,7 +66,7 @@ where
     fn unit_variant(self) -> Result<(), DeError> {
         match self.de.next()? {
             DeEvent::Start(e) => self.de.read_to_end(e.name()),
-            DeEvent::Text(_) => Ok(()),
+            DeEvent::Text(_) | DeEvent::CData(_) => Ok(()),
             _ => unreachable!(),
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -133,8 +133,10 @@ pub mod serialize {
     //! A module to handle serde (de)serialization errors
 
     use super::Error;
+    use crate::escape::EscapeError;
     use std::fmt;
     use std::num::{ParseFloatError, ParseIntError};
+    use std::string::FromUtf8Error;
 
     /// (De)serialization error
     #[derive(Debug)]
@@ -217,6 +219,19 @@ pub mod serialize {
     impl From<Error> for DeError {
         fn from(e: Error) -> Self {
             DeError::Xml(e)
+        }
+    }
+
+    impl From<EscapeError> for DeError {
+        #[inline]
+        fn from(e: EscapeError) -> Self {
+            Self::Xml(e.into())
+        }
+    }
+
+    impl From<FromUtf8Error> for DeError {
+        fn from(e: FromUtf8Error) -> Self {
+            Self::Xml(e.utf8_error().into())
         }
     }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -598,6 +598,12 @@ impl<'a> BytesText<'a> {
         Self::from_plain(content.as_bytes())
     }
 
+    /// Extracts the inner `Cow` from the `BytesText` event container.
+    #[inline]
+    pub fn into_inner(self) -> Cow<'a, [u8]> {
+        self.content
+    }
+
     /// Ensures that all data is owned to extend the object's lifetime if
     /// necessary.
     #[inline]

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -40,10 +40,13 @@ pub mod attributes;
 use encoding_rs::Encoding;
 use std::{borrow::Cow, collections::HashMap, io::BufRead, ops::Deref, str::from_utf8};
 
-use crate::escape::{do_unescape, escape};
+use crate::escape::{do_unescape, escape, partial_escape};
 use crate::utils::write_cow_string;
 use crate::{errors::Error, errors::Result, reader::Reader};
 use attributes::{Attribute, Attributes};
+
+#[cfg(feature = "serialize")]
+use crate::escape::EscapeError;
 
 use memchr;
 
@@ -604,11 +607,17 @@ impl<'a> BytesText<'a> {
         }
     }
 
-    /// Extracts the inner `Cow` from the `BytesText` event container.
+    /// Returns unescaped version of the text content, that can be written
+    /// as CDATA in XML
     #[cfg(feature = "serialize")]
-    #[inline]
-    pub(crate) fn into_inner(self) -> Cow<'a, [u8]> {
-        self.content
+    pub(crate) fn unescape(self) -> std::result::Result<BytesCData<'a>, EscapeError> {
+        //TODO: need to think about better API instead of dozens similar functions
+        // Maybe use builder pattern. After that expose function as public API
+        //FIXME: need to take into account entities defined in the document
+        Ok(BytesCData::new(match do_unescape(&self.content, None)? {
+            Cow::Borrowed(_) => self.content,
+            Cow::Owned(unescaped) => Cow::Owned(unescaped),
+        }))
     }
 
     /// gets escaped content
@@ -644,60 +653,6 @@ impl<'a> BytesText<'a> {
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,
     ) -> Result<Cow<'s, [u8]>> {
         do_unescape(self, custom_entities).map_err(Error::EscapeError)
-    }
-
-    /// Gets content of this text buffer in the specified encoding
-    #[cfg(feature = "serialize")]
-    pub(crate) fn decode(&self, decoder: crate::reader::Decoder) -> Result<Cow<'a, str>> {
-        Ok(match &self.content {
-            Cow::Borrowed(bytes) => {
-                #[cfg(feature = "encoding")]
-                {
-                    decoder.decode(bytes)
-                }
-                #[cfg(not(feature = "encoding"))]
-                {
-                    decoder.decode(bytes)?.into()
-                }
-            }
-            Cow::Owned(bytes) => {
-                #[cfg(feature = "encoding")]
-                let decoded = decoder.decode(bytes).into_owned();
-
-                #[cfg(not(feature = "encoding"))]
-                let decoded = decoder.decode(bytes)?.to_string();
-
-                decoded.into()
-            }
-        })
-    }
-
-    #[cfg(feature = "serialize")]
-    pub(crate) fn decode_and_escape(
-        &self,
-        decoder: crate::reader::Decoder,
-    ) -> Result<Cow<'a, str>> {
-        match self.decode(decoder)? {
-            Cow::Borrowed(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
-                match unescaped {
-                    Cow::Borrowed(unescaped) => {
-                        from_utf8(unescaped).map(|s| s.into()).map_err(Error::Utf8)
-                    }
-                    Cow::Owned(unescaped) => String::from_utf8(unescaped)
-                        .map(|s| s.into())
-                        .map_err(|e| Error::Utf8(e.utf8_error())),
-                }
-            }
-            Cow::Owned(decoded) => {
-                let unescaped =
-                    do_unescape(decoded.as_bytes(), None).map_err(Error::EscapeError)?;
-                String::from_utf8(unescaped.into_owned())
-                    .map(|s| s.into())
-                    .map_err(|e| Error::Utf8(e.utf8_error()))
-            }
-        }
     }
 
     /// helper method to unescape then decode self using the reader encoding
@@ -860,6 +815,117 @@ impl<'a> std::fmt::Debug for BytesText<'a> {
     }
 }
 
+/// CDATA content contains unescaped data from the reader. If you want to write them as a text,
+/// [convert](Self::escape) it to [`BytesText`]
+#[derive(Clone, Eq, PartialEq)]
+pub struct BytesCData<'a> {
+    content: Cow<'a, [u8]>,
+}
+
+impl<'a> BytesCData<'a> {
+    /// Creates a new `BytesCData` from a byte sequence.
+    #[inline]
+    pub fn new<C: Into<Cow<'a, [u8]>>>(content: C) -> Self {
+        Self {
+            content: content.into(),
+        }
+    }
+
+    /// Creates a new `BytesCData` from a string
+    #[inline]
+    pub fn from_str(content: &'a str) -> Self {
+        Self::new(content.as_bytes())
+    }
+
+    /// Extracts the inner `Cow` from the `BytesCData` event container.
+    #[inline]
+    pub fn into_inner(self) -> Cow<'a, [u8]> {
+        self.content
+    }
+
+    /// Ensures that all data is owned to extend the object's lifetime if
+    /// necessary.
+    #[inline]
+    pub fn into_owned(self) -> BytesCData<'static> {
+        BytesCData {
+            content: self.content.into_owned().into(),
+        }
+    }
+
+    /// Converts this CDATA content to an escaped version, that can be written
+    /// as an usual text in XML.
+    ///
+    /// This function performs following replacements:
+    ///
+    /// | Character | Replacement
+    /// |-----------|------------
+    /// | `<`       | `&lt;`
+    /// | `>`       | `&gt;`
+    /// | `&`       | `&amp;`
+    /// | `'`       | `&apos;`
+    /// | `"`       | `&quot;`
+    pub fn escape(self) -> BytesText<'a> {
+        BytesText::from_escaped(match escape(&self.content) {
+            Cow::Borrowed(_) => self.content,
+            Cow::Owned(escaped) => Cow::Owned(escaped),
+        })
+    }
+
+    /// Converts this CDATA content to an escaped version, that can be written
+    /// as an usual text in XML.
+    ///
+    /// In XML text content, it is allowed (though not recommended) to leave
+    /// the quote special characters `"` and `'` unescaped.
+    ///
+    /// This function performs following replacements:
+    ///
+    /// | Character | Replacement
+    /// |-----------|------------
+    /// | `<`       | `&lt;`
+    /// | `>`       | `&gt;`
+    /// | `&`       | `&amp;`
+    pub fn partial_escape(self) -> BytesText<'a> {
+        BytesText::from_escaped(match partial_escape(&self.content) {
+            Cow::Borrowed(_) => self.content,
+            Cow::Owned(escaped) => Cow::Owned(escaped),
+        })
+    }
+
+    /// Gets content of this text buffer in the specified encoding
+    #[cfg(feature = "serialize")]
+    pub(crate) fn decode(&self, decoder: crate::reader::Decoder) -> Result<Cow<'a, str>> {
+        Ok(match &self.content {
+            Cow::Borrowed(bytes) => {
+                #[cfg(feature = "encoding")]
+                {
+                    decoder.decode(bytes)
+                }
+                #[cfg(not(feature = "encoding"))]
+                {
+                    decoder.decode(bytes)?.into()
+                }
+            }
+            Cow::Owned(bytes) => {
+                #[cfg(feature = "encoding")]
+                let decoded = decoder.decode(bytes).into_owned();
+
+                #[cfg(not(feature = "encoding"))]
+                let decoded = decoder.decode(bytes)?.to_string();
+
+                decoded.into()
+            }
+        })
+    }
+}
+
+impl<'a> std::fmt::Debug for BytesCData<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "BytesCData {{ content: ")?;
+        write_cow_string(f, &self.content)?;
+        write!(f, " }}")
+    }
+}
+
 /// Event emitted by [`Reader::read_event`].
 ///
 /// [`Reader::read_event`]: ../reader/struct.Reader.html#method.read_event
@@ -876,7 +942,7 @@ pub enum Event<'a> {
     /// Comment `<!-- ... -->`.
     Comment(BytesText<'a>),
     /// CData `<![CDATA[...]]>`.
-    CData(BytesText<'a>),
+    CData(BytesCData<'a>),
     /// XML declaration `<?xml ...?>`.
     Decl(BytesDecl<'a>),
     /// Processing instruction `<?...?>`.
@@ -929,6 +995,14 @@ impl<'a> Deref for BytesEnd<'a> {
 
 impl<'a> Deref for BytesText<'a> {
     type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &*self.content
+    }
+}
+
+impl<'a> Deref for BytesCData<'a> {
+    type Target = [u8];
+
     fn deref(&self) -> &[u8] {
         &*self.content
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,7 +9,8 @@ use std::{fs::File, path::Path, str::from_utf8};
 use encoding_rs::{Encoding, UTF_16BE, UTF_16LE};
 
 use crate::errors::{Error, Result};
-use crate::events::{attributes::Attribute, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use crate::events::attributes::Attribute;
+use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 
 use memchr;
 
@@ -368,7 +369,7 @@ impl<R: BufRead> Reader<R> {
             Ok(Event::Comment(BytesText::from_escaped(&buf[3..len - 2])))
         } else if uncased_starts_with(buf, b"![CDATA[") {
             debug_assert!(len >= 10, "Minimum length guaranteed by read_bang_elem");
-            Ok(Event::CData(BytesText::from_plain(&buf[8..buf.len() - 2])))
+            Ok(Event::CData(BytesCData::new(&buf[8..buf.len() - 2])))
         } else if uncased_starts_with(buf, b"!DOCTYPE") {
             debug_assert!(len >= 8, "Minimum length guaranteed by read_bang_elem");
             let start = buf[8..]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1600,3 +1600,27 @@ impl Decoder {
         self.encoding.decode(bytes).0
     }
 }
+
+/// This implementation is required for tests of other parts of the library
+#[cfg(test)]
+#[cfg(feature = "serialize")]
+impl Decoder {
+    #[cfg(not(feature = "encoding"))]
+    pub(crate) fn utf8() -> Self {
+        Decoder
+    }
+
+    #[cfg(feature = "encoding")]
+    pub(crate) fn utf8() -> Self {
+        Decoder {
+            encoding: encoding_rs::UTF_8,
+        }
+    }
+
+    #[cfg(feature = "encoding")]
+    pub(crate) fn utf16() -> Self {
+        Decoder {
+            encoding: encoding_rs::UTF_16LE,
+        }
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,7 +1,7 @@
 //! A module to handle `Writer`
 
 use crate::errors::{Error, Result};
-use crate::events::{attributes::Attribute, BytesStart, BytesText, Event};
+use crate::events::{attributes::Attribute, BytesCData, BytesStart, BytesText, Event};
 use std::io::Write;
 
 /// XML writer.
@@ -261,7 +261,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write a CData event `<![CDATA[...]]>` inside the current element.
-    pub fn write_cdata_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
+    pub fn write_cdata_content(self, text: BytesCData) -> Result<&'a mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.to_borrowed()))?;
         self.writer.write_event(Event::CData(text))?;

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -180,7 +180,7 @@ fn test_cdata() {
 fn test_cdata_open_close() {
     let mut r = Reader::from_str("<![CDATA[test <> test]]>");
     r.trim_text(true);
-    next_eq!(r, CData, b"test &lt;&gt; test");
+    next_eq!(r, CData, b"test <> test");
 }
 
 #[test]


### PR DESCRIPTION
This PR allows deserializing `Vec` and other sequences from space-separated lists, as [defined](https://www.w3.org/TR/xmlschema11-2/#atomic-vs-list) by XML Schema specification. So now this is possible:
Deserialize
```rust
struct AnyName {
  // Will contain vec!["first", "second", "third"]
  attribute: Vec<String>,
}
```
from
```xml
<any-tag attribute="first second third">
```

This PR is based on #374, because before parsing text/CDATA content I will need to fix CDATA handling. It also cancels change in the bytes deserializing: now it is again possible to get a raw content of the parsed buffer using deserializing into `Vec<u8>` / `&[u8]`. This is not much useful in my opinion, although, so I put a TODO to look at this later.