### PR TITLE
Fix errors in sequence deserialization

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,10 @@ jobs:
       env:
         LLVM_PROFILE_FILE: coverage/serialize-escape-html-%p-%m.profraw
       run: cargo test --features serialize,escape-html
+    - name: Run tests (all features)
+      env:
+        LLVM_PROFILE_FILE: coverage/all-features-%p-%m.profraw
+      run: cargo test --all-features
     - name: Prepare coverage information for upload
       if: runner.os == 'Linux'
       # --token is required by grcov, but not required by coveralls.io, so pass

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,14 @@ encoding = ["encoding_rs"]
 ## to quadratic parsing time, because the deserializer must check the list of
 ## events as many times as the number of sequence fields present in the schema.
 ##
+## To reduce negative consequences, always [limit] the maximum number of events
+## that [`Deserializer`] will buffer.
+##
 ## This feature works only with `serialize` feature and has no effect if `serialize`
 ## is not enabled.
+##
+## [limit]: crate::de::Deserializer::event_buffer_size
+## [`Deserializer`]: crate::de::Deserializer
 overlapped-lists = []
 
 ## Enables support for [`serde`] serialization and deserialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,46 @@ default = []
 ## [standard compliant]: https://www.w3.org/TR/xml11/#charencoding
 encoding = ["encoding_rs"]
 
+## This feature enables support for deserializing lists where tags are overlapped
+## with tags that do not correspond to the list.
+##
+## When this feature is enabled, the XML:
+## ```xml
+## <any-name>
+##   <item/>
+##   <another-item/>
+##   <item/>
+##   <item/>
+## </any-name>
+## ```
+## could be deserialized to a struct:
+## ```ignore
+## #[derive(Deserialize)]
+## #[serde(rename_all = "kebab-case")]
+## struct AnyName {
+##   item: Vec<()>,
+##   another_item: (),
+## }
+## ```
+##
+## When this feature is not enabled (default), only the first element will be
+## associated with the field, and the deserialized type will report an error
+## (duplicated field) when the deserializer encounters a second `<item/>`.
+##
+## Note, that enabling this feature can lead to high and even unlimited memory
+## consumption, because deserializer should check all events up to the end of a
+## container tag (`</any-name>` in that example) to figure out that there are no
+## more items for a field. If `</any-name>` or even EOF is not encountered, the
+## parsing will never end which can lead to a denial-of-service (DoS) scenario.
+##
+## Having several lists and overlapped elements for them in XML could also lead
+## to quadratic parsing time, because the deserializer must check the list of
+## events as many times as the number of sequence fields present in the schema.
+##
+## This feature works only with `serialize` feature and has no effect if `serialize`
+## is not enabled.
+overlapped-lists = []
+
 ## Enables support for [`serde`] serialization and deserialization
 serialize = ["serde"]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,9 @@
 - [#9]: Deserialization erroneously was successful in some cases where error is expected.
   This broke deserialization of untagged enums which rely on error if variant cannot be parsed
 - [#387]: Allow to have an ordinary elements together with a `$value` field
+- [#387]: Internal deserializer state can be broken when deserializing a map with
+  a sequence field (such as `Vec<T>`), where elements of this sequence contains
+  another sequence. This error affects only users with the `serialize` feature enabled
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -36,9 +36,11 @@
 ### New Tests
 
 - [#9]: Added tests for incorrect nested tags in input
+- [#387]: Added a bunch of tests for sequences deserialization
 
 [#8]: https://github.com/Mingun/fast-xml/pull/8
 [#9]: https://github.com/Mingun/fast-xml/pull/9
+[#387]: https://github.com/tafia/quick-xml/pull/387
 [#391]: https://github.com/tafia/quick-xml/pull/391
 
 ## 0.23.0 -- 2022-05-08

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,11 @@
 
 ## Unreleased
 
+### New Features
+
+- [#387]: Allow overlapping between elements of sequence and other elements
+  (using new feature `overlapped-lists`)
+
 ### Bug Fixes
 
 - [#9]: Deserialization erroneously was successful in some cases where error is expected.

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 
 - [#9]: Deserialization erroneously was successful in some cases where error is expected.
   This broke deserialization of untagged enums which rely on error if variant cannot be parsed
+- [#387]: Allow to have an ordinary elements together with a `$value` field
 
 ### Misc Changes
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -649,7 +649,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_seq(seq::SeqAccess::new(self)?)
+        visitor.visit_seq(seq::TopLevelSeqAccess::new(self)?)
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -255,14 +255,6 @@ where
 {
     reader: R,
     peek: Option<DeEvent<'de>>,
-    /// Special sing that deserialized struct have a field with the special
-    /// name (see constant `INNER_VALUE`). That field should be deserialized
-    /// from the text content of the XML node:
-    ///
-    /// ```xml
-    /// <tag>value for INNER_VALUE field<tag>
-    /// ```
-    has_value_field: bool,
 }
 
 /// Deserialize an instance of type `T` from a string of XML text.
@@ -354,7 +346,6 @@ where
         Deserializer {
             reader,
             peek: None,
-            has_value_field: false,
         }
     }
 
@@ -544,10 +535,8 @@ where
         // Try to go to the next `<tag ...>...</tag>` or `<tag .../>`
         if let Some(e) = self.next_start()? {
             let name = e.name().to_vec();
-            self.has_value_field = fields.contains(&INNER_VALUE);
             let map = map::MapAccess::new(self, e, fields)?;
             let value = visitor.visit_map(map)?;
-            self.has_value_field = false;
             self.read_to_end(&name)?;
             Ok(value)
         } else {

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -1,18 +1,74 @@
 use crate::de::{DeError, DeEvent, Deserializer, XmlRead};
 use crate::events::BytesStart;
+use crate::reader::Decoder;
 use serde::de::{self, DeserializeSeed};
+#[cfg(not(feature = "encoding"))]
+use std::borrow::Cow;
 
-#[derive(Debug)]
-enum Names {
-    Unknown,
-    Peek(Vec<u8>),
+/// Check if tag `start` is included in the `fields` list. `decoder` is used to
+/// get a string representation of a tag.
+///
+/// Returns `true`, if `start` is not in the `fields` list and `false` otherwise.
+pub fn not_in(
+    fields: &'static [&'static str],
+    start: &BytesStart,
+    decoder: Decoder,
+) -> Result<bool, DeError> {
+    #[cfg(not(feature = "encoding"))]
+    let tag = Cow::Borrowed(decoder.decode(start.name())?);
+
+    #[cfg(feature = "encoding")]
+    let tag = decoder.decode(start.name());
+
+    Ok(fields.iter().all(|&field| field != tag.as_ref()))
 }
 
-impl Names {
-    fn is_valid(&self, start: &BytesStart) -> bool {
+/// A filter that determines, what tags should form a sequence.
+///
+/// There are two types of sequences:
+/// - sequence where each element represented by tags with the same name
+/// - sequence where each element can have a different tag
+///
+/// The first variant could represent a collection of structs, the second --
+/// a collection of enum variants.
+///
+/// In the second case we don't know what tag name should be expected as a
+/// sequence element, so we accept any element. Since the sequence are flattened
+/// into maps, we skip elements which have dedicated fields in a struct by using an
+/// `Exclude` filter that filters out elements with names matching field names
+/// from the struct.
+///
+/// # Lifetimes
+///
+/// `'de` represents a lifetime of the XML input, when filter stores the
+/// dedicated tag name
+#[derive(Debug)]
+enum TagFilter<'de> {
+    /// A `SeqAccess` interested only in tags with specified name to deserialize
+    /// an XML like this:
+    ///
+    /// ```xml
+    /// <...>
+    ///   <tag/>
+    ///   <tag/>
+    ///   <tag/>
+    ///   ...
+    /// </...>
+    /// ```
+    ///
+    /// The tag name is stored inside (`b"tag"` for that example)
+    Include(BytesStart<'de>), //TODO: Need to store only name instead of a whole tag
+    /// A `SeqAccess` interested in tags with any name, except explicitly listed.
+    /// Excluded tags are used as struct field names and therefore should not
+    /// fall into a `$value` category
+    Exclude(&'static [&'static str]),
+}
+
+impl<'de> TagFilter<'de> {
+    fn is_suitable(&self, start: &BytesStart, decoder: Decoder) -> Result<bool, DeError> {
         match self {
-            Names::Unknown => true,
-            Names::Peek(n) => n == start.name(),
+            Self::Include(n) => Ok(n.name() == start.name()),
+            Self::Exclude(fields) => not_in(fields, start, decoder),
         }
     }
 }
@@ -22,8 +78,10 @@ pub struct SeqAccess<'de, 'a, R>
 where
     R: XmlRead<'de>,
 {
+    /// Deserializer used to deserialize sequence items
     de: &'a mut Deserializer<'de, R>,
-    names: Names,
+    /// Filter that determines whether a tag is a part of this sequence.
+    filter: TagFilter<'de>,
 }
 
 impl<'a, 'de, R> SeqAccess<'de, 'a, R>
@@ -32,16 +90,17 @@ where
 {
     /// Get a new SeqAccess
     pub fn new(de: &'a mut Deserializer<'de, R>) -> Result<Self, DeError> {
-        let names = if de.has_value_field {
-            Names::Unknown
+        let filter = if de.has_value_field {
+            TagFilter::Exclude(&[])
         } else {
             if let DeEvent::Start(e) = de.peek()? {
-                Names::Peek(e.name().to_vec())
+                // Clone is cheap if event borrows from the input
+                TagFilter::Include(e.clone())
             } else {
-                Names::Unknown
+                TagFilter::Exclude(&[])
             }
         };
-        Ok(SeqAccess { de, names })
+        Ok(Self { de, filter })
     }
 }
 
@@ -55,10 +114,26 @@ where
     where
         T: DeserializeSeed<'de>,
     {
+        let decoder = self.de.reader.decoder();
         match self.de.peek()? {
             DeEvent::Eof | DeEvent::End(_) => Ok(None),
-            DeEvent::Start(e) if !self.names.is_valid(e) => Ok(None),
+            DeEvent::Start(e) if !self.filter.is_suitable(e, decoder)? => Ok(None),
             _ => seed.deserialize(&mut *self.de).map(Some),
         }
     }
+}
+
+#[test]
+fn test_not_in() {
+    let tag = BytesStart::borrowed_name(b"tag");
+
+    assert_eq!(not_in(&[], &tag, Decoder::utf8()).unwrap(), true);
+    assert_eq!(
+        not_in(&["no", "such", "tags"], &tag, Decoder::utf8()).unwrap(),
+        true
+    );
+    assert_eq!(
+        not_in(&["some", "tag", "included"], &tag, Decoder::utf8()).unwrap(),
+        false
+    );
 }

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -92,15 +92,11 @@ where
 {
     /// Creates a new accessor to a top-level sequence of XML elements.
     pub fn new(de: &'a mut Deserializer<'de, R>) -> Result<Self, DeError> {
-        let filter = if de.has_value_field {
-            TagFilter::Exclude(&[])
+        let filter = if let DeEvent::Start(e) = de.peek()? {
+            // Clone is cheap if event borrows from the input
+            TagFilter::Include(e.clone())
         } else {
-            if let DeEvent::Start(e) = de.peek()? {
-                // Clone is cheap if event borrows from the input
-                TagFilter::Include(e.clone())
-            } else {
-                TagFilter::Exclude(&[])
-            }
+            TagFilter::Exclude(&[])
         };
         Ok(Self { de, filter })
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -116,6 +116,8 @@ pub mod serialize {
     use super::*;
     use crate::utils::write_byte_string;
     use std::fmt;
+    #[cfg(feature = "overlapped-lists")]
+    use std::num::NonZeroUsize;
     use std::num::{ParseFloatError, ParseIntError};
 
     /// (De)serialization error
@@ -159,6 +161,10 @@ pub mod serialize {
         ExpectedStart,
         /// Unsupported operation
         Unsupported(&'static str),
+        /// Too many events were skipped while deserializing a sequence, event limit
+        /// exceeded. The limit was provided as an argument
+        #[cfg(feature = "overlapped-lists")]
+        TooManyEvents(NonZeroUsize),
     }
 
     impl fmt::Display for DeError {
@@ -183,6 +189,8 @@ pub mod serialize {
                 DeError::UnexpectedEof => write!(f, "Unexpected `Event::Eof`"),
                 DeError::ExpectedStart => write!(f, "Expecting `Event::Start`"),
                 DeError::Unsupported(s) => write!(f, "Unsupported operation {}", s),
+                #[cfg(feature = "overlapped-lists")]
+                DeError::TooManyEvents(s) => write!(f, "Deserializer buffers {} events, limit exceeded", s),
             }
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1669,6 +1669,23 @@ impl Decoder {
     }
 }
 
+/// This implementation is required for tests of other parts of the library
+#[cfg(test)]
+#[cfg(feature = "serialize")]
+impl Decoder {
+    #[cfg(not(feature = "encoding"))]
+    pub(crate) fn utf8() -> Self {
+        Decoder
+    }
+
+    #[cfg(feature = "encoding")]
+    pub(crate) fn utf8() -> Self {
+        Decoder {
+            encoding: encoding_rs::UTF_8,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     macro_rules! check {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -512,6 +512,2288 @@ mod tuple_struct {
     }
 }
 
+mod seq {
+    use super::*;
+
+    /// Check that top-level sequences can be deserialized from the multi-root XML documents
+    mod top_level {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn simple() {
+            from_str::<[(); 3]>("<root/><root>42</root><root>answer</root>").unwrap();
+
+            let data: Vec<()> = from_str("<root/><root>42</root><root>answer</root>").unwrap();
+            assert_eq!(data, vec![(), (), ()]);
+        }
+
+        /// Special case: empty sequence
+        #[test]
+        fn empty() {
+            from_str::<[(); 0]>("").unwrap();
+
+            let data: Vec<()> = from_str("").unwrap();
+            assert_eq!(data, vec![]);
+        }
+
+        /// Special case: one-element sequence
+        #[test]
+        fn one_element() {
+            from_str::<[(); 1]>("<root/>").unwrap();
+            from_str::<[(); 1]>("<root>42</root>").unwrap();
+            from_str::<[(); 1]>("text").unwrap();
+            from_str::<[(); 1]>("<![CDATA[cdata]]>").unwrap();
+
+            let data: Vec<()> = from_str("<root/>").unwrap();
+            assert_eq!(data, vec![()]);
+
+            let data: Vec<()> = from_str("<root>42</root>").unwrap();
+            assert_eq!(data, vec![()]);
+
+            let data: Vec<()> = from_str("text").unwrap();
+            assert_eq!(data, vec![()]);
+
+            let data: Vec<()> = from_str("<![CDATA[cdata]]>").unwrap();
+            assert_eq!(data, vec![()]);
+        }
+
+        #[test]
+        fn excess_attribute() {
+            from_str::<[(); 3]>(r#"<root/><root excess="attribute">42</root><root>answer</root>"#)
+                .unwrap();
+
+            let data: Vec<()> =
+                from_str(r#"<root/><root excess="attribute">42</root><root>answer</root>"#)
+                    .unwrap();
+            assert_eq!(data, vec![(), (), ()]);
+        }
+
+        #[test]
+        fn mixed_content() {
+            from_str::<[(); 3]>(
+                r#"
+                <element/>
+                text
+                <![CDATA[cdata]]>
+                "#,
+            )
+            .unwrap();
+
+            let data: Vec<()> = from_str(
+                r#"
+                <element/>
+                text
+                <![CDATA[cdata]]>
+                "#,
+            )
+            .unwrap();
+            assert_eq!(data, vec![(), (), ()]);
+        }
+    }
+
+    /// Tests where each sequence item have an identical name in an XML.
+    /// That explicitly means that `enum`s as list elements are not supported
+    /// in that case, because enum requires different tags.
+    ///
+    /// (by `enums` we mean [externally tagged enums] is serde terminology)
+    ///
+    /// [externally tagged enums]: https://serde.rs/enum-representations.html#externally-tagged
+    mod fixed_name {
+        use super::*;
+
+        /// This module contains tests where size of the list have a compile-time size
+        mod fixed_size {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                item: [(); 3],
+            }
+
+            /// Simple case: count of elements matches expected size of sequence,
+            /// each element has the same name. Successful deserialization expected
+            #[test]
+            fn simple() {
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <item/>
+                        <item/>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+            }
+
+            /// Special case: empty sequence
+            #[test]
+            #[ignore = "it is impossible to distinguish between missed field and empty list: use `Option<>` or #[serde(default)]"]
+            fn empty() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    item: [(); 0],
+                }
+
+                from_str::<List>(r#"<root></root>"#).unwrap();
+                from_str::<List>(r#"<root/>"#).unwrap();
+            }
+
+            /// Special case: one-element sequence
+            #[test]
+            fn one_element() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    item: [(); 1],
+                }
+
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+            }
+
+            /// Fever elements than expected size of sequence, each element has
+            /// the same name. Failure expected
+            #[test]
+            fn fever_elements() {
+                let data = from_str::<List>(
+                    r#"
+                    <root>
+                        <item/>
+                        <item/>
+                    </root>
+                    "#,
+                );
+
+                match data {
+                    Err(DeError::Custom(e)) => {
+                        assert_eq!(e, "invalid length 2, expected an array of length 3")
+                    }
+                    e => panic!(
+                        r#"Expected `Err(Custom("invalid length 2, expected an array of length 3"))`, but found {:?}"#,
+                        e
+                    ),
+                }
+            }
+
+            /// More elements than expected size of sequence, each element has
+            /// the same name. Failure expected. If you wish to ignore excess
+            /// elements, use the special type, that consume as much elements
+            /// as possible, but ignores excess elements
+            #[test]
+            fn excess_elements() {
+                let data = from_str::<List>(
+                    r#"
+                    <root>
+                        <item/>
+                        <item/>
+                        <item/>
+                        <item/>
+                    </root>
+                    "#,
+                );
+
+                match data {
+                    Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `item`"),
+                    e => panic!(
+                        r#"Expected `Err(Custom("duplicate field `item`"))`, but found {:?}"#,
+                        e
+                    ),
+                }
+            }
+
+            /// Mixed content assumes, that some elements will have an internal
+            /// name `$value`, so, unless field named the same, it is expected
+            /// to fail
+            #[test]
+            fn mixed_content() {
+                let data = from_str::<List>(
+                    r#"
+                    <root>
+                        <element/>
+                        text
+                        <![CDATA[cdata]]>
+                    </root>
+                    "#,
+                );
+
+                match data {
+                    Err(DeError::Custom(e)) => assert_eq!(e, "missing field `item`"),
+                    e => panic!(
+                        r#"Expected `Err(Custom("missing field `item`"))`, but found {:?}"#,
+                        e
+                    ),
+                }
+            }
+
+            /// In those tests sequence should be deserialized from an XML
+            /// with additional elements that is not defined in the struct.
+            /// That fields should be skipped during deserialization
+            mod unknown_items {
+                use super::*;
+
+                #[test]
+                fn before() {
+                    from_str::<List>(
+                        r#"
+                        <root>
+                            <unknown/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+
+                #[test]
+                fn after() {
+                    from_str::<List>(
+                        r#"
+                        <root>
+                            <item/>
+                            <item/>
+                            <item/>
+                            <unknown/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+
+                #[test]
+                fn overlapped() {
+                    from_str::<List>(
+                        r#"
+                        <root>
+                            <item/>
+                            <unknown/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+            }
+
+            /// In those tests non-sequential field is defined in the struct
+            /// before sequential, so it will be deserialized before the list.
+            /// That struct should be deserialized from an XML where these
+            /// fields comes in an arbitrary order
+            mod field_before_list {
+                use super::*;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Root {
+                    node: (),
+                    item: [(); 3],
+                }
+
+                #[test]
+                fn before() {
+                    from_str::<Root>(
+                        r#"
+                        <root>
+                            <node/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+
+                #[test]
+                fn after() {
+                    from_str::<Root>(
+                        r#"
+                        <root>
+                            <item/>
+                            <item/>
+                            <item/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+
+                #[test]
+                fn overlapped() {
+                    from_str::<Root>(
+                        r#"
+                        <root>
+                            <item/>
+                            <node/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+            }
+
+            /// In those tests non-sequential field is defined in the struct
+            /// after sequential, so it will be deserialized after the list.
+            /// That struct should be deserialized from an XML where these
+            /// fields comes in an arbitrary order
+            mod field_after_list {
+                use super::*;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Root {
+                    item: [(); 3],
+                    node: (),
+                }
+
+                #[test]
+                fn before() {
+                    from_str::<Root>(
+                        r#"
+                        <root>
+                            <node/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+
+                #[test]
+                fn after() {
+                    from_str::<Root>(
+                        r#"
+                        <root>
+                            <item/>
+                            <item/>
+                            <item/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+
+                #[test]
+                fn overlapped() {
+                    from_str::<Root>(
+                        r#"
+                        <root>
+                            <item/>
+                            <node/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+            }
+
+            /// In those tests two lists are deserialized simultaneously.
+            /// Lists should be deserialized even when them overlaps
+            mod two_lists {
+                use super::*;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Pair {
+                    item: [(); 3],
+                    element: [(); 2],
+                }
+
+                #[test]
+                fn splitted() {
+                    from_str::<Pair>(
+                        r#"
+                        <root>
+                            <element/>
+                            <element/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+
+                #[test]
+                fn overlapped() {
+                    from_str::<Pair>(
+                        r#"
+                        <root>
+                            <item/>
+                            <element/>
+                            <item/>
+                            <element/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+                }
+            }
+
+            /// Deserialization of primitives slightly differs from deserialization
+            /// of complex types, so need to check this separately
+            #[test]
+            fn primitives() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    item: [usize; 3],
+                }
+
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item>41</item>
+                        <item>42</item>
+                        <item>43</item>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+                assert_eq!(data, List { item: [41, 42, 43] });
+
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <item>41</item>
+                        <item><item>42</item></item>
+                        <item>43</item>
+                    </root>
+                    "#,
+                )
+                .unwrap_err();
+            }
+        }
+
+        /// This module contains tests where size of the list have an unspecified size
+        mod variable_size {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                item: Vec<()>,
+            }
+
+            /// Simple case: count of elements matches expected size of sequence,
+            /// each element has the same name. Successful deserialization expected
+            #[test]
+            fn simple() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item/>
+                        <item/>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: vec![(), (), ()],
+                    }
+                );
+            }
+
+            /// Special case: empty sequence
+            #[test]
+            #[ignore = "it is impossible to distinguish between missed field and empty list: use `Option<>` or #[serde(default)]"]
+            fn empty() {
+                let data: List = from_str(r#"<root></root>"#).unwrap();
+                assert_eq!(data, List { item: vec![] });
+
+                let data: List = from_str(r#"<root/>"#).unwrap();
+                assert_eq!(data, List { item: vec![] });
+            }
+
+            /// Special case: one-element sequence
+            #[test]
+            fn one_element() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(data, List { item: vec![()] });
+            }
+
+            /// Mixed content assumes, that some elements will have an internal
+            /// name `$value`, so, unless field named the same, it is expected
+            /// to fail
+            #[test]
+            fn mixed_content() {
+                let data = from_str::<List>(
+                    r#"
+                    <root>
+                        <element/>
+                        text
+                        <![CDATA[cdata]]>
+                    </root>
+                    "#,
+                );
+
+                match data {
+                    Err(DeError::Custom(e)) => assert_eq!(e, "missing field `item`"),
+                    e => panic!(
+                        r#"Expected `Err(Custom("missing field `item`"))`, but found {:?}"#,
+                        e
+                    ),
+                }
+            }
+
+            /// In those tests sequence should be deserialized from the XML
+            /// with additional elements that is not defined in the struct.
+            /// That fields should be skipped during deserialization
+            mod unknown_items {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[test]
+                fn before() {
+                    let data: List = from_str(
+                        r#"
+                        <root>
+                            <unknown/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        List {
+                            item: vec![(), (), ()],
+                        }
+                    );
+                }
+
+                #[test]
+                fn after() {
+                    let data: List = from_str(
+                        r#"
+                        <root>
+                            <item/>
+                            <item/>
+                            <item/>
+                            <unknown/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        List {
+                            item: vec![(), (), ()],
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: List = from_str(
+                        r#"
+                        <root>
+                            <item/>
+                            <unknown/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        List {
+                            item: vec![(), (), ()],
+                        }
+                    );
+                }
+            }
+
+            /// In those tests non-sequential field is defined in the struct
+            /// before sequential, so it will be deserialized before the list.
+            /// That struct should be deserialized from the XML where these
+            /// fields comes in an arbitrary order
+            mod field_before_list {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Debug, PartialEq, Default, Deserialize)]
+                struct Root {
+                    node: (),
+                    item: Vec<()>,
+                }
+
+                #[test]
+                fn before() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <node/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: vec![(), (), ()],
+                        }
+                    );
+                }
+
+                #[test]
+                fn after() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <item/>
+                            <item/>
+                            <item/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: vec![(), (), ()],
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <item/>
+                            <node/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: vec![(), (), ()],
+                        }
+                    );
+                }
+            }
+
+            /// In those tests non-sequential field is defined in the struct
+            /// after sequential, so it will be deserialized after the list.
+            /// That struct should be deserialized from the XML where these
+            /// fields comes in an arbitrary order
+            mod field_after_list {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Debug, PartialEq, Default, Deserialize)]
+                struct Root {
+                    item: Vec<()>,
+                    node: (),
+                }
+
+                #[test]
+                fn before() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <node/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: vec![(), (), ()],
+                            node: (),
+                        }
+                    );
+                }
+
+                #[test]
+                fn after() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <item/>
+                            <item/>
+                            <item/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: vec![(), (), ()],
+                            node: (),
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <item/>
+                            <node/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: vec![(), (), ()],
+                            node: (),
+                        }
+                    );
+                }
+            }
+
+            /// In those tests two lists are deserialized simultaneously.
+            /// Lists should be deserialized even when them overlaps
+            mod two_lists {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Pair {
+                    item: Vec<()>,
+                    element: Vec<()>,
+                }
+
+                #[test]
+                fn splitted() {
+                    let data: Pair = from_str(
+                        r#"
+                        <root>
+                            <element/>
+                            <element/>
+                            <item/>
+                            <item/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Pair {
+                            item: vec![(), (), ()],
+                            element: vec![(), ()],
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: Pair = from_str(
+                        r#"
+                        <root>
+                            <item/>
+                            <element/>
+                            <item/>
+                            <element/>
+                            <item/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Pair {
+                            item: vec![(), (), ()],
+                            element: vec![(), ()],
+                        }
+                    );
+                }
+            }
+
+            /// Deserialization of primitives slightly differs from deserialization
+            /// of complex types, so need to check this separately
+            #[test]
+            fn primitives() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    item: Vec<usize>,
+                }
+
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item>41</item>
+                        <item>42</item>
+                        <item>43</item>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: vec![41, 42, 43],
+                    }
+                );
+
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <item>41</item>
+                        <item><item>42</item></item>
+                        <item>43</item>
+                    </root>
+                    "#,
+                )
+                .unwrap_err();
+            }
+        }
+    }
+
+    /// Check that sequences inside element can be deserialized.
+    /// In terms of serde this is a sequence flatten into the struct:
+    ///
+    /// ```ignore
+    /// struct Root {
+    ///   #[serde(flatten)]
+    ///   items: Vec<T>,
+    /// }
+    /// ```
+    /// except that fact that this is not supported nowadays
+    /// (https://github.com/serde-rs/serde/issues/1905)
+    ///
+    /// Because this is very frequently used pattern in the XML, quick-xml
+    /// have a workaround for this. If a field will have a special name `$value`
+    /// then any `xs:element`s in the `xs:sequence` / `xs:all`, except that
+    /// which name matches the struct name, will be associated with this field:
+    ///
+    /// ```ignore
+    /// struct Root {
+    ///   field: U,
+    ///   #[serde(rename = "$value")]
+    ///   items: Vec<Enum>,
+    /// }
+    /// ```
+    /// In this example `<field>` tag will be associated with a `field` field,
+    /// but all other tags will be associated with an `items` field. Disadvantages
+    /// of this approach that you can have only one field, but usually you don't
+    /// want more
+    mod variable_name {
+        use super::*;
+        use serde::de::{Deserializer, EnumAccess, VariantAccess, Visitor};
+        use std::fmt::{self, Formatter};
+
+        // NOTE: Derive could be possible once https://github.com/serde-rs/serde/issues/2126 is resolved
+        macro_rules! impl_deserialize_choice {
+            ($name:ident : $(($field:ident, $field_name:literal)),*) => {
+                impl<'de> Deserialize<'de> for $name {
+                    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                    where
+                        D: Deserializer<'de>,
+                    {
+                        #[derive(Deserialize)]
+                        #[serde(field_identifier)]
+                        #[serde(rename_all = "kebab-case")]
+                        enum Tag {
+                            $($field,)*
+                            Other(String),
+                        }
+
+                        struct EnumVisitor;
+                        impl<'de> Visitor<'de> for EnumVisitor {
+                            type Value = $name;
+
+                            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                                f.write_str("enum ")?;
+                                f.write_str(stringify!($name))
+                            }
+
+                            fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+                            where
+                                A: EnumAccess<'de>,
+                            {
+                                match data.variant()? {
+                                    $(
+                                        (Tag::$field, variant) => variant.unit_variant().map(|_| $name::$field),
+                                    )*
+                                    (Tag::Other(t), v) => v.unit_variant().map(|_| $name::Other(t)),
+                                }
+                            }
+                        }
+
+                        const VARIANTS: &'static [&'static str] = &[
+                            $($field_name,)*
+                            "<any other tag>"
+                        ];
+                        deserializer.deserialize_enum(stringify!($name), VARIANTS, EnumVisitor)
+                    }
+                }
+            };
+        }
+
+        /// Type that can be deserialized from `<one>`, `<two>`, or any other element
+        #[derive(Debug, PartialEq)]
+        enum Choice {
+            One,
+            Two,
+            /// Any other tag name except `One` or `Two`, name of tag stored inside variant
+            Other(String),
+        }
+        impl_deserialize_choice!(Choice: (One, "one"), (Two, "two"));
+
+        /// Type that can be deserialized from `<first>`, `<second>`, or any other element
+        #[derive(Debug, PartialEq)]
+        enum Choice2 {
+            First,
+            Second,
+            /// Any other tag name except `First` or `Second`, name of tag stored inside variant
+            Other(String),
+        }
+        impl_deserialize_choice!(Choice2: (First, "first"), (Second, "second"));
+
+        /// Type that can be deserialized from `<one>`, `<two>`, or any other element.
+        /// Used for `primitives` tests
+        #[derive(Debug, PartialEq, Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        enum Choice3 {
+            One(usize),
+            Two(String),
+            #[serde(other)]
+            Other,
+        }
+
+        /// This module contains tests where size of the list have a compile-time size
+        mod fixed_size {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                #[serde(rename = "$value")]
+                item: [Choice; 3],
+            }
+
+            /// Simple case: count of elements matches expected size of sequence,
+            /// each element has the same name. Successful deserialization expected
+            #[test]
+            fn simple() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <one/>
+                        <two/>
+                        <three/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                    }
+                );
+            }
+
+            /// Special case: empty sequence
+            #[test]
+            #[ignore = "it is impossible to distinguish between missed field and empty list: use `Option<>` or #[serde(default)]"]
+            fn empty() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    #[serde(rename = "$value")]
+                    item: [Choice; 0],
+                }
+
+                from_str::<List>(r#"<root></root>"#).unwrap();
+                from_str::<List>(r#"<root/>"#).unwrap();
+            }
+
+            /// Special case: one-element sequence
+            #[test]
+            fn one_element() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    #[serde(rename = "$value")]
+                    item: [Choice; 1],
+                }
+
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <one/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: [Choice::One],
+                    }
+                );
+            }
+
+            /// Fever elements than expected size of sequence, each element has
+            /// the same name. Failure expected
+            #[test]
+            fn fever_elements() {
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <one/>
+                        <two/>
+                    </root>
+                    "#,
+                )
+                .unwrap_err();
+            }
+
+            /// More elements than expected size of sequence, each element has
+            /// the same name. Failure expected. If you wish to ignore excess
+            /// elements, use the special type, that consume as much elements
+            /// as possible, but ignores excess elements
+            #[test]
+            fn excess_elements() {
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <one/>
+                        <two/>
+                        <three/>
+                        <four/>
+                    </root>
+                    "#,
+                )
+                .unwrap_err();
+            }
+
+            #[test]
+            fn mixed_content() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    #[serde(rename = "$value")]
+                    item: [(); 3],
+                }
+
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <element/>
+                        text
+                        <![CDATA[cdata]]>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+            }
+
+            // There cannot be unknown items, because any tag name is accepted
+
+            /// In those tests non-sequential field is defined in the struct
+            /// before sequential, so it will be deserialized before the list.
+            /// That struct should be deserialized from the XML where these
+            /// fields comes in an arbitrary order
+            mod field_before_list {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Root {
+                    node: (),
+                    #[serde(rename = "$value")]
+                    item: [Choice; 3],
+                }
+
+                #[test]
+                fn before() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <node/>
+                            <one/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                        }
+                    );
+                }
+
+                #[test]
+                fn after() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <two/>
+                            <three/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <node/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                        }
+                    );
+                }
+            }
+
+            /// In those tests non-sequential field is defined in the struct
+            /// after sequential, so it will be deserialized after the list.
+            /// That struct should be deserialized from the XML where these
+            /// fields comes in an arbitrary order
+            mod field_after_list {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Root {
+                    #[serde(rename = "$value")]
+                    item: [Choice; 3],
+                    node: (),
+                }
+
+                #[test]
+                fn before() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <node/>
+                            <one/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                            node: (),
+                        }
+                    );
+                }
+
+                #[test]
+                fn after() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <two/>
+                            <three/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                            node: (),
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <node/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                            node: (),
+                        }
+                    );
+                }
+            }
+
+            /// In those tests two lists are deserialized simultaneously.
+            /// Lists should be deserialized even when them overlaps
+            mod two_lists {
+                use super::*;
+
+                /// A field with a variable-name items defined before a field with a fixed-name
+                /// items
+                mod choice_and_fixed {
+                    use super::*;
+                    use pretty_assertions::assert_eq;
+
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        #[serde(rename = "$value")]
+                        item: [Choice; 3],
+                        element: [(); 2],
+                    }
+
+                    /// A list with fixed-name elements located before a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements located after a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <two/>
+                                <three/>
+                                <element/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a fixed-name one
+                    #[test]
+                    fn overlapped_fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <element/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a variable-name one
+                    #[test]
+                    fn overlapped_fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <element/>
+                                <two/>
+                                <three/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+                }
+
+                /// A field with a variable-name items defined after a field with a fixed-name
+                /// items
+                mod fixed_and_choice {
+                    use super::*;
+                    use pretty_assertions::assert_eq;
+
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        element: [(); 2],
+                        #[serde(rename = "$value")]
+                        item: [Choice; 3],
+                    }
+
+                    /// A list with fixed-name elements located before a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements located after a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <two/>
+                                <three/>
+                                <element/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a fixed-name one
+                    #[test]
+                    fn overlapped_fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <element/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a variable-name one
+                    #[test]
+                    fn overlapped_fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <element/>
+                                <two/>
+                                <three/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [(), ()],
+                            }
+                        );
+                    }
+                }
+
+                /// Tests are ignored, but exists to show a problem.
+                /// May be it will be solved in the future
+                mod choice_and_choice {
+                    use super::*;
+                    use pretty_assertions::assert_eq;
+
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        #[serde(rename = "$value")]
+                        item: [Choice; 3],
+                        // Actually, we cannot rename both fields to `$value`, which is now
+                        // required to indicate, that field accepts elements with any name
+                        #[serde(rename = "$value")]
+                        element: [Choice2; 2],
+                    }
+
+                    #[test]
+                    #[ignore = "There is no way to associate XML elements with `item` or `element` without extra knowledge from type"]
+                    fn splitted() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <first/>
+                                <second/>
+                                <one/>
+                                <two/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [Choice2::First, Choice2::Second],
+                            }
+                        );
+                    }
+
+                    #[test]
+                    #[ignore = "There is no way to associate XML elements with `item` or `element` without extra knowledge from type"]
+                    fn overlapped() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <first/>
+                                <two/>
+                                <second/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: [Choice2::First, Choice2::Second],
+                            }
+                        );
+                    }
+                }
+            }
+
+            /// Deserialization of primitives slightly differs from deserialization
+            /// of complex types, so need to check this separately
+            #[test]
+            fn primitives() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    #[serde(rename = "$value")]
+                    item: [Choice3; 3],
+                }
+
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <one>41</one>
+                        <two>42</two>
+                        <three>43</three>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: [
+                            Choice3::One(41),
+                            Choice3::Two("42".to_string()),
+                            Choice3::Other,
+                        ],
+                    }
+                );
+
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <one>41</one>
+                        <two><item>42</item></two>
+                        <three>43</three>
+                    </root>
+                    "#,
+                )
+                .unwrap_err();
+            }
+        }
+
+        /// This module contains tests where size of the list have an unspecified size
+        mod variable_size {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                #[serde(rename = "$value")]
+                item: Vec<Choice>,
+            }
+
+            /// Simple case: count of elements matches expected size of sequence,
+            /// each element has the same name. Successful deserialization expected
+            #[test]
+            fn simple() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <one/>
+                        <two/>
+                        <three/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                    }
+                );
+            }
+
+            /// Special case: empty sequence
+            #[test]
+            #[ignore = "it is impossible to distinguish between missed field and empty list: use `Option<>` or #[serde(default)]"]
+            fn empty() {
+                let data = from_str::<List>(r#"<root></root>"#).unwrap();
+                assert_eq!(data, List { item: vec![] });
+
+                let data = from_str::<List>(r#"<root/>"#).unwrap();
+                assert_eq!(data, List { item: vec![] });
+            }
+
+            /// Special case: one-element sequence
+            #[test]
+            fn one_element() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <one/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: vec![Choice::One],
+                    }
+                );
+            }
+
+            #[test]
+            fn mixed_content() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    #[serde(rename = "$value")]
+                    item: Vec<()>,
+                }
+
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <element/>
+                        text
+                        <![CDATA[cdata]]>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: vec![(), (), ()],
+                    }
+                );
+            }
+
+            // There cannot be unknown items, because any tag name is accepted
+
+            /// In those tests non-sequential field is defined in the struct
+            /// before sequential, so it will be deserialized before the list.
+            /// That struct should be deserialized from the XML where these
+            /// fields comes in an arbitrary order
+            mod field_before_list {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Root {
+                    node: (),
+                    #[serde(rename = "$value")]
+                    item: Vec<Choice>,
+                }
+
+                #[test]
+                fn before() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <node/>
+                            <one/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                        }
+                    );
+                }
+
+                #[test]
+                fn after() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <two/>
+                            <three/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <node/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            node: (),
+                            item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                        }
+                    );
+                }
+            }
+
+            /// In those tests non-sequential field is defined in the struct
+            /// after sequential, so it will be deserialized after the list.
+            /// That struct should be deserialized from the XML where these
+            /// fields comes in an arbitrary order
+            mod field_after_list {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct Root {
+                    #[serde(rename = "$value")]
+                    item: Vec<Choice>,
+                    node: (),
+                }
+
+                #[test]
+                fn before() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <node/>
+                            <one/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            node: (),
+                        }
+                    );
+                }
+
+                #[test]
+                fn after() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <two/>
+                            <three/>
+                            <node/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            node: (),
+                        }
+                    );
+                }
+
+                #[test]
+                fn overlapped() {
+                    let data: Root = from_str(
+                        r#"
+                        <root>
+                            <one/>
+                            <node/>
+                            <two/>
+                            <three/>
+                        </root>
+                        "#,
+                    )
+                    .unwrap();
+
+                    assert_eq!(
+                        data,
+                        Root {
+                            item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            node: (),
+                        }
+                    );
+                }
+            }
+
+            /// In those tests two lists are deserialized simultaneously.
+            /// Lists should be deserialized even when them overlaps
+            mod two_lists {
+                use super::*;
+
+                /// A field with a variable-name items defined before a field with a fixed-name
+                /// items
+                mod choice_and_fixed {
+                    use super::*;
+                    use pretty_assertions::assert_eq;
+
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        #[serde(rename = "$value")]
+                        item: Vec<Choice>,
+                        element: Vec<()>,
+                    }
+
+                    /// A list with fixed-name elements located before a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: vec![(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements located after a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <two/>
+                                <three/>
+                                <element/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: vec![(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a fixed-name one
+                    #[test]
+                    fn overlapped_fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <element/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: vec![(), ()],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a variable-name one
+                    #[test]
+                    fn overlapped_fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <element/>
+                                <two/>
+                                <three/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: vec![(), ()],
+                            }
+                        );
+                    }
+                }
+
+                /// A field with a variable-name items defined after a field with a fixed-name
+                /// items
+                mod fixed_and_choice {
+                    use super::*;
+                    use pretty_assertions::assert_eq;
+
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        element: Vec<()>,
+                        #[serde(rename = "$value")]
+                        item: Vec<Choice>,
+                    }
+
+                    /// A list with fixed-name elements located before a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                element: vec![(), ()],
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements located after a list with variable-name
+                    /// elements in an XML
+                    #[test]
+                    fn fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <two/>
+                                <three/>
+                                <element/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                element: vec![(), ()],
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a fixed-name one
+                    #[test]
+                    fn overlapped_fixed_before() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <element/>
+                                <one/>
+                                <two/>
+                                <element/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                element: vec![(), ()],
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            }
+                        );
+                    }
+
+                    /// A list with fixed-name elements are mixed with a list with variable-name
+                    /// elements in an XML, and the first element is a variable-name one
+                    #[test]
+                    fn overlapped_fixed_after() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <element/>
+                                <two/>
+                                <three/>
+                                <element/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                element: vec![(), ()],
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            }
+                        );
+                    }
+                }
+
+                /// Tests are ignored, but exists to show a problem.
+                /// May be it will be solved in the future
+                mod choice_and_choice {
+                    use super::*;
+                    use pretty_assertions::assert_eq;
+
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        #[serde(rename = "$value")]
+                        item: Vec<Choice>,
+                        // Actually, we cannot rename both fields to `$value`, which is now
+                        // required to indicate, that field accepts elements with any name
+                        #[serde(rename = "$value")]
+                        element: Vec<Choice2>,
+                    }
+
+                    #[test]
+                    #[ignore = "There is no way to associate XML elements with `item` or `element` without extra knowledge from type"]
+                    fn splitted() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <first/>
+                                <second/>
+                                <one/>
+                                <two/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: vec![Choice2::First, Choice2::Second],
+                            }
+                        );
+                    }
+
+                    #[test]
+                    #[ignore = "There is no way to associate XML elements with `item` or `element` without extra knowledge from type"]
+                    fn overlapped() {
+                        let data: Pair = from_str(
+                            r#"
+                            <root>
+                                <one/>
+                                <first/>
+                                <two/>
+                                <second/>
+                                <three/>
+                            </root>
+                            "#,
+                        )
+                        .unwrap();
+
+                        assert_eq!(
+                            data,
+                            Pair {
+                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                                element: vec![Choice2::First, Choice2::Second],
+                            }
+                        );
+                    }
+                }
+            }
+
+            /// Deserialization of primitives slightly differs from deserialization
+            /// of complex types, so need to check this separately
+            #[test]
+            fn primitives() {
+                #[derive(Debug, PartialEq, Deserialize)]
+                struct List {
+                    #[serde(rename = "$value")]
+                    item: Vec<Choice3>,
+                }
+
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <one>41</one>
+                        <two>42</two>
+                        <three>43</three>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        item: vec![
+                            Choice3::One(41),
+                            Choice3::Two("42".to_string()),
+                            Choice3::Other,
+                        ],
+                    }
+                );
+
+                from_str::<List>(
+                    r#"
+                    <root>
+                        <one>41</one>
+                        <two><item>42</item></two>
+                        <three>43</three>
+                    </root>
+                    "#,
+                )
+                .unwrap_err();
+            }
+        }
+    }
+}
+
 macro_rules! maplike_errors {
     ($type:ty) => {
         mod non_closed {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -738,6 +738,8 @@ mod seq {
             /// That fields should be skipped during deserialization
             mod unknown_items {
                 use super::*;
+                #[cfg(not(feature = "overlapped-lists"))]
+                use pretty_assertions::assert_eq;
 
                 #[test]
                 fn before() {
@@ -771,7 +773,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    from_str::<List>(
+                    let data = from_str::<List>(
                         r#"
                         <root>
                             <item/>
@@ -780,8 +782,21 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -791,6 +806,8 @@ mod seq {
             /// fields comes in an arbitrary order
             mod field_before_list {
                 use super::*;
+                #[cfg(not(feature = "overlapped-lists"))]
+                use pretty_assertions::assert_eq;
 
                 #[derive(Debug, PartialEq, Deserialize)]
                 struct Root {
@@ -830,7 +847,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    from_str::<Root>(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <item/>
@@ -839,8 +856,21 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -850,6 +880,8 @@ mod seq {
             /// fields comes in an arbitrary order
             mod field_after_list {
                 use super::*;
+                #[cfg(not(feature = "overlapped-lists"))]
+                use pretty_assertions::assert_eq;
 
                 #[derive(Debug, PartialEq, Deserialize)]
                 struct Root {
@@ -889,7 +921,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    from_str::<Root>(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <item/>
@@ -898,8 +930,21 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -907,6 +952,8 @@ mod seq {
             /// Lists should be deserialized even when them overlaps
             mod two_lists {
                 use super::*;
+                #[cfg(not(feature = "overlapped-lists"))]
+                use pretty_assertions::assert_eq;
 
                 #[derive(Debug, PartialEq, Deserialize)]
                 struct Pair {
@@ -932,7 +979,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    from_str::<Pair>(
+                    let data = from_str::<Pair>(
                         r#"
                         <root>
                             <item/>
@@ -942,8 +989,21 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -1117,7 +1177,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: List = from_str(
+                    let data = from_str::<List>(
                         r#"
                         <root>
                             <item/>
@@ -1126,15 +1186,24 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         List {
                             item: vec![(), (), ()],
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `item`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -1200,7 +1269,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: Root = from_str(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <item/>
@@ -1209,16 +1278,27 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         Root {
                             node: (),
                             item: vec![(), (), ()],
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "duplicate field `item`")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -1284,7 +1364,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: Root = from_str(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <item/>
@@ -1293,16 +1373,27 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         Root {
                             item: vec![(), (), ()],
                             node: (),
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "duplicate field `item`")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -1344,7 +1435,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: Pair = from_str(
+                    let data = from_str::<Pair>(
                         r#"
                         <root>
                             <item/>
@@ -1354,16 +1445,25 @@ mod seq {
                             <item/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         Pair {
                             item: vec![(), (), ()],
                             element: vec![(), ()],
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `item`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -1713,7 +1813,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: Root = from_str(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <one/>
@@ -1722,16 +1822,27 @@ mod seq {
                             <three/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         Root {
                             node: (),
                             item: [Choice::One, Choice::Two, Choice::Other("three".into())],
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -1798,7 +1909,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: Root = from_str(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <one/>
@@ -1807,16 +1918,27 @@ mod seq {
                             <three/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         Root {
                             item: [Choice::One, Choice::Two, Choice::Other("three".into())],
                             node: (),
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -1894,7 +2016,7 @@ mod seq {
                     /// elements in an XML, and the first element is a fixed-name one
                     #[test]
                     fn overlapped_fixed_before() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <element/>
@@ -1904,23 +2026,34 @@ mod seq {
                                 <three/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: [Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: [(), ()],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => {
+                                assert_eq!(e, "invalid length 1, expected an array of length 2")
+                            }
+                            e => panic!(
+                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
 
                     /// A list with fixed-name elements are mixed with a list with variable-name
                     /// elements in an XML, and the first element is a variable-name one
                     #[test]
                     fn overlapped_fixed_after() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <one/>
@@ -1930,16 +2063,27 @@ mod seq {
                                 <element/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: [Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: [(), ()],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => {
+                                assert_eq!(e, "invalid length 1, expected an array of length 3")
+                            }
+                            e => panic!(
+                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
                 }
 
@@ -2012,7 +2156,7 @@ mod seq {
                     /// elements in an XML, and the first element is a fixed-name one
                     #[test]
                     fn overlapped_fixed_before() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <element/>
@@ -2022,23 +2166,34 @@ mod seq {
                                 <three/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: [Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: [(), ()],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => {
+                                assert_eq!(e, "invalid length 1, expected an array of length 2")
+                            }
+                            e => panic!(
+                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
 
                     /// A list with fixed-name elements are mixed with a list with variable-name
                     /// elements in an XML, and the first element is a variable-name one
                     #[test]
                     fn overlapped_fixed_after() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <one/>
@@ -2048,16 +2203,27 @@ mod seq {
                                 <element/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: [Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: [(), ()],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => {
+                                assert_eq!(e, "invalid length 1, expected an array of length 3")
+                            }
+                            e => panic!(
+                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
                 }
 
@@ -2105,7 +2271,7 @@ mod seq {
                     #[test]
                     #[ignore = "There is no way to associate XML elements with `item` or `element` without extra knowledge from type"]
                     fn overlapped() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <one/>
@@ -2115,16 +2281,27 @@ mod seq {
                                 <three/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: [Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: [Choice2::First, Choice2::Second],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => {
+                                assert_eq!(e, "invalid length 1, expected an array of length 3")
+                            }
+                            e => panic!(
+                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
                 }
             }
@@ -2331,7 +2508,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: Root = from_str(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <one/>
@@ -2340,16 +2517,25 @@ mod seq {
                             <three/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         Root {
                             node: (),
                             item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -2416,7 +2602,7 @@ mod seq {
 
                 #[test]
                 fn overlapped() {
-                    let data: Root = from_str(
+                    let data = from_str::<Root>(
                         r#"
                         <root>
                             <one/>
@@ -2425,16 +2611,25 @@ mod seq {
                             <three/>
                         </root>
                         "#,
-                    )
-                    .unwrap();
+                    );
 
+                    #[cfg(feature = "overlapped-lists")]
                     assert_eq!(
-                        data,
+                        data.unwrap(),
                         Root {
                             item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
                             node: (),
                         }
                     );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                            e
+                        ),
+                    }
                 }
             }
 
@@ -2512,7 +2707,7 @@ mod seq {
                     /// elements in an XML, and the first element is a fixed-name one
                     #[test]
                     fn overlapped_fixed_before() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <element/>
@@ -2522,23 +2717,32 @@ mod seq {
                                 <three/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: vec![(), ()],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `element`"),
+                            e => panic!(
+                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
 
                     /// A list with fixed-name elements are mixed with a list with variable-name
                     /// elements in an XML, and the first element is a variable-name one
                     #[test]
                     fn overlapped_fixed_after() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <one/>
@@ -2548,16 +2752,25 @@ mod seq {
                                 <element/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: vec![(), ()],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
+                            e => panic!(
+                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
                 }
 
@@ -2630,7 +2843,7 @@ mod seq {
                     /// elements in an XML, and the first element is a fixed-name one
                     #[test]
                     fn overlapped_fixed_before() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <element/>
@@ -2640,23 +2853,32 @@ mod seq {
                                 <three/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 element: vec![(), ()],
                                 item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `element`"),
+                            e => panic!(
+                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
 
                     /// A list with fixed-name elements are mixed with a list with variable-name
                     /// elements in an XML, and the first element is a variable-name one
                     #[test]
                     fn overlapped_fixed_after() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <one/>
@@ -2666,16 +2888,25 @@ mod seq {
                                 <element/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 element: vec![(), ()],
                                 item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
+                            e => panic!(
+                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
                 }
 
@@ -2723,7 +2954,7 @@ mod seq {
                     #[test]
                     #[ignore = "There is no way to associate XML elements with `item` or `element` without extra knowledge from type"]
                     fn overlapped() {
-                        let data: Pair = from_str(
+                        let data = from_str::<Pair>(
                             r#"
                             <root>
                                 <one/>
@@ -2733,16 +2964,27 @@ mod seq {
                                 <three/>
                             </root>
                             "#,
-                        )
-                        .unwrap();
+                        );
 
+                        #[cfg(feature = "overlapped-lists")]
                         assert_eq!(
-                            data,
+                            data.unwrap(),
                             Pair {
                                 item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
                                 element: vec![Choice2::First, Choice2::Second],
                             }
                         );
+
+                        #[cfg(not(feature = "overlapped-lists"))]
+                        match data {
+                            Err(DeError::Custom(e)) => {
+                                assert_eq!(e, "invalid length 1, expected an array of length 3")
+                            }
+                            e => panic!(
+                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                e
+                            ),
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Replaces https://github.com/Mingun/fast-xml/pull/12

Fixes #342

This PR adds a bunch of tests to ensure, that deserialization of sequences is correct in all situations.

- Structs with `$value` field can now deserialize their other fields from elements, not only from attributes, as it was before:
    ```xml
    <any-tag>
      <before/>
      <item/>
      <item/>
      <item/>
      <after/>
    </any-tag>
    ```
    can be deserialized into
    ```rust
    struct AnyName {
      before: (),
      item: Vec<()>,
      after: (),
    }
    ```

- Added a new cargo feature `overlapped-lists` which allows also interleave sequence
  tags with non-sequence tags in the XML. When use that feature the following XML
  can be deserialized to the struct shown above:
    ```xml
    <any-tag>
      <item/>
      <item/>
      <before/>
      <item/>
      <after/>
      <item/>
    </any-tag>
    ```