### PR TITLE
Rename reading methods, fix some encoding errors in error-processing paths and tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -96,13 +96,22 @@
 
 - [#403]: Remove deprecated `quick_xml::de::from_bytes` and `Deserializer::from_borrowing_reader`
 
+- [#412]: Rename methods of `Reader`:
+  |Old Name                 |New Name
+  |-------------------------|---------------------------------------------------
+  |`read_event`             |`read_event_into`
+  |`read_to_end`            |`read_to_end_into`
+  |`read_text`              |`read_text_into`
+  |`read_event_unbuffered`  |`read_event`
+  |`read_to_end_unbuffered` |`read_to_end`
+
 ### New Tests
 
 - [#9]: Added tests for incorrect nested tags in input
 - [#387]: Added a bunch of tests for sequences deserialization
 - [#393]: Added more tests for namespace resolver
 - [#393]: Added tests for reserved names (started with "xml"i) -- see <https://www.w3.org/TR/xml-names11/#xmlReserved>
-- [#363]: Add tests for `Reader::read_event_buffered` to ensure that proper events generated for corresponding inputs
+- [#363]: Add tests for `Reader::read_event_impl` to ensure that proper events generated for corresponding inputs
 - [#407]: Improved benchmark suite to cover whole-document parsing, escaping and unescaping text
 
 [#8]: https://github.com/Mingun/fast-xml/pull/8
@@ -118,6 +127,7 @@
 [#395]: https://github.com/tafia/quick-xml/pull/395
 [#403]: https://github.com/tafia/quick-xml/pull/403
 [#407]: https://github.com/tafia/quick-xml/pull/407
+[#412]: https://github.com/tafia/quick-xml/pull/412
 
 ## 0.23.0 -- 2022-05-08
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -107,6 +107,7 @@
 
 [#8]: https://github.com/Mingun/fast-xml/pull/8
 [#9]: https://github.com/Mingun/fast-xml/pull/9
+[#118]: https://github.com/tafia/quick-xml/issues/118
 [#180]: https://github.com/tafia/quick-xml/issues/180
 [#191]: https://github.com/tafia/quick-xml/issues/191
 [#324]: https://github.com/tafia/quick-xml/issues/324

--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,8 @@
   returns `ResolveResult::Unknown` if prefix was not registered in namespace buffer
 - [#393]: Fix breaking processing after encounter an attribute with a reserved name (started with "xmlns")
 - [#363]: Do not generate empty `Event::Text` events
+- [#412]: Fix using incorrect encoding if `read_to_end` family of methods or `read_text`
+  method not found a corresponding end tag and reader has non-UTF-8 encoding
 
 ### Misc Changes
 
@@ -104,6 +106,7 @@
   |`read_text`              |`read_text_into`
   |`read_event_unbuffered`  |`read_event`
   |`read_to_end_unbuffered` |`read_to_end`
+- [#412]: Change `read_to_end*` and `read_text_into` to accept `QName` instead of `AsRef<[u8]>`
 
 ### New Tests
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ let mut buf = Vec::new();
 loop {
     // NOTE: this is the generic case when we don't know about the input BufRead.
     // when the input is a &str or a &[u8], we don't actually need to use another
-    // buffer, we could directly call `reader.read_event_unbuffered()`
-    match reader.read_event(&mut buf) {
+    // buffer, we could directly call `reader.read_event()`
+    match reader.read_event_into(&mut buf) {
         Ok(Event::Start(ref e)) => {
             match e.name() {
                 b"tag1" => println!("attributes values: {:?}",
@@ -77,7 +77,7 @@ reader.trim_text(true);
 let mut writer = Writer::new(Cursor::new(Vec::new()));
 let mut buf = Vec::new();
 loop {
-    match reader.read_event(&mut buf) {
+    match reader.read_event_into(&mut buf) {
         Ok(Event::Start(ref e)) if e.name() == b"this_tag" => {
 
             // crates a new element ... alternatively we could reuse `e` by calling

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -21,7 +21,7 @@ static PLAYERS: &[u8] = include_bytes!("../tests/documents/players.xml");
 fn parse_document(doc: &[u8]) -> XmlResult<()> {
     let mut r = Reader::from_reader(doc);
     loop {
-        match r.read_event_unbuffered()? {
+        match r.read_event()? {
             Event::Start(e) | Event::Empty(e) => {
                 for attr in e.attributes() {
                     criterion::black_box(attr?.unescaped_value()?);

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -34,7 +34,7 @@ fn read_event(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut buf = Vec::new();
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
                     Ok(Event::Eof) => break,
                     _ => (),
@@ -57,7 +57,7 @@ fn read_event(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut buf = Vec::new();
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
                     Ok(Event::Eof) => break,
                     _ => (),
@@ -137,7 +137,7 @@ fn bytes_text_unescaped(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut nbtxt = criterion::black_box(0);
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
                     Ok(Event::Text(ref e)) => nbtxt += e.unescaped().unwrap().len(),
                     Ok(Event::Eof) => break,
@@ -175,7 +175,7 @@ fn bytes_text_unescaped(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut nbtxt = criterion::black_box(0);
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
                     Ok(Event::Text(ref e)) => nbtxt += e.unescaped().unwrap().len(),
                     Ok(Event::Eof) => break,
@@ -215,7 +215,7 @@ fn one_event(c: &mut Criterion) {
             let mut r = Reader::from_reader(src.as_ref());
             let mut nbtxt = criterion::black_box(0);
             r.check_end_names(false).check_comments(false);
-            match r.read_event(&mut buf) {
+            match r.read_event_into(&mut buf) {
                 Ok(Event::StartText(e)) => nbtxt += e.len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
@@ -235,7 +235,7 @@ fn one_event(c: &mut Criterion) {
             r.check_end_names(false)
                 .check_comments(false)
                 .trim_text(true);
-            match r.read_event(&mut buf) {
+            match r.read_event_into(&mut buf) {
                 Ok(Event::Start(ref e)) => nbtxt += e.len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
@@ -255,7 +255,7 @@ fn one_event(c: &mut Criterion) {
             r.check_end_names(false)
                 .check_comments(false)
                 .trim_text(true);
-            match r.read_event(&mut buf) {
+            match r.read_event_into(&mut buf) {
                 Ok(Event::Comment(ref e)) => nbtxt += e.unescaped().unwrap().len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
@@ -275,7 +275,7 @@ fn one_event(c: &mut Criterion) {
             r.check_end_names(false)
                 .check_comments(false)
                 .trim_text(true);
-            match r.read_event(&mut buf) {
+            match r.read_event_into(&mut buf) {
                 Ok(Event::CData(ref e)) => nbtxt += e.len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
@@ -298,7 +298,7 @@ fn attributes(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut buf = Vec::new();
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Empty(e)) => {
                         for attr in e.attributes() {
                             let _attr = attr.unwrap();
@@ -321,7 +321,7 @@ fn attributes(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut buf = Vec::new();
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Empty(e)) => {
                         for attr in e.attributes().with_checks(false) {
                             let _attr = attr.unwrap();
@@ -344,7 +344,7 @@ fn attributes(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut buf = Vec::new();
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Empty(e)) if e.name() == QName(b"player") => {
                         for name in ["num", "status", "avg"] {
                             if let Some(_attr) = e.try_get_attribute(name).unwrap() {

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -18,7 +18,7 @@ fn low_level_comparison(c: &mut Criterion) {
             let mut count = criterion::black_box(0);
             let mut buf = Vec::new();
             loop {
-                match r.read_event(&mut buf) {
+                match r.read_event_into(&mut buf) {
                     Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
                     Ok(Event::Eof) => break,
                     _ => (),

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let entity_re = Regex::new(r#"<!ENTITY\s+([^ \t\r\n]+)\s+"([^"]*)"\s*>"#)?;
 
     loop {
-        match reader.read_event(&mut buf) {
+        match reader.read_event_into(&mut buf) {
             Ok(Event::DocType(ref e)) => {
                 for cap in entity_re.captures_iter(&e) {
                     custom_entities.insert(cap[1].to_vec(), cap[2].to_vec());

--- a/examples/nested_readers.rs
+++ b/examples/nested_readers.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), quick_xml::Error> {
     let mut reader = Reader::from_file("tests/documents/document.xml")?;
     let mut found_tables = Vec::new();
     loop {
-        match reader.read_event(&mut buf)? {
+        match reader.read_event_into(&mut buf)? {
             Event::Start(element) => match element.name().as_ref() {
                 b"w:tbl" => {
                     count += 1;
@@ -33,7 +33,7 @@ fn main() -> Result<(), quick_xml::Error> {
                     let mut row_index = 0;
                     loop {
                         skip_buf.clear();
-                        match reader.read_event(&mut skip_buf)? {
+                        match reader.read_event_into(&mut skip_buf)? {
                             Event::Start(element) => match element.name().as_ref() {
                                 b"w:tr" => {
                                     stats.rows.push(vec![]);

--- a/examples/read_texts.rs
+++ b/examples/read_texts.rs
@@ -12,11 +12,11 @@ fn main() {
     let mut buf = Vec::new();
 
     loop {
-        match reader.read_event(&mut buf) {
+        match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) if e.name().as_ref() == b"tag2" => {
                 txt.push(
                     reader
-                        .read_text(b"tag2", &mut Vec::new())
+                        .read_text_into(b"tag2", &mut Vec::new())
                         .expect("Cannot decode text value"),
                 );
                 println!("{:?}", txt);

--- a/examples/read_texts.rs
+++ b/examples/read_texts.rs
@@ -1,5 +1,6 @@
 fn main() {
     use quick_xml::events::Event;
+    use quick_xml::name::QName;
     use quick_xml::Reader;
 
     let xml = "<tag1>text1</tag1><tag1>text2</tag1>\
@@ -16,7 +17,7 @@ fn main() {
             Ok(Event::Start(ref e)) if e.name().as_ref() == b"tag2" => {
                 txt.push(
                     reader
-                        .read_text_into(b"tag2", &mut Vec::new())
+                        .read_text_into(QName(b"tag2"), &mut Vec::new())
                         .expect("Cannot decode text value"),
                 );
                 println!("{:?}", txt);

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
     let mut reader = Reader::from_reader(cursor);
     let mut buf = vec![];
     loop {
-        match reader.read_event(&mut buf) {
+        match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e))=> {
                 if e.unescaped().is_err() {
                     break;

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -949,7 +949,7 @@ pub struct IoReader<R: BufRead> {
 impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
     fn next(&mut self) -> Result<DeEvent<'static>, DeError> {
         let event = loop {
-            let e = self.reader.read_event(&mut self.buf)?;
+            let e = self.reader.read_event_into(&mut self.buf)?;
             match e {
                 //TODO: Probably not the best idea treat StartText as usual text
                 // Usually this event will represent a BOM
@@ -971,7 +971,7 @@ impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
     }
 
     fn read_to_end(&mut self, name: QName) -> Result<(), DeError> {
-        match self.reader.read_to_end(name, &mut self.buf) {
+        match self.reader.read_to_end_into(name, &mut self.buf) {
             Err(Error::UnexpectedEof(_)) => Err(DeError::UnexpectedEof),
             other => Ok(other?),
         }
@@ -993,7 +993,7 @@ pub struct SliceReader<'de> {
 impl<'de> XmlRead<'de> for SliceReader<'de> {
     fn next(&mut self) -> Result<DeEvent<'de>, DeError> {
         loop {
-            let e = self.reader.read_event_unbuffered()?;
+            let e = self.reader.read_event()?;
             match e {
                 //TODO: Probably not the best idea treat StartText as usual text
                 // Usually this event will represent a BOM
@@ -1011,7 +1011,7 @@ impl<'de> XmlRead<'de> for SliceReader<'de> {
     }
 
     fn read_to_end(&mut self, name: QName) -> Result<(), DeError> {
-        match self.reader.read_to_end_unbuffered(name) {
+        match self.reader.read_to_end(name) {
             Err(Error::UnexpectedEof(_)) => Err(DeError::UnexpectedEof),
             other => Ok(other?),
         }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -9,7 +9,7 @@ use crate::reader::{is_whitespace, Reader};
 use crate::utils::{write_byte_string, write_cow_string, Bytes};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::iter::FusedIterator;
-use std::{borrow::Cow, collections::HashMap, io::BufRead, ops::Range};
+use std::{borrow::Cow, collections::HashMap, ops::Range};
 
 /// A struct representing a key/value XML attribute.
 ///
@@ -81,7 +81,7 @@ impl<'a> Attribute<'a> {
     ///
     /// [`unescaped_value()`]: #method.unescaped_value
     /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
-    pub fn unescape_and_decode_value<B: BufRead>(&self, reader: &Reader<B>) -> XmlResult<String> {
+    pub fn unescape_and_decode_value<B>(&self, reader: &Reader<B>) -> XmlResult<String> {
         self.do_unescape_and_decode_value(reader, None)
     }
 
@@ -99,7 +99,7 @@ impl<'a> Attribute<'a> {
     /// # Pre-condition
     ///
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
-    pub fn unescape_and_decode_value_with_custom_entities<B: BufRead>(
+    pub fn unescape_and_decode_value_with_custom_entities<B>(
         &self,
         reader: &Reader<B>,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
@@ -108,7 +108,7 @@ impl<'a> Attribute<'a> {
     }
 
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
-    fn do_unescape_and_decode_value<B: BufRead>(
+    fn do_unescape_and_decode_value<B>(
         &self,
         reader: &Reader<B>,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! # Reading
 //! When reading a XML stream, the events are emitted by
-//! [`Reader::read_event`]. You must listen
+//! [`Reader::read_event_into`]. You must listen
 //! for the different types of events you are interested in.
 //!
 //! See [`Reader`] for further information.
@@ -29,10 +29,8 @@
 //!
 //! See [`Writer`] for further information.
 //!
-//! [`Reader::read_event`]: ../reader/struct.Reader.html#method.read_event
-//! [`Reader`]: ../reader/struct.Reader.html
-//! [`Writer`]: ../writer/struct.Writer.html
-//! [`Event`]: enum.Event.html
+//! [`Writer`]: crate::writer::Writer
+//! [`Event`]: crate::events::Event
 
 pub mod attributes;
 
@@ -928,7 +926,7 @@ impl<'a> Deref for BytesCData<'a> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Event emitted by [`Reader::read_event`].
+/// Event emitted by [`Reader::read_event_into`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Event<'a> {
     /// Text that appeared before the first opening tag or an [XML declaration].
@@ -956,7 +954,7 @@ pub enum Event<'a> {
     /// let mut reader = Reader::from_bytes(xml);
     /// let mut events_processed = 0;
     /// loop {
-    ///     match reader.read_event_unbuffered() {
+    ///     match reader.read_event() {
     ///         Ok(Event::StartText(e)) => {
     ///             assert_eq!(events_processed, 0);
     ///             // Content contains BOM
@@ -1066,7 +1064,10 @@ mod test {
         let mut buf = Vec::new();
         let mut parsed_local_names = Vec::new();
         loop {
-            match rdr.read_event(&mut buf).expect("unable to read xml event") {
+            match rdr
+                .read_event_into(&mut buf)
+                .expect("unable to read xml event")
+            {
                 Event::Start(ref e) => parsed_local_names.push(
                     from_utf8(e.local_name().as_ref())
                         .expect("unable to build str from local_name")

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -39,7 +39,6 @@ use encoding_rs::Encoding;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
-use std::io::BufRead;
 use std::ops::Deref;
 use std::str::from_utf8;
 
@@ -755,7 +754,7 @@ impl<'a> BytesText<'a> {
     /// it might be wiser to manually use
     /// 1. BytesText::unescaped()
     /// 2. Reader::decode(...)
-    pub fn unescape_and_decode<B: BufRead>(&self, reader: &Reader<B>) -> Result<String> {
+    pub fn unescape_and_decode<B>(&self, reader: &Reader<B>) -> Result<String> {
         self.do_unescape_and_decode_with_custom_entities(reader, None)
     }
 
@@ -769,7 +768,7 @@ impl<'a> BytesText<'a> {
     /// # Pre-condition
     ///
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
-    pub fn unescape_and_decode_with_custom_entities<B: BufRead>(
+    pub fn unescape_and_decode_with_custom_entities<B>(
         &self,
         reader: &Reader<B>,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,
@@ -777,7 +776,7 @@ impl<'a> BytesText<'a> {
         self.do_unescape_and_decode_with_custom_entities(reader, Some(custom_entities))
     }
 
-    fn do_unescape_and_decode_with_custom_entities<B: BufRead>(
+    fn do_unescape_and_decode_with_custom_entities<B>(
         &self,
         reader: &Reader<B>,
         custom_entities: Option<&HashMap<Vec<u8>, Vec<u8>>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! // The `Reader` does not implement `Iterator` because it outputs borrowed data (`Cow`s)
 //! loop {
-//!     match reader.read_event(&mut buf) {
+//!     match reader.read_event_into(&mut buf) {
 //!     // for triggering namespaced events, use this instead:
 //!     // match reader.read_namespaced_event(&mut buf) {
 //!         Ok(Event::Start(ref e)) => {
@@ -86,7 +86,7 @@
 //! let mut writer = Writer::new(Cursor::new(Vec::new()));
 //! let mut buf = Vec::new();
 //! loop {
-//!     match reader.read_event(&mut buf) {
+//!     match reader.read_event_into(&mut buf) {
 //!         Ok(Event::Start(ref e)) if e.name().as_ref() == b"this_tag" => {
 //!
 //!             // crates a new element ... alternatively we could reuse `e` by calling

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -107,7 +107,7 @@ impl EncodingRef {
 
 /// A low level encoding-agnostic XML event reader.
 ///
-/// Consumes a `BufRead` and streams XML `Event`s.
+/// Consumes bytes and streams XML [`Event`]s.
 ///
 /// # Examples
 ///
@@ -144,7 +144,7 @@ impl EncodingRef {
 /// }
 /// ```
 #[derive(Clone)]
-pub struct Reader<R: BufRead> {
+pub struct Reader<R> {
     /// reader
     pub(crate) reader: R,
     /// current buffer position, useful for debugging errors
@@ -198,8 +198,8 @@ pub struct Reader<R: BufRead> {
 }
 
 /// Builder methods
-impl<R: BufRead> Reader<R> {
-    /// Creates a `Reader` that reads from a reader implementing `BufRead`.
+impl<R> Reader<R> {
+    /// Creates a `Reader` that reads from a given reader.
     pub fn from_reader(reader: R) -> Self {
         Self {
             reader,
@@ -323,7 +323,7 @@ impl<R: BufRead> Reader<R> {
 }
 
 /// Getters
-impl<R: BufRead> Reader<R> {
+impl<R> Reader<R> {
     /// Consumes `Reader` returning the underlying reader
     ///
     /// Can be used to compute line and column of a parsing error position
@@ -761,7 +761,7 @@ impl<R: BufRead> Reader<R> {
 }
 
 /// Private methods
-impl<R: BufRead> Reader<R> {
+impl<R> Reader<R> {
     /// Read text into the given buffer, and return an event that borrows from
     /// either that buffer or from the input itself, based on the type of the
     /// reader.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -22,7 +22,7 @@ use std::io::Write;
 /// let mut writer = Writer::new(Cursor::new(Vec::new()));
 /// let mut buf = Vec::new();
 /// loop {
-///     match reader.read_event(&mut buf) {
+///     match reader.read_event_into(&mut buf) {
 ///         Ok(Event::Start(ref e)) if e.name().as_ref() == b"this_tag" => {
 ///
 ///             // crates a new element ... alternatively we could reuse `e` by calling

--- a/tests/documents/sample_1_full.txt
+++ b/tests/documents/sample_1_full.txt
@@ -1,4 +1,6 @@
 StartDocument(1.0, utf-8)
+Characters(
+)
 StartElement(project [name="project-name"])
 Characters(
     )

--- a/tests/documents/sample_2_full.txt
+++ b/tests/documents/sample_2_full.txt
@@ -1,4 +1,6 @@
 StartDocument(1.0, utf-8)
+Characters(
+)
 StartElement({urn:example:namespace}p:data)
 Characters(
   )

--- a/tests/serde-migrated.rs
+++ b/tests/serde-migrated.rs
@@ -14,6 +14,7 @@ struct Simple {
     d: Option<String>,
 }
 
+#[track_caller]
 fn test_parse_ok<'a, T: std::fmt::Debug>(errors: &[(&'a str, T)])
 where
     T: PartialEq + Debug + ser::Serialize + for<'de> de::Deserialize<'de>,
@@ -37,6 +38,7 @@ where
     }
 }
 
+#[track_caller]
 fn test_parse_err<'a, T>(errors: &[&'a str])
 where
     T: PartialEq + Debug + ser::Serialize + for<'de> de::Deserialize<'de>,

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -1,3 +1,4 @@
+use quick_xml::escape::unescape;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::{QName, ResolveResult};
 use quick_xml::{Decoder, Reader, Result};
@@ -403,21 +404,25 @@ fn namespace_name(n: ResolveResult, name: QName, decoder: Decoder) -> String {
     let name = decoder.decode(name.as_ref()).unwrap();
     match n {
         // Produces string '{namespace}prefixed_name'
-        ResolveResult::Bound(n) => format!("{{{}}}{}", from_utf8(n.as_ref()).unwrap(), name),
+        ResolveResult::Bound(n) => format!("{{{}}}{}", decoder.decode(n.as_ref()).unwrap(), name),
         _ => name.to_string(),
     }
 }
 
-fn make_attrs(e: &BytesStart) -> ::std::result::Result<String, String> {
+fn make_attrs(e: &BytesStart, decoder: Decoder) -> ::std::result::Result<String, String> {
     let mut atts = Vec::new();
     for a in e.attributes() {
         match a {
             Ok(a) => {
                 if a.key.as_namespace_binding().is_none() {
+                    let key = decoder.decode(a.key.as_ref()).unwrap();
+                    let value = decoder.decode(a.value.as_ref()).unwrap();
+                    let unescaped_value = unescape(value.as_bytes()).unwrap();
                     atts.push(format!(
                         "{}=\"{}\"",
-                        from_utf8(a.key.as_ref()).unwrap(),
-                        from_utf8(&*a.unescaped_value().unwrap()).unwrap()
+                        key,
+                        // unescape does not change validity of an UTF-8 string
+                        from_utf8(&*unescaped_value).unwrap()
                     ));
                 }
             }
@@ -430,43 +435,45 @@ fn make_attrs(e: &BytesStart) -> ::std::result::Result<String, String> {
 fn xmlrs_display(opt_event: Result<(ResolveResult, Event)>, decoder: Decoder) -> String {
     match opt_event {
         Ok((_, Event::StartText(_))) => "StartText".to_string(),
-        Ok((n, Event::Start(ref e))) => {
+        Ok((n, Event::Start(e))) => {
             let name = namespace_name(n, e.name(), decoder);
-            match make_attrs(e) {
-                Ok(ref attrs) if attrs.is_empty() => format!("StartElement({})", &name),
-                Ok(ref attrs) => format!("StartElement({} [{}])", &name, &attrs),
+            match make_attrs(&e, decoder) {
+                Ok(attrs) if attrs.is_empty() => format!("StartElement({})", &name),
+                Ok(attrs) => format!("StartElement({} [{}])", &name, &attrs),
                 Err(e) => format!("StartElement({}, attr-error: {})", &name, &e),
             }
         }
-        Ok((n, Event::Empty(ref e))) => {
+        Ok((n, Event::Empty(e))) => {
             let name = namespace_name(n, e.name(), decoder);
-            match make_attrs(e) {
-                Ok(ref attrs) if attrs.is_empty() => format!("EmptyElement({})", &name),
-                Ok(ref attrs) => format!("EmptyElement({} [{}])", &name, &attrs),
+            match make_attrs(&e, decoder) {
+                Ok(attrs) if attrs.is_empty() => format!("EmptyElement({})", &name),
+                Ok(attrs) => format!("EmptyElement({} [{}])", &name, &attrs),
                 Err(e) => format!("EmptyElement({}, attr-error: {})", &name, &e),
             }
         }
-        Ok((n, Event::End(ref e))) => {
+        Ok((n, Event::End(e))) => {
             let name = namespace_name(n, e.name(), decoder);
             format!("EndElement({})", name)
         }
-        Ok((_, Event::Comment(ref e))) => format!("Comment({})", from_utf8(e).unwrap()),
-        Ok((_, Event::CData(ref e))) => format!("CData({})", from_utf8(e).unwrap()),
-        Ok((_, Event::Text(ref e))) => match e.unescaped() {
-            Ok(c) => format!("Characters({})", decoder.decode(c.as_ref()).unwrap()),
-            Err(ref err) => format!("FailedUnescape({:?}; {})", e.escaped(), err),
+        Ok((_, Event::Comment(e))) => format!("Comment({})", decoder.decode(&e).unwrap()),
+        Ok((_, Event::CData(e))) => format!("CData({})", decoder.decode(&e).unwrap()),
+        Ok((_, Event::Text(e))) => match unescape(decoder.decode(&e).unwrap().as_bytes()) {
+            Ok(c) => format!("Characters({})", from_utf8(c.as_ref()).unwrap()),
+            Err(err) => format!("FailedUnescape({:?}; {})", e.escaped(), err),
         },
-        Ok((_, Event::Decl(ref e))) => {
+        Ok((_, Event::Decl(e))) => {
             let version_cow = e.version().unwrap();
-            let version = from_utf8(version_cow.as_ref()).unwrap();
+            let version = decoder.decode(version_cow.as_ref()).unwrap();
             let encoding_cow = e.encoding().unwrap().unwrap();
-            let encoding = from_utf8(encoding_cow.as_ref()).unwrap();
+            let encoding = decoder.decode(encoding_cow.as_ref()).unwrap();
             format!("StartDocument({}, {})", version, encoding)
         }
         Ok((_, Event::Eof)) => format!("EndDocument"),
-        Ok((_, Event::PI(ref e))) => format!("ProcessingInstruction(PI={})", from_utf8(e).unwrap()),
-        Err(ref e) => format!("Error: {}", e),
-        Ok((_, Event::DocType(ref e))) => format!("DocType({})", from_utf8(e).unwrap()),
+        Ok((_, Event::PI(e))) => {
+            format!("ProcessingInstruction(PI={})", decoder.decode(&e).unwrap())
+        }
+        Ok((_, Event::DocType(e))) => format!("DocType({})", decoder.decode(&e).unwrap()),
+        Err(e) => format!("Error: {}", e),
     }
 }
 

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -355,21 +355,15 @@ fn default_namespace_applies_to_end_elem() {
 }
 
 #[track_caller]
-fn test(input: &str, output: &str, is_short: bool) {
-    test_bytes(input.as_bytes(), output.as_bytes(), is_short);
+fn test(input: &str, output: &str, trim: bool) {
+    test_bytes(input.as_bytes(), output.as_bytes(), trim);
 }
 
 #[track_caller]
-fn test_bytes(input: &[u8], output: &[u8], is_short: bool) {
-    // Normalize newlines on Windows to just \n, which is what the reader and
-    // writer use.
-    // let input = input.replace("\r\n", "\n");
-    // let input = input.as_bytes();
-    // let output = output.replace("\r\n", "\n");
-    // let output = output.as_bytes();
+fn test_bytes(input: &[u8], output: &[u8], trim: bool) {
     let mut reader = Reader::from_reader(input);
     reader
-        .trim_text(is_short)
+        .trim_text(trim)
         .check_comments(true)
         .expand_empty_elements(false);
 
@@ -401,20 +395,6 @@ fn test_bytes(input: &[u8], output: &[u8], is_short: bool) {
                 break;
             }
             panic!("Unexpected event: {}", line);
-        }
-
-        if !is_short && line.starts_with("StartDocument") {
-            // advance next Characters(empty space) ...
-            if let Ok(Event::Text(ref e)) = reader.read_event(&mut Vec::new()) {
-                if e.iter().any(|b| match *b {
-                    b' ' | b'\r' | b'\n' | b'\t' => false,
-                    _ => true,
-                }) {
-                    panic!("Reader expects empty Text event after a StartDocument");
-                }
-            } else {
-                panic!("Reader expects empty Text event after a StartDocument");
-            }
         }
     }
 }


### PR DESCRIPTION
This PR includes some of the stuff, improving code here and there, including:
- fix incorrect encoding used when handle some errors
- remove excess `BufRead` constraints which opens door for the `async` support fo the same `Reader` struct
- some minor improvements in tests
- some documentation updates
- rename core methods to better reflect their purpose:
  |Old Name                 |New Name
  |-------------------------|---------------------------------------------------
  |`read_event`             |`read_event_into`
  |`read_to_end`            |`read_to_end_into`
  |`read_text`              |`read_text_into`
  |`read_event_unbuffered`  |`read_event`
  |`read_to_end_unbuffered` |`read_to_end`

  (_`read_namespaced_event` is not renamed because I plan to remove it in the namespace PR_)