### PR TITLE
Add `<event>::borrow()` and some minor stuff

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,8 @@
 - [#395]: Add support for XML Schema `xs:list`
 - [#324]: `Reader::from_str` / `Deserializer::from_str` / `from_str` now ignore
   the XML declared encoding and always use UTF-8
+- [#416]: Add `borrow()` methods in all event structs which allows to get
+  a borrowed version of any event
 
 ### Bug Fixes
 
@@ -108,6 +110,9 @@
   |`read_to_end_unbuffered` |`read_to_end`
 - [#412]: Change `read_to_end*` and `read_text_into` to accept `QName` instead of `AsRef<[u8]>`
 
+- [#416]: `BytesStart::to_borrowed` renamed to `BytesStart::borrow`, the same method
+  added to all events
+
 ### New Tests
 
 - [#9]: Added tests for incorrect nested tags in input
@@ -131,6 +136,7 @@
 [#403]: https://github.com/tafia/quick-xml/pull/403
 [#407]: https://github.com/tafia/quick-xml/pull/407
 [#412]: https://github.com/tafia/quick-xml/pull/412
+[#416]: https://github.com/tafia/quick-xml/pull/416
 
 ## 0.23.0 -- 2022-05-08
 

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -25,7 +25,10 @@ fn low_level_comparison(c: &mut Criterion) {
                 }
                 buf.clear();
             }
-            assert_eq!(count, 1550, "Overall tag count in ./tests/documents/sample_rss.xml");
+            assert_eq!(
+                count, 1550,
+                "Overall tag count in ./tests/documents/sample_rss.xml"
+            );
         })
     });
 
@@ -49,7 +52,10 @@ fn low_level_comparison(c: &mut Criterion) {
                 }
                 input = &input[consumed..];
             }
-            assert_eq!(count, 1550, "Overall tag count in ./tests/documents/sample_rss.xml");
+            assert_eq!(
+                count, 1550,
+                "Overall tag count in ./tests/documents/sample_rss.xml"
+            );
         })
     });
 
@@ -68,7 +74,10 @@ fn low_level_comparison(c: &mut Criterion) {
                     _ => (),
                 }
             }
-            assert_eq!(count, 1550, "Overall tag count in ./tests/documents/sample_rss.xml");
+            assert_eq!(
+                count, 1550,
+                "Overall tag count in ./tests/documents/sample_rss.xml"
+            );
         })
     });
 
@@ -83,7 +92,10 @@ fn low_level_comparison(c: &mut Criterion) {
                     _ => (),
                 }
             }
-            assert_eq!(count, 1550, "Overall tag count in ./tests/documents/sample_rss.xml");
+            assert_eq!(
+                count, 1550,
+                "Overall tag count in ./tests/documents/sample_rss.xml"
+            );
         })
     });
 
@@ -101,7 +113,10 @@ fn low_level_comparison(c: &mut Criterion) {
                     _ => (),
                 }
             }
-            assert_eq!(count, 1550, "Overall tag count in ./tests/documents/sample_rss.xml");
+            assert_eq!(
+                count, 1550,
+                "Overall tag count in ./tests/documents/sample_rss.xml"
+            );
         })
     });
 
@@ -166,7 +181,10 @@ fn low_level_comparison(c: &mut Criterion) {
                     count += 1;
                 }
             }
-            assert_eq!(count, 1550, "Overall tag count in ./tests/documents/sample_rss.xml");
+            assert_eq!(
+                count, 1550,
+                "Overall tag count in ./tests/documents/sample_rss.xml"
+            );
         })
     });
     group.finish();

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -517,7 +517,7 @@ where
     forward!(deserialize_any);
     forward!(deserialize_ignored_any);
 
-    /// Tuple representation is the same as [sequences](#method.deserialize_seq).
+    /// Tuple representation is the same as [sequences](Self::deserialize_seq).
     fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
     where
         V: Visitor<'de>,
@@ -525,7 +525,7 @@ where
         self.deserialize_seq(visitor)
     }
 
-    /// Named tuple representation is the same as [unnamed tuples](#method.deserialize_tuple).
+    /// Named tuple representation is the same as [unnamed tuples](Self::deserialize_tuple).
     fn deserialize_tuple_struct<V>(
         self,
         _name: &'static str,
@@ -687,7 +687,7 @@ where
     forward!(deserialize_any);
     forward!(deserialize_ignored_any);
 
-    /// Representation of tuples the same as [sequences](#method.deserialize_seq).
+    /// Representation of tuples the same as [sequences](Self::deserialize_seq).
     fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
     where
         V: Visitor<'de>,
@@ -695,7 +695,7 @@ where
         self.deserialize_seq(visitor)
     }
 
-    /// Representation of named tuples the same as [unnamed tuples](#method.deserialize_tuple).
+    /// Representation of named tuples the same as [unnamed tuples](Self::deserialize_tuple).
     fn deserialize_tuple_struct<V>(
         self,
         _name: &'static str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -79,8 +79,6 @@ impl From<AttrError> for Error {
 }
 
 /// A specialized `Result` type where the error is hard-wired to [`Error`].
-///
-/// [`Error`]: enum.Error.html
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl std::fmt::Display for Error {

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -17,15 +17,13 @@ use std::{borrow::Cow, collections::HashMap, ops::Range};
 /// want to access the value using one of the [`unescaped_value`] and [`unescape_and_decode_value`]
 /// functions.
 ///
-/// [`unescaped_value`]: #method.unescaped_value
-/// [`unescape_and_decode_value`]: #method.unescape_and_decode_value
+/// [`unescaped_value`]: Self::unescaped_value
+/// [`unescape_and_decode_value`]: Self::unescape_and_decode_value
 #[derive(Clone, PartialEq)]
 pub struct Attribute<'a> {
     /// The key to uniquely define the attribute.
     ///
     /// If [`Attributes::with_checks`] is turned off, the key might not be unique.
-    ///
-    /// [`Attributes::with_checks`]: struct.Attributes.html#method.with_checks
     pub key: QName<'a>,
     /// The raw value of the attribute.
     pub value: Cow<'a, [u8]>,
@@ -39,7 +37,7 @@ impl<'a> Attribute<'a> {
     ///
     /// This will allocate if the value contains any escape sequences.
     ///
-    /// See also [`unescaped_value_with_custom_entities()`](#method.unescaped_value_with_custom_entities)
+    /// See also [`unescaped_value_with_custom_entities()`](Self::unescaped_value_with_custom_entities)
     pub fn unescaped_value(&self) -> XmlResult<Cow<[u8]>> {
         self.make_unescaped_value(None)
     }
@@ -52,7 +50,7 @@ impl<'a> Attribute<'a> {
     ///
     /// This will allocate if the value contains any escape sequences.
     ///
-    /// See also [`unescaped_value()`](#method.unescaped_value)
+    /// See also [`unescaped_value()`](Self::unescaped_value)
     ///
     /// # Pre-condition
     ///
@@ -76,11 +74,11 @@ impl<'a> Attribute<'a> {
     /// This allocates a `String` in all cases. For performance reasons it might be a better idea to
     /// instead use one of:
     ///
-    /// * [`Reader::decode()`], as it only allocates when the decoding can't be performed otherwise.
+    /// * [`Reader::decoder().decode()`], as it only allocates when the decoding can't be performed otherwise.
     /// * [`unescaped_value()`], as it doesn't allocate when no escape sequences are used.
     ///
-    /// [`unescaped_value()`]: #method.unescaped_value
-    /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
+    /// [`unescaped_value()`]: Self::unescaped_value
+    /// [`Reader::decoder().decode()`]: crate::reader::Decoder::decode
     pub fn unescape_and_decode_value<B>(&self, reader: &Reader<B>) -> XmlResult<String> {
         self.do_unescape_and_decode_value(reader, None)
     }
@@ -90,11 +88,11 @@ impl<'a> Attribute<'a> {
     /// This allocates a `String` in all cases. For performance reasons it might be a better idea to
     /// instead use one of:
     ///
-    /// * [`Reader::decode()`], as it only allocates when the decoding can't be performed otherwise.
+    /// * [`Reader::decoder().decode()`], as it only allocates when the decoding can't be performed otherwise.
     /// * [`unescaped_value_with_custom_entities()`], as it doesn't allocate when no escape sequences are used.
     ///
-    /// [`unescaped_value_with_custom_entities()`]: #method.unescaped_value_with_custom_entities
-    /// [`Reader::decode()`]: ../../reader/struct.Reader.html#method.decode
+    /// [`unescaped_value_with_custom_entities()`]: Self::unescaped_value_with_custom_entities
+    /// [`Reader::decoder().decode()`]: crate::reader::Decoder::decode
     ///
     /// # Pre-condition
     ///
@@ -189,7 +187,7 @@ impl<'a> From<Attr<&'a [u8]>> for Attribute<'a> {
 /// Yields `Result<Attribute>`. An `Err` will be yielded if an attribute is malformed or duplicated.
 /// The duplicate check can be turned off by calling [`with_checks(false)`].
 ///
-/// [`with_checks(false)`]: #method.with_checks
+/// [`with_checks(false)`]: Self::with_checks
 #[derive(Clone, Debug)]
 pub struct Attributes<'a> {
     /// slice of `Element` corresponding to attributes

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -670,7 +670,9 @@ impl<'a> Deref for BytesEnd<'a> {
 /// in escaped form. Internally data is stored in escaped form
 #[derive(Clone, Eq, PartialEq)]
 pub struct BytesText<'a> {
-    // Invariant: The content is always escaped.
+    /// Escaped then encoded content of the event. Content is encoded in the XML
+    /// document encoding when event comes from the reader and should be in the
+    /// document encoding when event passed to the writer
     content: Cow<'a, [u8]>,
 }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -108,13 +108,12 @@ impl<'a> From<BytesText<'a>> for BytesStartText<'a> {
 ///
 /// `<name attr="value">`.
 ///
-/// The name can be accessed using the [`name`], [`local_name`] or [`unescaped`] methods. An
-/// iterator over the attributes is returned by the [`attributes`] method.
+/// The name can be accessed using the [`name`] or [`local_name`] methods.
+/// An iterator over the attributes is returned by the [`attributes`] method.
 ///
-/// [`name`]: #method.name
-/// [`local_name`]: #method.local_name
-/// [`unescaped`]: #method.unescaped
-/// [`attributes`]: #method.attributes
+/// [`name`]: Self::name
+/// [`local_name`]: Self::local_name
+/// [`attributes`]: Self::attributes
 #[derive(Clone, Eq, PartialEq)]
 pub struct BytesStart<'a> {
     /// content of the element, before any utf8 conversion
@@ -203,7 +202,7 @@ impl<'a> BytesStart<'a> {
     /// # }}
     /// ```
     ///
-    /// [`to_end`]: #method.to_end
+    /// [`to_end`]: Self::to_end
     pub fn to_borrowed(&self) -> BytesStart {
         BytesStart::borrowed(&self.buf, self.name_len)
     }
@@ -718,7 +717,7 @@ impl<'a> BytesText<'a> {
     /// Searches for '&' into content and try to escape the coded character if possible
     /// returns Malformed error with index within element if '&' is not followed by ';'
     ///
-    /// See also [`unescaped_with_custom_entities()`](#method.unescaped_with_custom_entities)
+    /// See also [`unescaped_with_custom_entities()`](Self::unescaped_with_custom_entities)
     pub fn unescaped(&self) -> Result<Cow<[u8]>> {
         self.make_unescaped(None)
     }
@@ -733,7 +732,7 @@ impl<'a> BytesText<'a> {
     ///
     /// The keys and values of `custom_entities`, if any, must be valid UTF-8.
     ///
-    /// See also [`unescaped()`](#method.unescaped)
+    /// See also [`unescaped()`](Self::unescaped)
     pub fn unescaped_with_custom_entities<'s>(
         &'s self,
         custom_entities: &HashMap<Vec<u8>, Vec<u8>>,

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1051,47 +1051,6 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn local_name() {
-        use std::str::from_utf8;
-        let xml = r#"
-            <foo:bus attr='bar'>foobusbar</foo:bus>
-            <foo: attr='bar'>foobusbar</foo:>
-            <:foo attr='bar'>foobusbar</:foo>
-            <foo:bus:baz attr='bar'>foobusbar</foo:bus:baz>
-            "#;
-        let mut rdr = Reader::from_str(xml);
-        let mut buf = Vec::new();
-        let mut parsed_local_names = Vec::new();
-        loop {
-            match rdr
-                .read_event_into(&mut buf)
-                .expect("unable to read xml event")
-            {
-                Event::Start(ref e) => parsed_local_names.push(
-                    from_utf8(e.local_name().as_ref())
-                        .expect("unable to build str from local_name")
-                        .to_string(),
-                ),
-                Event::End(ref e) => parsed_local_names.push(
-                    from_utf8(e.local_name().as_ref())
-                        .expect("unable to build str from local_name")
-                        .to_string(),
-                ),
-                Event::Eof => break,
-                _ => {}
-            }
-        }
-        assert_eq!(parsed_local_names[0], "bus".to_string());
-        assert_eq!(parsed_local_names[1], "bus".to_string());
-        assert_eq!(parsed_local_names[2], "".to_string());
-        assert_eq!(parsed_local_names[3], "".to_string());
-        assert_eq!(parsed_local_names[4], "foo".to_string());
-        assert_eq!(parsed_local_names[5], "foo".to_string());
-        assert_eq!(parsed_local_names[6], "bus:baz".to_string());
-        assert_eq!(parsed_local_names[7], "bus:baz".to_string());
-    }
-
-    #[test]
     fn bytestart_create() {
         let b = BytesStart::owned_name("test");
         assert_eq!(b.len(), 4);

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -34,7 +34,7 @@
 
 pub mod attributes;
 
-#[cfg(feature = "encoding_rs")]
+#[cfg(feature = "encoding")]
 use encoding_rs::Encoding;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -554,7 +554,7 @@ impl<'a> BytesDecl<'a> {
     }
 
     /// Gets the decoder struct
-    #[cfg(feature = "encoding_rs")]
+    #[cfg(feature = "encoding")]
     pub fn encoder(&self) -> Option<&'static Encoding> {
         self.encoding()
             .and_then(|e| e.ok())

--- a/src/name.rs
+++ b/src/name.rs
@@ -797,4 +797,31 @@ mod namespaces {
         );
         assert_eq!(resolver.find(name, &buffer), Unknown(b"unknown".to_vec()));
     }
+
+    /// Checks how the QName is decomposed to a prefix and a local name
+    #[test]
+    fn prefix_and_local_name() {
+        let name = QName(b"foo:bus");
+        assert_eq!(name.prefix(), Some(Prefix(b"foo")));
+        assert_eq!(name.local_name(), LocalName(b"bus"));
+        assert_eq!(name.decompose(), (LocalName(b"bus"), Some(Prefix(b"foo"))));
+
+        let name = QName(b"foo:");
+        assert_eq!(name.prefix(), Some(Prefix(b"foo")));
+        assert_eq!(name.local_name(), LocalName(b""));
+        assert_eq!(name.decompose(), (LocalName(b""), Some(Prefix(b"foo"))));
+
+        let name = QName(b":foo");
+        assert_eq!(name.prefix(), Some(Prefix(b"")));
+        assert_eq!(name.local_name(), LocalName(b"foo"));
+        assert_eq!(name.decompose(), (LocalName(b"foo"), Some(Prefix(b""))));
+
+        let name = QName(b"foo:bus:baz");
+        assert_eq!(name.prefix(), Some(Prefix(b"foo")));
+        assert_eq!(name.local_name(), LocalName(b"bus:baz"));
+        assert_eq!(
+            name.decompose(),
+            (LocalName(b"bus:baz"), Some(Prefix(b"foo")))
+        );
+    }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -234,9 +234,9 @@ impl<R> Reader<R> {
     ///
     /// (`false` by default)
     ///
-    /// [`Empty`]: events/enum.Event.html#variant.Empty
-    /// [`Start`]: events/enum.Event.html#variant.Start
-    /// [`End`]: events/enum.Event.html#variant.End
+    /// [`Empty`]: Event::Empty
+    /// [`Start`]: Event::Start
+    /// [`End`]: Event::End
     pub fn expand_empty_elements(&mut self, val: bool) -> &mut Self {
         self.expand_empty_elements = val;
         self
@@ -249,7 +249,7 @@ impl<R> Reader<R> {
     ///
     /// (`false` by default)
     ///
-    /// [`Text`]: events/enum.Event.html#variant.Text
+    /// [`Text`]: Event::Text
     pub fn trim_text(&mut self, val: bool) -> &mut Self {
         self.trim_text_start = val;
         self.trim_text_end = val;
@@ -262,7 +262,7 @@ impl<R> Reader<R> {
     ///
     /// (`false` by default)
     ///
-    /// [`Text`]: events/enum.Event.html#variant.Text
+    /// [`Text`]: Event::Text
     pub fn trim_text_end(&mut self, val: bool) -> &mut Self {
         self.trim_text_end = val;
         self
@@ -278,7 +278,7 @@ impl<R> Reader<R> {
     ///
     /// (`true` by default)
     ///
-    /// [`End`]: events/enum.Event.html#variant.End
+    /// [`End`]: Event::End
     pub fn trim_markup_names_in_closing_tags(&mut self, val: bool) -> &mut Self {
         self.trim_markup_names_in_closing_tags = val;
         self
@@ -300,7 +300,7 @@ impl<R> Reader<R> {
     ///
     /// (`true` by default)
     ///
-    /// [`End`]: events/enum.Event.html#variant.End
+    /// [`End`]: Event::End
     pub fn check_end_names(&mut self, val: bool) -> &mut Self {
         self.check_end_names = val;
         self
@@ -315,7 +315,7 @@ impl<R> Reader<R> {
     ///
     /// (`false` by default)
     ///
-    /// [`Comment`]: events/enum.Event.html#variant.Comment
+    /// [`Comment`]: Event::Comment
     pub fn check_comments(&mut self, val: bool) -> &mut Self {
         self.check_comments = val;
         self

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -154,7 +154,7 @@ where
         } else {
             self.parent
                 .writer
-                .write_event(Event::Start(self.attrs.to_borrowed()))?;
+                .write_event(Event::Start(self.attrs.borrow()))?;
             self.parent.writer.write(&self.children)?;
             self.parent
                 .writer

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -152,13 +152,15 @@ impl<W: Write> Writer<W> {
 
     /// Manually write a newline and indentation at the proper level.
     ///
-    /// This can be used when the heuristic to line break and indent after any [Event] apart
-    /// from [Text] fails such as when a [Start] occurs directly after [Text].
-    /// This method will do nothing if `Writer` was not constructed with `new_with_indent`.
+    /// This can be used when the heuristic to line break and indent after any
+    /// [`Event`] apart from [`Text`] fails such as when a [`Start`] occurs directly
+    /// after [`Text`].
     ///
-    /// [Event]: events/enum.Event.html
-    /// [Text]: events/enum.Event.html#variant.Text
-    /// [Start]: events/enum.Event.html#variant.Start
+    /// This method will do nothing if `Writer` was not constructed with [`new_with_indent`].
+    ///
+    /// [`Text`]: Event::Text
+    /// [`Start`]: Event::Start
+    /// [`new_with_indent`]: Self::new_with_indent
     pub fn write_indent(&mut self) -> Result<()> {
         if let Some(ref i) = self.indent {
             self.writer.write_all(b"\n").map_err(Error::Io)?;
@@ -171,7 +173,8 @@ impl<W: Write> Writer<W> {
 
     /// Provides a simple, high-level API for writing XML elements.
     ///
-    /// Returns an [ElementWriter] that simplifies setting attributes and writing content inside the element.
+    /// Returns an [`ElementWriter`] that simplifies setting attributes and writing
+    /// content inside the element.
     ///
     /// # Example
     ///

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -256,7 +256,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     /// Write some text inside the current element.
     pub fn write_text_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
         self.writer
-            .write_event(Event::Start(self.start_tag.to_borrowed()))?;
+            .write_event(Event::Start(self.start_tag.borrow()))?;
         self.writer.write_event(Event::Text(text))?;
         self.writer
             .write_event(Event::End(self.start_tag.to_end()))?;
@@ -266,7 +266,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     /// Write a CData event `<![CDATA[...]]>` inside the current element.
     pub fn write_cdata_content(self, text: BytesCData) -> Result<&'a mut Writer<W>> {
         self.writer
-            .write_event(Event::Start(self.start_tag.to_borrowed()))?;
+            .write_event(Event::Start(self.start_tag.borrow()))?;
         self.writer.write_event(Event::CData(text))?;
         self.writer
             .write_event(Event::End(self.start_tag.to_end()))?;
@@ -276,7 +276,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     /// Write a processing instruction `<?...?>` inside the current element.
     pub fn write_pi_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
         self.writer
-            .write_event(Event::Start(self.start_tag.to_borrowed()))?;
+            .write_event(Event::Start(self.start_tag.borrow()))?;
         self.writer.write_event(Event::PI(text))?;
         self.writer
             .write_event(Event::End(self.start_tag.to_end()))?;
@@ -295,7 +295,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
         F: Fn(&mut Writer<W>) -> Result<()>,
     {
         self.writer
-            .write_event(Event::Start(self.start_tag.to_borrowed()))?;
+            .write_event(Event::Start(self.start_tag.borrow()))?;
         closure(&mut self.writer)?;
         self.writer
             .write_event(Event::End(self.start_tag.to_end()))?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -122,7 +122,7 @@ fn fuzz_53() {
     let mut buf = vec![];
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(quick_xml::events::Event::Eof) | Err(..) => break,
+            Ok(Eof) | Err(..) => break,
             _ => buf.clear(),
         }
     }
@@ -138,7 +138,7 @@ fn test_issue94() {
     let mut buf = vec![];
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(quick_xml::events::Event::Eof) | Err(..) => break,
+            Ok(Eof) | Err(..) => break,
             _ => buf.clear(),
         }
         buf.clear();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -95,7 +95,7 @@ fn test_comment_starting_with_gt() {
 }
 
 #[test]
-#[cfg(feature = "encoding_rs")]
+#[cfg(feature = "encoding")]
 fn test_koi8_r_encoding() {
     let src: &[u8] = include_bytes!("documents/opennews_all.rss");
     let mut r = Reader::from_reader(src as &[u8]);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3,9 +3,10 @@ use std::io::Cursor;
 use std::str::from_utf8;
 
 use quick_xml::events::attributes::{AttrError, Attribute};
-use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::events::Event::*;
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText};
 use quick_xml::name::QName;
-use quick_xml::{events::Event::*, Reader, Result, Writer};
+use quick_xml::{Reader, Result, Writer};
 
 use pretty_assertions::assert_eq;
 
@@ -621,7 +622,7 @@ fn test_read_write_roundtrip_escape() -> Result<()> {
             Text(e) => {
                 let t = e.escaped();
                 assert!(writer
-                    .write_event(Event::Text(BytesText::from_escaped(t.to_vec())))
+                    .write_event(Text(BytesText::from_escaped(t.to_vec())))
                     .is_ok());
             }
             e => assert!(writer.write_event(e).is_ok()),
@@ -654,7 +655,7 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
             Text(e) => {
                 let t = e.unescape_and_decode(&reader).unwrap();
                 assert!(writer
-                    .write_event(Event::Text(BytesText::from_plain_str(&t)))
+                    .write_event(Text(BytesText::from_plain_str(&t)))
                     .is_ok());
             }
             e => assert!(writer.write_event(e).is_ok()),
@@ -799,10 +800,8 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::StartText(e)) => {
-                    txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap())
-                }
-                Ok(Event::Eof) => break,
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(Eof) => break,
                 _ => (),
             }
         }
@@ -825,10 +824,8 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::StartText(e)) => {
-                    txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap())
-                }
-                Ok(Event::Eof) => break,
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(Eof) => break,
                 _ => (),
             }
         }
@@ -846,10 +843,8 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::StartText(e)) => {
-                    txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap())
-                }
-                Ok(Event::Eof) => break,
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(Eof) => break,
                 _ => (),
             }
         }
@@ -869,10 +864,8 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::StartText(e)) => {
-                    txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap())
-                }
-                Ok(Event::Eof) => break,
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(Eof) => break,
                 _ => (),
             }
         }


### PR DESCRIPTION
This PR makes some refactoring that I do on my path to the implementing namespaces support.

Currently I need to fix lifetime issues and I plan split reader and writer events into separate structs, which requires some preparing work. In order to not make that PR too big I made this PR with this work.

I fixed some intradoc links, move tests to appropriate place and introduced two improvements:
- `BytesStart` and `BytesEnd` structs now implements `From<QName>` that allows to create them easely (useful for writing)
- `Writer::write_event` now consumes event using an `Into` trait. `AsRef` trait, used before, does not allow to accept two unrelated structs which `reader::Event` and `writer::Event` will be. On the contrary, `writer::Event` will implement `From<reader::Event>` which would allow to write reader events as before. In order to not lose the ownership, the `Event::borrow()` method is introduced, as a counterpart to the `Event::into_owned()` method, so `Writer::write_event` could consume only borrowed event