### PR TITLE
Use lcov format when sending coverage results

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,8 +42,6 @@ jobs:
       run: cargo test --features serialize,escape-html
     - name: Prepare coverage information for upload
       if: runner.os == 'Linux'
-      # --token is required by grcov, but not required by coveralls.io, so pass
-      # something to get it work. See https://github.com/mozilla/grcov/issues/833
       run: |
         grcov ./coverage \
               -s . \
@@ -51,14 +49,12 @@ jobs:
               --branch \
               --ignore-not-existing \
               --ignore 'tests/*' \
-              -t coveralls+ \
-              --token ? \
-              -o ./coveralls.json
+              -o ./coverage.lcov
     - name: Upload coverage to codecov.io
       if: runner.os == 'Linux'
       uses: codecov/codecov-action@v2
       with:
-        files: ./coveralls.json
+        files: ./coverage.lcov
         flags: unittests
         verbose: true
       continue-on-error: true


### PR DESCRIPTION
I confused https://codecov.io and https://coveralls.io when I was preparing coverage and chose the `coverage+` format, although it is not required in this case and the [grcov Readme.md](https://github.com/mozilla/grcov#lcov-output) recommends using `lcov` to upload to codecov.io.