### PR TITLE
Add method to allow treating start tags as empty

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -445,6 +445,9 @@ impl<R: BufRead> Reader<R> {
     }
 
     fn is_empty_tag(&self, tag: &[u8]) -> bool {
+        if tag.len() == 0 {
+            return false;
+        }
         self.empty_tags
             .windows(tag.len())
             .position(|w| w == tag)

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -1,0 +1,54 @@
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+#[test]
+fn test_html_unclosed_tags_such_as_link_and_meta() {
+    let xml = "<!DOCTYPE html>
+        <html lang=\"en\">
+          <head>
+            <meta charset=\"utf-8\">
+            <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">
+            <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+
+            <title>crates.io: Rust Package Registry</title>
+
+
+        <!-- EMBER_CLI_FASTBOOT_TITLE --><!-- EMBER_CLI_FASTBOOT_HEAD -->
+        <link rel=\"manifest\" href=\"/manifest.webmanifest\">
+        <link rel=\"apple-touch-icon\" href=\"/cargo-835dd6a18132048a52ac569f2615b59d.png\" sizes=\"227x227\">
+
+            <link rel=\"stylesheet\" href=\"/assets/vendor-8d023d47762d5431764f589a6012123e.css\" integrity=\"sha256-EoB7fsYkdS7BZba47+C/9D7yxwPZojsE4pO7RIuUXdE= sha512-/SzGQGR0yj5AG6YPehZB3b6MjpnuNCTOGREQTStETobVRrpYPZKneJwcL/14B8ufcvobJGFDvnTKdcDDxbh6/A==\" >
+            <link rel=\"stylesheet\" href=\"/assets/cargo-cedb8082b232ce89dd449d869fb54b98.css\" integrity=\"sha256-S9K9jZr6nSyYicYad3JdiTKrvsstXZrvYqmLUX9i3tc= sha512-CDGjy3xeyiqBgUMa+GelihW394pqAARXwsU+HIiOotlnp1sLBVgO6v2ZszL0arwKU8CpvL9wHyLYBIdfX92YbQ==\" >
+
+
+            <link rel=\"shortcut icon\" href=\"/favicon.ico\" type=\"image/x-icon\">
+            <link rel=\"icon\" href=\"/cargo-835dd6a18132048a52ac569f2615b59d.png\" type=\"image/png\"/>
+            <link rel=\"search\" href=\"/opensearch.xml\" type=\"application/opensearchdescription+xml\" title=\"Cargo\">
+          </head>
+          <body>
+            <!-- EMBER_CLI_FASTBOOT_BODY -->
+            <noscript>
+                <div id=\"main\">
+                    <div class='noscript'>
+                        This site requires JavaScript to be enabled.
+                    </div>
+                </div>
+            </noscript>
+
+            <script src=\"/assets/vendor-bfe89101b20262535de5a5ccdc276965.js\" integrity=\"sha256-U12Xuwhz1bhJXWyFW/hRr+Wa8B6FFDheTowik5VLkbw= sha512-J/cUUuUN55TrdG8P6Zk3/slI0nTgzYb8pOQlrXfaLgzr9aEumr9D1EzmFyLy1nrhaDGpRN1T8EQrU21Jl81pJQ==\" ></script>
+            <script src=\"/assets/cargo-4023b68501b7b3e17b2bb31f50f5eeea.js\" integrity=\"sha256-9atimKc1KC6HMJF/B07lP3Cjtgr2tmET8Vau0Re5mVI= sha512-XJyBDQU4wtA1aPyPXaFzTE5Wh/mYJwkKHqZ/Fn4p/ezgdKzSCFu6FYn81raBCnCBNsihfhrkb88uF6H5VraHMA==\" ></script>
+
+          </body>
+        </html>
+}";
+    let mut reader = Reader::from_str(xml);
+    reader.treat_tag_as_empty("link meta");
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(Event::Eof) => break,
+            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            _ => {}
+        }
+    }
+}


### PR DESCRIPTION
Allows parsing the HTML in the README.
```html
<meta charset="utf-8">
<link rel="manifest" href="/manifest.webmanifest">
```

```rust
let mut reader = Reader::from_str(xml);
reader.treat_tag_as_empty("link meta");
```