### PR TITLE
Always use UTF-8 for a `Reader` and a `Deserializer` created from a string

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -92,6 +92,8 @@
 - [#118]: Remove `BytesStart::unescaped*` set of methods because they could return wrong results
   Use methods on `Attribute` instead
 
+- [#403]: Remove deprecated `quick_xml::de::from_bytes` and `Deserializer::from_borrowing_reader`
+
 ### New Tests
 
 - [#9]: Added tests for incorrect nested tags in input
@@ -109,6 +111,7 @@
 [#391]: https://github.com/tafia/quick-xml/pull/391
 [#393]: https://github.com/tafia/quick-xml/pull/393
 [#395]: https://github.com/tafia/quick-xml/pull/395
+[#403]: https://github.com/tafia/quick-xml/pull/403
 
 ## 0.23.0 -- 2022-05-08
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@
 - [#191]: New event variant `StartText` emitted for bytes before the XML declaration
   or a start comment or a tag. For streams with BOM this event will contain a BOM
 - [#395]: Add support for XML Schema `xs:list`
+- [#324]: `Reader::from_str` / `Deserializer::from_str` / `from_str` now ignore
+  the XML declared encoding and always use UTF-8
 
 ### Bug Fixes
 
@@ -106,6 +108,7 @@
 [#9]: https://github.com/Mingun/fast-xml/pull/9
 [#180]: https://github.com/tafia/quick-xml/issues/180
 [#191]: https://github.com/tafia/quick-xml/issues/191
+[#324]: https://github.com/tafia/quick-xml/issues/324
 [#363]: https://github.com/tafia/quick-xml/issues/363
 [#387]: https://github.com/tafia/quick-xml/pull/387
 [#391]: https://github.com/tafia/quick-xml/pull/391

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -297,7 +297,8 @@ pub fn from_str<'de, T>(s: &'de str) -> Result<T, DeError>
 where
     T: Deserialize<'de>,
 {
-    from_slice(s.as_bytes())
+    let mut de = Deserializer::from_str(s);
+    T::deserialize(&mut de)
 }
 
 /// Deserialize an instance of type `T` from bytes of XML text.
@@ -696,12 +697,17 @@ where
 impl<'de> Deserializer<'de, SliceReader<'de>> {
     /// Create new deserializer that will borrow data from the specified string
     pub fn from_str(s: &'de str) -> Self {
-        Self::from_slice(s.as_bytes())
+        Self::from_borrowing_reader(Reader::from_str(s))
     }
 
     /// Create new deserializer that will borrow data from the specified byte array
     pub fn from_slice(bytes: &'de [u8]) -> Self {
-        let mut reader = Reader::from_bytes(bytes);
+        Self::from_borrowing_reader(Reader::from_bytes(bytes))
+    }
+
+    /// Create new deserializer that will borrow data from the specified borrowing reader
+    #[inline]
+    fn from_borrowing_reader(mut reader: Reader<&'de [u8]>) -> Self {
         reader
             .expand_empty_elements(true)
             .check_end_names(true)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -301,15 +301,6 @@ where
 }
 
 /// Deserialize an instance of type `T` from bytes of XML text.
-#[deprecated = "Use `from_slice` instead"]
-pub fn from_bytes<'de, T>(s: &'de [u8]) -> Result<T, DeError>
-where
-    T: Deserialize<'de>,
-{
-    from_slice(s)
-}
-
-/// Deserialize an instance of type `T` from bytes of XML text.
 pub fn from_slice<'de, T>(s: &'de [u8]) -> Result<T, DeError>
 where
     T: Deserialize<'de>,
@@ -398,12 +389,6 @@ where
             #[cfg(not(feature = "overlapped-lists"))]
             peek: None,
         }
-    }
-
-    /// Get a new deserializer from a regular BufRead
-    #[deprecated = "Use `Deserializer::new` instead"]
-    pub fn from_borrowing_reader(reader: R) -> Self {
-        Self::new(reader)
     }
 
     /// Set the maximum number of events that could be skipped during deserialization

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -4765,3 +4765,25 @@ mod xml_schema_lists {
         }
     }
 }
+
+/// Test for https://github.com/tafia/quick-xml/issues/324
+#[test]
+fn from_str_should_ignore_encoding() {
+    let xml = r#"
+        <?xml version="1.0" encoding="windows-1252" ?>
+        <A a="€" />
+    "#;
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    struct A {
+        a: String,
+    }
+
+    let a: A = from_str(xml).unwrap();
+    assert_eq!(
+        a,
+        A {
+            a: "€".to_string()
+        }
+    );
+}


### PR DESCRIPTION
Fixes #324 