### PR TITLE
Fix broken benchmarks and build them on CI so it will be hard to happened again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build
+    - name: Build benchmarks
+      run: cargo bench --no-run
+    - name: Build benchmarks (compare)
+      working-directory: compare
+      run: cargo bench --no-run
     - name: Run tests (no features)
       env:
         LLVM_PROFILE_FILE: coverage/no-features-%p-%m.profraw

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -202,7 +202,7 @@ fn one_event(c: &mut Criterion) {
                 .check_comments(false)
                 .trim_text(true);
             match r.read_event(&mut buf) {
-                Ok(Event::Start(ref e)) => nbtxt += e.unescaped().unwrap().len(),
+                Ok(Event::Start(ref e)) => nbtxt += e.len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
 


### PR DESCRIPTION
Fixes an oversight from #400 and prevents such problems in the future