### PR TITLE
Make `Deserializer::from_str` and `::from_slice` actually accessible

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,7 @@
 - fix: allow to deserialize `unit`s from any data in attribute values and text nodes
 - refactor: unify errors when EOF encountered during serde deserialization
 - test: ensure that after deserializing all XML was consumed
-- feat: add `Deserializer::from_str` and `Deserializer::from_bytes`
+- feat: add `Deserializer::from_str`, `Deserializer::from_slice` and `Deserializer::from_reader`
 - refactor: reduce number of unnecessary copies when deserialize numbers/booleans/identifiers
   from the attribute and element names and attribute values
 - fix: allow to deserialize `unit`s from text and CDATA content.

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@
 - refactor: unify errors when EOF encountered during serde deserialization
 - test: ensure that after deserializing all XML was consumed
 - feat: add `Deserializer::from_str`, `Deserializer::from_slice` and `Deserializer::from_reader`
+- refactor: deprecate `from_bytes` and `Deserializer::from_borrowing_reader` because
+  they are fully equivalent to `from_slice` and `Deserializer::new`
 - refactor: reduce number of unnecessary copies when deserialize numbers/booleans/identifiers
   from the attribute and element names and attribute values
 - fix: allow to deserialize `unit`s from text and CDATA content.

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     de::escape::EscapedDeserializer,
-    de::{BorrowingReader, DeEvent, Deserializer, INNER_VALUE, UNFLATTEN_PREFIX},
+    de::{DeEvent, Deserializer, XmlRead, INNER_VALUE, UNFLATTEN_PREFIX},
     errors::serialize::DeError,
     events::attributes::Attribute,
     events::BytesStart,
@@ -29,7 +29,10 @@ enum State {
 }
 
 /// A deserializer for `Attributes`
-pub(crate) struct MapAccess<'de, 'a, R: BorrowingReader<'de>> {
+pub(crate) struct MapAccess<'de, 'a, R>
+where
+    R: XmlRead<'de>,
+{
     /// Tag -- owner of attributes
     start: BytesStart<'de>,
     de: &'a mut Deserializer<'de, R>,
@@ -46,7 +49,10 @@ pub(crate) struct MapAccess<'de, 'a, R: BorrowingReader<'de>> {
     unflatten_fields: Vec<&'static [u8]>,
 }
 
-impl<'de, 'a, R: BorrowingReader<'de>> MapAccess<'de, 'a, R> {
+impl<'de, 'a, R> MapAccess<'de, 'a, R>
+where
+    R: XmlRead<'de>,
+{
     /// Create a new MapAccess
     pub fn new(
         de: &'a mut Deserializer<'de, R>,
@@ -76,7 +82,10 @@ impl<'de, 'a, R: BorrowingReader<'de>> MapAccess<'de, 'a, R> {
     }
 }
 
-impl<'de, 'a, R: BorrowingReader<'de>> de::MapAccess<'de> for MapAccess<'de, 'a, R> {
+impl<'de, 'a, R> de::MapAccess<'de> for MapAccess<'de, 'a, R>
+where
+    R: XmlRead<'de>,
+{
     type Error = DeError;
 
     fn next_key_seed<K: DeserializeSeed<'de>>(

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -626,10 +626,7 @@ where
 /// A trait that borrows an XML reader that borrows from the input. For a &[u8]
 /// input the events will borrow from that input, whereas with a BufRead input
 /// all events will be converted to 'static, allocating whenever necessary.
-pub trait BorrowingReader<'i>
-where
-    Self: 'i,
-{
+pub trait BorrowingReader<'i> {
     /// Return an input-borrowing event.
     fn next(&mut self) -> Result<DeEvent<'i>, DeError>;
 
@@ -646,7 +643,7 @@ struct IoReader<R: BufRead> {
     buf: Vec<u8>,
 }
 
-impl<'i, R: BufRead + 'i> BorrowingReader<'i> for IoReader<R> {
+impl<'i, R: BufRead> BorrowingReader<'i> for IoReader<R> {
     fn next(&mut self) -> Result<DeEvent<'static>, DeError> {
         let event = loop {
             let e = self.reader.read_event(&mut self.buf)?;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -163,7 +163,7 @@ where
     has_value_field: bool,
 }
 
-/// Deserialize an instance of type T from a string of XML text.
+/// Deserialize an instance of type `T` from a string of XML text.
 pub fn from_str<'de, T>(s: &'de str) -> Result<T, DeError>
 where
     T: Deserialize<'de>,
@@ -171,16 +171,16 @@ where
     from_bytes(s.as_bytes())
 }
 
-/// Deserialize a xml slice of bytes
+/// Deserialize an instance of type `T` from bytes of XML text.
 pub fn from_bytes<'de, T>(s: &'de [u8]) -> Result<T, DeError>
 where
     T: Deserialize<'de>,
 {
-    let mut de = Deserializer::from_bytes(s);
+    let mut de = Deserializer::from_slice(s);
     T::deserialize(&mut de)
 }
 
-/// Deserialize an instance of type T from bytes of XML text.
+/// Deserialize an instance of type `T` from bytes of XML text.
 pub fn from_slice<T>(b: &[u8]) -> Result<T, DeError>
 where
     T: DeserializeOwned,
@@ -188,21 +188,15 @@ where
     from_reader(b)
 }
 
-/// Deserialize from a reader
+/// Deserialize from a reader. This method will do internal copies of data
+/// readed from `reader`. If you want have a `&[u8]` or `&str` input and want
+/// to borrow as much as possible, use [`from_bytes`] or [`from_str`]
 pub fn from_reader<R, T>(reader: R) -> Result<T, DeError>
 where
     R: BufRead,
     T: DeserializeOwned,
 {
-    let mut reader = Reader::from_reader(reader);
-    reader
-        .expand_empty_elements(true)
-        .check_end_names(true)
-        .trim_text(true);
-    let mut de = Deserializer::from_borrowing_reader(IoReader {
-        reader,
-        buf: Vec::new(),
-    });
+    let mut de = Deserializer::from_reader(reader);
     T::deserialize(&mut de)
 }
 
@@ -246,7 +240,13 @@ impl<'de, R> Deserializer<'de, R>
 where
     R: BorrowingReader<'de>,
 {
-    /// Get a new deserializer
+    /// Create an XML deserializer from one of the possible quick_xml input sources.
+    ///
+    /// Typically it is more convenient to use one of these methods instead:
+    ///
+    ///  - [`Deserializer::from_str`]
+    ///  - [`Deserializer::from_slice`]
+    ///  - [`Deserializer::from_reader`]
     pub fn new(reader: R) -> Self {
         Deserializer {
             reader,
@@ -340,17 +340,39 @@ where
 impl<'de> Deserializer<'de, SliceReader<'de>> {
     /// Create new deserializer that will borrow data from the specified string
     pub fn from_str(s: &'de str) -> Self {
-        Self::from_bytes(s.as_bytes())
+        Self::from_slice(s.as_bytes())
     }
 
     /// Create new deserializer that will borrow data from the specified byte array
-    pub fn from_bytes(bytes: &'de [u8]) -> Self {
+    pub fn from_slice(bytes: &'de [u8]) -> Self {
         let mut reader = Reader::from_bytes(bytes);
         reader
             .expand_empty_elements(true)
             .check_end_names(true)
             .trim_text(true);
-        Self::from_borrowing_reader(SliceReader { reader })
+        Self::new(SliceReader { reader })
+    }
+}
+
+impl<'de, R> Deserializer<'de, IoReader<R>>
+where
+    R: BufRead,
+{
+    /// Create new deserializer that will copy data from the specified reader
+    /// into internal buffer. If you already have a string or a byte array, use
+    /// [`Self::from_str`] or [`Self::from_slice`] instead, because they will
+    /// borrow instead of copy, whenever possible
+    pub fn from_reader(reader: R) -> Self {
+        let mut reader = Reader::from_reader(reader);
+        reader
+            .expand_empty_elements(true)
+            .check_end_names(true)
+            .trim_text(true);
+
+        Self::new(IoReader {
+            reader,
+            buf: Vec::new(),
+        })
     }
 }
 
@@ -623,7 +645,7 @@ where
     }
 }
 
-/// A trait that borrows an XML reader that borrows from the input. For a &[u8]
+/// A trait that borrows an XML reader that borrows from the input. For a `&[u8]`
 /// input the events will borrow from that input, whereas with a BufRead input
 /// all events will be converted to 'static, allocating whenever necessary.
 pub trait BorrowingReader<'i> {
@@ -638,7 +660,11 @@ pub trait BorrowingReader<'i> {
     fn decoder(&self) -> Decoder;
 }
 
-struct IoReader<R: BufRead> {
+/// XML input source that reads from a std::io input stream.
+///
+/// You cannot create it, it is created automatically when you call
+/// [`Deserializer::from_reader`]
+pub struct IoReader<R: BufRead> {
     reader: Reader<R>,
     buf: Vec<u8>,
 }
@@ -675,7 +701,11 @@ impl<'i, R: BufRead> BorrowingReader<'i> for IoReader<R> {
     }
 }
 
-struct SliceReader<'de> {
+/// XML input source that reads from a slice of bytes and can borrow from it.
+///
+/// You cannot create it, it is created automatically when you call
+/// [`Deserializer::from_str`] or [`Deserializer::from_slice`]
+pub struct SliceReader<'de> {
     reader: Reader<&'de [u8]>,
 }
 
@@ -735,21 +765,15 @@ mod tests {
     fn read_to_end() {
         use crate::de::DeEvent::*;
 
-        let mut reader = Reader::from_bytes(
-            r#"
+        let mut de = Deserializer::from_slice(
+            br#"
             <root>
                 <tag a="1"><tag>text</tag>content</tag>
                 <tag a="2"><![CDATA[cdata content]]></tag>
                 <self-closed/>
             </root>
-            "#
-            .as_bytes(),
+            "#,
         );
-        reader
-            .expand_empty_elements(true)
-            .check_end_names(true)
-            .trim_text(true);
-        let mut de = Deserializer::from_borrowing_reader(SliceReader { reader });
 
         assert_eq!(
             de.next().unwrap(),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -168,11 +168,20 @@ pub fn from_str<'de, T>(s: &'de str) -> Result<T, DeError>
 where
     T: Deserialize<'de>,
 {
-    from_bytes(s.as_bytes())
+    from_slice(s.as_bytes())
 }
 
 /// Deserialize an instance of type `T` from bytes of XML text.
+#[deprecated = "Use `from_slice` instead"]
 pub fn from_bytes<'de, T>(s: &'de [u8]) -> Result<T, DeError>
+where
+    T: Deserialize<'de>,
+{
+    from_slice(s)
+}
+
+/// Deserialize an instance of type `T` from bytes of XML text.
+pub fn from_slice<'de, T>(s: &'de [u8]) -> Result<T, DeError>
 where
     T: Deserialize<'de>,
 {
@@ -180,17 +189,9 @@ where
     T::deserialize(&mut de)
 }
 
-/// Deserialize an instance of type `T` from bytes of XML text.
-pub fn from_slice<T>(b: &[u8]) -> Result<T, DeError>
-where
-    T: DeserializeOwned,
-{
-    from_reader(b)
-}
-
 /// Deserialize from a reader. This method will do internal copies of data
 /// readed from `reader`. If you want have a `&[u8]` or `&str` input and want
-/// to borrow as much as possible, use [`from_bytes`] or [`from_str`]
+/// to borrow as much as possible, use [`from_slice`] or [`from_str`]
 pub fn from_reader<R, T>(reader: R) -> Result<T, DeError>
 where
     R: BufRead,
@@ -256,6 +257,7 @@ where
     }
 
     /// Get a new deserializer from a regular BufRead
+    #[deprecated = "Use `Deserializer::new` instead"]
     pub fn from_borrowing_reader(reader: R) -> Self {
         Self::new(reader)
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -149,7 +149,7 @@ pub enum DeEvent<'a> {
 /// An xml deserializer
 pub struct Deserializer<'de, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     reader: R,
     peek: Option<DeEvent<'de>>,
@@ -238,7 +238,7 @@ where
 
 impl<'de, R> Deserializer<'de, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     /// Create an XML deserializer from one of the possible quick_xml input sources.
     ///
@@ -392,7 +392,7 @@ macro_rules! deserialize_type {
 
 impl<'de, 'a, R> de::Deserializer<'de> for &'a mut Deserializer<'de, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     type Error = DeError;
 
@@ -645,10 +645,13 @@ where
     }
 }
 
-/// A trait that borrows an XML reader that borrows from the input. For a `&[u8]`
-/// input the events will borrow from that input, whereas with a BufRead input
-/// all events will be converted to 'static, allocating whenever necessary.
-pub trait BorrowingReader<'i> {
+/// Trait used by the deserializer for iterating over input. This is manually
+/// "specialized" for iterating over `&[u8]`.
+///
+/// You do not need to implement this trait, it is needed to abstract from
+/// [borrowing](SliceReader) and [copying](IoReader) data sources and reuse code in
+/// deserializer
+pub trait XmlRead<'i> {
     /// Return an input-borrowing event.
     fn next(&mut self) -> Result<DeEvent<'i>, DeError>;
 
@@ -669,7 +672,7 @@ pub struct IoReader<R: BufRead> {
     buf: Vec<u8>,
 }
 
-impl<'i, R: BufRead> BorrowingReader<'i> for IoReader<R> {
+impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
     fn next(&mut self) -> Result<DeEvent<'static>, DeError> {
         let event = loop {
             let e = self.reader.read_event(&mut self.buf)?;
@@ -709,7 +712,7 @@ pub struct SliceReader<'de> {
     reader: Reader<&'de [u8]>,
 }
 
-impl<'de> BorrowingReader<'de> for SliceReader<'de> {
+impl<'de> XmlRead<'de> for SliceReader<'de> {
     fn next(&mut self) -> Result<DeEvent<'de>, DeError> {
         loop {
             let e = self.reader.read_event_unbuffered()?;

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -1,4 +1,4 @@
-use crate::de::{BorrowingReader, DeError, DeEvent, Deserializer};
+use crate::de::{DeError, DeEvent, Deserializer, XmlRead};
 use crate::{events::BytesStart, reader::Decoder};
 use serde::de::{self, DeserializeSeed};
 
@@ -25,7 +25,7 @@ impl Names {
 /// A SeqAccess
 pub struct SeqAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     de: &'a mut Deserializer<'de, R>,
     names: Names,
@@ -33,7 +33,7 @@ where
 
 impl<'a, 'de, R> SeqAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     /// Get a new SeqAccess
     pub fn new(de: &'a mut Deserializer<'de, R>) -> Result<Self, DeError> {
@@ -57,7 +57,7 @@ where
 
 impl<'de, 'a, R> de::SeqAccess<'de> for SeqAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     type Error = DeError;
 

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -1,5 +1,5 @@
 use crate::{
-    de::{escape::EscapedDeserializer, BorrowingReader, DeEvent, Deserializer},
+    de::{escape::EscapedDeserializer, DeEvent, Deserializer, XmlRead},
     errors::serialize::DeError,
 };
 use serde::de::{self, DeserializeSeed, Deserializer as SerdeDeserializer, Visitor};
@@ -8,14 +8,14 @@ use std::borrow::Cow;
 /// An enum access
 pub struct EnumAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     de: &'a mut Deserializer<'de, R>,
 }
 
 impl<'de, 'a, R> EnumAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     pub fn new(de: &'a mut Deserializer<'de, R>) -> Self {
         EnumAccess { de }
@@ -24,7 +24,7 @@ where
 
 impl<'de, 'a, R> de::EnumAccess<'de> for EnumAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     type Error = DeError;
     type Variant = VariantAccess<'de, 'a, R>;
@@ -50,14 +50,14 @@ where
 
 pub struct VariantAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     de: &'a mut Deserializer<'de, R>,
 }
 
 impl<'de, 'a, R> de::VariantAccess<'de> for VariantAccess<'de, 'a, R>
 where
-    R: BorrowingReader<'de>,
+    R: XmlRead<'de>,
 {
     type Error = DeError;
 


### PR DESCRIPTION
Previously, I've [added](https://github.com/tafia/quick-xml/commit/d683c377d9d9b75c2daabbb384030a30287ab624) this two methods to the `Deserializer` in #309, but because they was implemented for private type `SliceReader`, it was not actually possible to use that methods outside of crate.

Here a made types `SliceReader` and `IoReader` public, add a documentation for them and a new method `Deserializer::from_reader`. Method `Deserializer::from_bytes` was renamed to `Deserializer::from_slice` to follow convention that `serde-json`, `serde-yaml` and other follows.

Also free function `from_slice` now behaves the same as `from_bytes` (i.e. borrow from input instead of copying, like `from_reader`).

`from_bytes` was deprecated in preference to `from_slice`, because now those functions a fully equivalently.
`Deserializer::from_borrowing_reader` was deprecated in preference to `Deserializer::new`, because those methods a fully equivalently.

You may want to create a deserializer for a [transcoding](https://serde.rs/transcode.html) purposes.