### PR TITLE
Add more XML libraries to comparison

### DIFF
--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dev-dependencies]
 criterion = "0.3"
 quick-xml = { path = "..", features = ["serialize"] }
+rapid-xml = "0.2"
 xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 criterion = "0.3"
 quick-xml = { path = "..", features = ["serialize"] }
 xml-rs = "0.8"
+xml5ever = "0.17"
 serde-xml-rs = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 pretty_assertions = "1.2"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dev-dependencies]
 criterion = "0.3"
+maybe_xml = "0.2"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
 xml_oxide = "0.3"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dev-dependencies]
 criterion = "0.3"
 quick-xml = { path = "..", features = ["serialize"] }
+xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"
 xmlparser = "0.13"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -11,6 +11,7 @@ criterion = "0.3"
 maybe_xml = "0.2"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
+rusty_xml = { version = "0.3", package = "RustyXML" }
 xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -11,6 +11,7 @@ criterion = "0.3"
 quick-xml = { path = "..", features = ["serialize"] }
 xml-rs = "0.8"
 xml5ever = "0.17"
+xmlparser = "0.13"
 serde-xml-rs = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 pretty_assertions = "1.2"

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -87,6 +87,24 @@ fn low_level_comparison(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("RustyXML", |b| {
+        use rusty_xml::{Event, Parser};
+
+        b.iter(|| {
+            let mut r = Parser::new();
+            r.feed_str(SOURCE);
+
+            let mut count = criterion::black_box(0);
+            for event in r {
+                match event.unwrap() {
+                    Event::ElementStart(_) => count += 1,
+                    _ => (),
+                }
+            }
+            assert_eq!(count, 1550, "Overall tag count in ./tests/sample_rss.xml");
+        })
+    });
+
     group.bench_function("xml_oxide", |b| {
         use xml_oxide::sax::parser::Parser;
         use xml_oxide::sax::Event;

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -44,6 +44,26 @@ fn low_level_comparison(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("xml_oxide", |b| {
+        use xml_oxide::sax::parser::Parser;
+        use xml_oxide::sax::Event;
+
+        b.iter(|| {
+            let mut r = Parser::from_reader(SOURCE.as_bytes());
+
+            let mut count = criterion::black_box(0);
+            loop {
+                // Makes no progress if error is returned, so need unwrap()
+                match r.read_event().unwrap() {
+                    Event::StartElement(_) => count += 1,
+                    Event::EndDocument => break,
+                    _ => (),
+                }
+            }
+            assert_eq!(count, 1550, "Overall tag count in ./tests/sample_rss.xml");
+        })
+    });
+
     group.bench_function("xml5ever", |b| {
         use xml5ever::buffer_queue::BufferQueue;
         use xml5ever::tokenizer::{TagKind, Token, TokenSink, XmlTokenizer};

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -29,6 +29,21 @@ fn low_level_comparison(c: &mut Criterion) {
         })
     });
 
+    group.bench_function("xmlparser", |b| {
+        use xmlparser::{Token, Tokenizer};
+
+        b.iter(|| {
+            let mut count = criterion::black_box(0);
+            for token in Tokenizer::from(SOURCE) {
+                match token {
+                    Ok(Token::ElementStart { .. }) => count += 1,
+                    _ => (),
+                }
+            }
+            assert_eq!(count, 1550, "Overall tag count in ./tests/sample_rss.xml");
+        })
+    });
+
     group.bench_function("xml5ever", |b| {
         use xml5ever::buffer_queue::BufferQueue;
         use xml5ever::tokenizer::{TagKind, Token, TokenSink, XmlTokenizer};


### PR DESCRIPTION
Replaces https://github.com/Mingun/fast-xml/pull/7

From that benchmarks quick-xml 2-3x times faster than the nearest competitors. Need to notice, however, that comparison very rough and tests only one XML. Also, different libraries supports different set of features, but at least we can see explicit outsiders.