### PR TITLE
[work-in-progress]: Perform all decoding internally

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -103,6 +103,9 @@
 
 - [#416]: `BytesStart::to_borrowed` renamed to `BytesStart::borrow`, the same method
   added to all events
+- [#420]: `BytesText::from_escaped_str()` and `BytesText::from_plain_str()` renamed to
+  `BytesText::from_escaped()` and `BytesText::from_plain()`, respectively. The previous functions
+  with those names (which operated over `&[u8]`) have been removed.
 
 - [#421]: Removed ability to deserialize byte arrays from serde deserializer.
   XML is not able to store binary data directly, you should always use some encoding

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -24,11 +24,11 @@ fn parse_document(doc: &[u8]) -> XmlResult<()> {
         match r.read_event()? {
             Event::Start(e) | Event::Empty(e) => {
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(&r)?);
+                    criterion::black_box(attr?.unescape_value()?);
                 }
             }
             Event::Text(e) => {
-                criterion::black_box(e.decode_and_unescape(&r)?);
+                criterion::black_box(e.unescape()?);
             }
             Event::CData(e) => {
                 criterion::black_box(e.into_inner());

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -293,26 +293,26 @@ fn escaping(c: &mut Criterion) {
 
     group.bench_function("no_chars_to_escape_long", |b| {
         b.iter(|| {
-            criterion::black_box(escape(LOREM_IPSUM_TEXT.as_bytes()));
+            criterion::black_box(escape(LOREM_IPSUM_TEXT));
         })
     });
 
     group.bench_function("no_chars_to_escape_short", |b| {
         b.iter(|| {
-            criterion::black_box(escape(b"just bit of text"));
+            criterion::black_box(escape("just bit of text"));
         })
     });
 
     group.bench_function("escaped_chars_short", |b| {
         b.iter(|| {
-            criterion::black_box(escape(b"age > 72 && age < 21"));
-            criterion::black_box(escape(b"\"what's that?\""));
+            criterion::black_box(escape("age > 72 && age < 21"));
+            criterion::black_box(escape("\"what's that?\""));
         })
     });
 
     group.bench_function("escaped_chars_long", |b| {
         let lorem_ipsum_with_escape_chars =
-b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. & Hac habitasse platea dictumst vestibulum rhoncus est pellentesque.
 Risus ultricies tristique nulla aliquet enim tortor at. Fermentum odio eu feugiat pretium nibh ipsum.
 Volutpat sed cras ornare arcu dui. Scelerisque fermentum dui faucibus in ornare quam. Arcu cursus

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -176,7 +176,7 @@ fn one_event(c: &mut Criterion) {
                 .check_comments(false)
                 .trim_text(true);
             match r.read_event_into(&mut buf) {
-                Ok(Event::Comment(e)) => nbtxt += e.decode_and_unescape(&r).unwrap().len(),
+                Ok(Event::Comment(e)) => nbtxt += e.unescape().unwrap().len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -236,8 +236,11 @@ where
             // try getting map from attributes (key= "value")
             let (key, value) = a.into();
             self.source = ValueSource::Attribute(value.unwrap_or_default());
-            seed.deserialize(EscapedDeserializer::new(Cow::Borrowed(&slice[key]), false))
-                .map(Some)
+            seed.deserialize(EscapedDeserializer::new(
+                Cow::Borrowed(std::str::from_utf8(&slice[key])?),
+                false,
+            )) // TODO(dalley): this is temporary
+            .map(Some)
         } else {
             // try getting from events (<key>value</key>)
             match self.de.peek()? {
@@ -288,8 +291,8 @@ where
                         // }
                         seed.deserialize(self.unflatten_fields.remove(p).into_deserializer())
                     } else {
-                        let name = Cow::Borrowed(e.local_name().into_inner());
-                        seed.deserialize(EscapedDeserializer::new(name, false))
+                        let name = std::str::from_utf8(e.local_name().into_inner())?; // TODO(dalley): this is temporary
+                        seed.deserialize(EscapedDeserializer::new(Cow::Borrowed(name), false))
                     };
                     key.map(Some)
                 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1062,7 +1062,7 @@ mod tests {
                 de.write,
                 vec![
                     Start(BytesStart::borrowed_name(b"inner")),
-                    Text(BytesText::from_escaped_str("text")),
+                    Text(BytesText::from_escaped("text")),
                     Start(BytesStart::borrowed_name(b"inner")),
                     End(BytesEnd::borrowed(b"inner")),
                     End(BytesEnd::borrowed(b"inner")),
@@ -1099,7 +1099,7 @@ mod tests {
                 de.read,
                 vec![
                     Start(BytesStart::borrowed_name(b"inner")),
-                    Text(BytesText::from_escaped_str("text")),
+                    Text(BytesText::from_escaped("text")),
                     Start(BytesStart::borrowed_name(b"inner")),
                     End(BytesEnd::borrowed(b"inner")),
                     End(BytesEnd::borrowed(b"inner")),
@@ -1126,7 +1126,7 @@ mod tests {
                 vec![
                     // This comment here to keep the same formatting of both arrays
                     // otherwise rustfmt suggest one-line it
-                    Text(BytesText::from_escaped_str("text")),
+                    Text(BytesText::from_escaped("text")),
                 ]
             );
 
@@ -1149,15 +1149,12 @@ mod tests {
             assert_eq!(
                 de.read,
                 vec![
-                    Text(BytesText::from_escaped_str("text")),
+                    Text(BytesText::from_escaped("text")),
                     End(BytesEnd::borrowed(b"inner")),
                 ]
             );
             assert_eq!(de.write, vec![]);
-            assert_eq!(
-                de.next().unwrap(),
-                Text(BytesText::from_escaped_str("text"))
-            );
+            assert_eq!(de.next().unwrap(), Text(BytesText::from_escaped("text")));
             assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"inner")));
             assert_eq!(
                 de.next().unwrap(),
@@ -1200,7 +1197,7 @@ mod tests {
                 de.write,
                 vec![
                     Start(BytesStart::borrowed_name(b"skip")),
-                    Text(BytesText::from_escaped_str("text")),
+                    Text(BytesText::from_escaped("text")),
                     Start(BytesStart::borrowed_name(b"skip")),
                     End(BytesEnd::borrowed(b"skip")),
                     End(BytesEnd::borrowed(b"skip")),
@@ -1224,7 +1221,7 @@ mod tests {
                 de.write,
                 vec![
                     Start(BytesStart::borrowed_name(b"skip")),
-                    Text(BytesText::from_escaped_str("text")),
+                    Text(BytesText::from_escaped("text")),
                     Start(BytesStart::borrowed_name(b"skip")),
                     End(BytesEnd::borrowed(b"skip")),
                     End(BytesEnd::borrowed(b"skip")),
@@ -1246,7 +1243,7 @@ mod tests {
                 de.read,
                 vec![
                     Start(BytesStart::borrowed_name(b"skip")),
-                    Text(BytesText::from_escaped_str("text")),
+                    Text(BytesText::from_escaped("text")),
                     Start(BytesStart::borrowed_name(b"skip")),
                     End(BytesEnd::borrowed(b"skip")),
                     End(BytesEnd::borrowed(b"skip")),
@@ -1409,7 +1406,7 @@ mod tests {
                     br#"item name="hello" source="world.rs""#,
                     4
                 )),
-                Text(BytesText::from_escaped(b"Some text".as_ref())),
+                Text(BytesText::from_escaped("Some text")),
                 End(BytesEnd::borrowed(b"item")),
                 Start(BytesStart::borrowed(b"item2", 5)),
                 End(BytesEnd::borrowed(b"item2")),

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -33,13 +33,12 @@ where
     where
         V: DeserializeSeed<'de>,
     {
-        let decoder = self.de.reader.decoder();
         let de = match self.de.peek()? {
-            DeEvent::Text(t) => EscapedDeserializer::new(Cow::Borrowed(t), decoder, true),
+            DeEvent::Text(t) => EscapedDeserializer::new(Cow::Borrowed(t), true),
             // Escape sequences does not processed inside CDATA section
-            DeEvent::CData(t) => EscapedDeserializer::new(Cow::Borrowed(t), decoder, false),
+            DeEvent::CData(t) => EscapedDeserializer::new(Cow::Borrowed(t), false),
             DeEvent::Start(e) => {
-                EscapedDeserializer::new(Cow::Borrowed(e.name().into_inner()), decoder, false)
+                EscapedDeserializer::new(Cow::Borrowed(e.name().into_inner()), false)
             }
             _ => {
                 return Err(DeError::Unsupported(

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -34,11 +34,18 @@ where
         V: DeserializeSeed<'de>,
     {
         let de = match self.de.peek()? {
-            DeEvent::Text(t) => EscapedDeserializer::new(Cow::Borrowed(t), true),
+            DeEvent::Text(t) => {
+                EscapedDeserializer::new(Cow::Borrowed(std::str::from_utf8(t)?), true)
+            } // TODO(dalley): temporary
             // Escape sequences does not processed inside CDATA section
-            DeEvent::CData(t) => EscapedDeserializer::new(Cow::Borrowed(t), false),
+            DeEvent::CData(t) => {
+                EscapedDeserializer::new(Cow::Borrowed(std::str::from_utf8(t)?), false)
+            } // TODO(dalley): temporary
             DeEvent::Start(e) => {
-                EscapedDeserializer::new(Cow::Borrowed(e.name().into_inner()), false)
+                EscapedDeserializer::new(
+                    Cow::Borrowed(std::str::from_utf8(e.name().into_inner())?),
+                    false,
+                ) // TODO(dalley): temporary
             }
             _ => {
                 return Err(DeError::Unsupported(

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -104,9 +104,14 @@ impl<'a> From<(&'a str, &'a str)> for Attribute<'a> {
     /// assert_eq!(features.value, "Bells &amp; whistles".as_bytes());
     /// ```
     fn from(val: (&'a str, &'a str)) -> Attribute<'a> {
+        let value = match escape(val.1).into() {
+            Cow::Borrowed(v) => Cow::Borrowed(v.as_bytes().into()),
+            Cow::Owned(v) => Cow::Owned(v.into()),
+        };
+
         Attribute {
             key: QName(val.0.as_bytes()),
-            value: escape(val.1.as_bytes()),
+            value: value,
         }
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -750,13 +750,12 @@ impl<'a> BytesText<'a> {
         &self,
         resolve_entity: impl Fn(&str) -> Option<&'entity str>,
     ) -> Result<Cow<str>> {
-        // from_utf8 should never fail because content is always UTF-8 encoded
-        Ok(unescape_with(from_utf8(&self.content)?, resolve_entity)?)
+        Ok(unescape_with(from_utf8(self)?, resolve_entity)?) // TODO(dalley): this is temporary
     }
 
     /// Gets escaped content.
-    pub fn escape(&self) -> Cow<str> {
-        Cow::Borrowed(std::str::from_utf8(&self.content).unwrap()) // TODO(dalley): remove from_utf8
+    pub fn escape(&self) -> &str {
+        from_utf8(self).unwrap() // TODO(dalley): this is temporary
     }
 }
 
@@ -842,10 +841,8 @@ impl<'a> BytesCData<'a> {
     /// | `'`       | `&apos;`
     /// | `"`       | `&quot;`
     pub fn escape(self) -> BytesText<'a> {
-        BytesText::from_escaped(match escape(&self.content) {
-            Cow::Borrowed(_) => self.content,
-            Cow::Owned(escaped) => Cow::Owned(escaped),
-        })
+        let content = std::str::from_utf8(&self.content).unwrap(); // TODO(dalley): this is temporary
+        BytesText::from_escaped(escape(&content)).into_owned()
     }
 
     /// Converts this CDATA content to an escaped version, that can be written
@@ -862,10 +859,8 @@ impl<'a> BytesCData<'a> {
     /// | `>`       | `&gt;`
     /// | `&`       | `&amp;`
     pub fn partial_escape(self) -> BytesText<'a> {
-        BytesText::from_escaped(match partial_escape(&self.content) {
-            Cow::Borrowed(_) => self.content,
-            Cow::Owned(escaped) => Cow::Owned(escaped),
-        })
+        let content = std::str::from_utf8(&self.content).unwrap(); // TODO(dalley): this is temporary
+        BytesText::from_escaped(partial_escape(&content)).into_owned()
     }
 }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -673,37 +673,25 @@ pub struct BytesText<'a> {
 }
 
 impl<'a> BytesText<'a> {
-    /// Creates a new `BytesText` from an escaped byte sequence.
-    #[inline]
-    pub fn from_escaped<C: Into<Cow<'a, [u8]>>>(content: C) -> Self {
-        Self {
-            content: content.into(),
-        }
-    }
-
-    /// Creates a new `BytesText` from a byte sequence. The byte sequence is
-    /// expected not to be escaped.
-    #[inline]
-    pub fn from_plain(content: &'a [u8]) -> Self {
-        Self {
-            content: escape(content),
-        }
-    }
-
     /// Creates a new `BytesText` from an escaped string.
     #[inline]
-    pub fn from_escaped_str<C: Into<Cow<'a, str>>>(content: C) -> Self {
-        Self::from_escaped(match content.into() {
-            Cow::Owned(o) => Cow::Owned(o.into_bytes()),
-            Cow::Borrowed(b) => Cow::Borrowed(b.as_bytes()),
-        })
+    pub fn from_escaped<C: Into<Cow<'a, str>>>(content: C) -> Self {
+        let content = match content.into() {
+            Cow::Borrowed(c) => Cow::Borrowed(c.as_bytes().into()),
+            Cow::Owned(c) => Cow::Owned(c.into()),
+        };
+        Self { content }
     }
 
     /// Creates a new `BytesText` from a string. The string is expected not to
     /// be escaped.
     #[inline]
-    pub fn from_plain_str(content: &'a str) -> Self {
-        Self::from_plain(content.as_bytes())
+    pub fn from_plain(content: &'a str) -> Self {
+        let content = match escape(content).into() {
+            Cow::Borrowed(c) => Cow::Borrowed(c.as_bytes().into()),
+            Cow::Owned(c) => Cow::Owned(c.into()),
+        };
+        Self { content }
     }
 
     /// Ensures that all data is owned to extend the object's lifetime if

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@
 //! A streaming API based on the [StAX] model. This is suited for larger XML documents which
 //! cannot completely read into memory at once.
 //!
-//! The user has to expicitely _ask_ for the next XML event, similar
-//! to a database cursor.
+//! The user has to explicitly _ask_ for the next XML event, similar to a database cursor.
 //! This is achieved by the following two structs:
 //!
 //! - [`Reader`]: A low level XML pull-reader where buffer allocation/clearing is left to user.
@@ -58,8 +57,8 @@
 //!                 _ => (),
 //!             }
 //!         },
-//!         // unescape and decode the text event using the reader encoding
-//!         Ok(Event::Text(e)) => txt.push(e.decode_and_unescape(&reader).unwrap().into_owned()),
+//!         // unescape the text event
+//!         Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
 //!         Ok(Event::Eof) => break, // exits the loop when reaching end of file
 //!         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
 //!         _ => (), // There are several other `Event`s we do not consider here
@@ -156,5 +155,5 @@ mod writer;
 #[cfg(feature = "serialize")]
 pub use crate::errors::serialize::DeError;
 pub use crate::errors::{Error, Result};
-pub use crate::reader::{Decoder, Reader};
+pub use crate::reader::Reader;
 pub use crate::writer::{ElementWriter, Writer};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -824,6 +824,7 @@ impl<R> Reader<R> {
                     bytes
                 };
 
+                let content = std::str::from_utf8(content)?; // TODO(dalley): temporary
                 Ok(if first {
                     Event::StartText(BytesText::from_escaped(content).into())
                 } else {
@@ -898,7 +899,8 @@ impl<R> Reader<R> {
                         return Err(Error::UnexpectedToken("--".to_string()));
                     }
                 }
-                Ok(Event::Comment(BytesText::from_escaped(&buf[3..len - 2])))
+                let comment = std::str::from_utf8(&buf[3..len - 2])?; // TODO(dalley): this is temporary
+                Ok(Event::Comment(BytesText::from_escaped(comment)))
             }
             BangType::CData if uncased_starts_with(buf, b"![CDATA[") => {
                 Ok(Event::CData(BytesCData::new(&buf[8..])))
@@ -909,7 +911,8 @@ impl<R> Reader<R> {
                     .position(|b| !is_whitespace(*b))
                     .unwrap_or_else(|| len - 8);
                 debug_assert!(start < len - 8, "DocType must have a name");
-                Ok(Event::DocType(BytesText::from_escaped(&buf[8 + start..])))
+                let doctype = std::str::from_utf8(&buf[8 + start..])?; // TODO(dalley): this is temporary
+                Ok(Event::DocType(BytesText::from_escaped(doctype)))
             }
             _ => Err(bang_type.to_err()),
         }
@@ -974,7 +977,8 @@ impl<R> Reader<R> {
 
                 Ok(Event::Decl(event))
             } else {
-                Ok(Event::PI(BytesText::from_escaped(&buf[1..len - 1])))
+                let pi = std::str::from_utf8(&buf[1..len - 1])?; // TODO(dalley): this is temporary
+                Ok(Event::PI(BytesText::from_escaped(pi)))
             }
         } else {
             self.buf_position -= len;
@@ -2563,7 +2567,7 @@ mod test {
 
                     assert_eq!(
                         reader.read_event_impl($buf).unwrap(),
-                        Event::StartText(BytesText::from_escaped(b"bom".as_ref()).into())
+                        Event::StartText(BytesText::from_escaped("bom").into())
                     );
                 }
 
@@ -2583,7 +2587,7 @@ mod test {
 
                     assert_eq!(
                         reader.read_event_impl($buf).unwrap(),
-                        Event::DocType(BytesText::from_escaped(b"x".as_ref()))
+                        Event::DocType(BytesText::from_escaped("x"))
                     );
                 }
 
@@ -2593,7 +2597,7 @@ mod test {
 
                     assert_eq!(
                         reader.read_event_impl($buf).unwrap(),
-                        Event::PI(BytesText::from_escaped(b"xml-stylesheet".as_ref()))
+                        Event::PI(BytesText::from_escaped("xml-stylesheet"))
                     );
                 }
 
@@ -2642,7 +2646,7 @@ mod test {
 
                     assert_eq!(
                         reader.read_event_impl($buf).unwrap(),
-                        Event::Text(BytesText::from_escaped(b"text".as_ref()))
+                        Event::Text(BytesText::from_escaped("text"))
                     );
                 }
 
@@ -2662,7 +2666,7 @@ mod test {
 
                     assert_eq!(
                         reader.read_event_impl($buf).unwrap(),
-                        Event::Comment(BytesText::from_escaped(b"".as_ref()))
+                        Event::Comment(BytesText::from_escaped(""))
                     );
                 }
 

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -100,7 +100,7 @@ impl<'r, W: Write> Serializer<'r, W> {
         value: P,
         escaped: bool,
     ) -> Result<(), DeError> {
-        let value = value.to_string().into_bytes();
+        let value = value.to_string();
         let event = if escaped {
             BytesText::from_escaped(value)
         } else {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -108,7 +108,7 @@ impl<W: Write> Writer<W> {
             Event::Empty(ref e) => self.write_wrapped(b"<", e, b"/>"),
             Event::Text(ref e) => {
                 next_should_line_break = false;
-                self.write(&e.escape())
+                self.write(e.escape().as_bytes())
             }
             Event::Comment(ref e) => self.write_wrapped(b"<!--", e, b"-->"),
             Event::CData(ref e) => {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -195,7 +195,7 @@ impl<W: Write> Writer<W> {
     /// // writes <tag attr1="value1" attr2="value2">with some text inside</tag>
     /// writer.create_element("tag")
     ///     .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter())  // or add attributes from an iterator
-    ///     .write_text_content(BytesText::from_plain_str("with some text inside"))?;
+    ///     .write_text_content(BytesText::from_plain("with some text inside"))?;
     ///
     /// // writes <tag><fruit quantity="0">apple</fruit><fruit quantity="1">orange</fruit></tag>
     /// writer.create_element("tag")
@@ -205,7 +205,7 @@ impl<W: Write> Writer<W> {
     ///             writer
     ///                 .create_element("fruit")
     ///                 .with_attribute(("quantity", quant.to_string().as_str()))
-    ///                 .write_text_content(BytesText::from_plain_str(item))?;
+    ///                 .write_text_content(BytesText::from_plain(item))?;
     ///         }
     ///         Ok(())
     ///     })?;
@@ -422,7 +422,7 @@ mod indentation {
         let start = BytesStart::borrowed_name(name)
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         let end = BytesEnd::borrowed(name);
-        let text = BytesText::from_plain(b"text");
+        let text = BytesText::from_plain("text");
 
         writer
             .write_event(Event::Start(start))
@@ -449,7 +449,7 @@ mod indentation {
         let start = BytesStart::borrowed_name(name)
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         let end = BytesEnd::borrowed(name);
-        let text = BytesText::from_plain(b"text");
+        let text = BytesText::from_plain("text");
         let inner = BytesStart::borrowed_name(b"inner");
 
         writer
@@ -535,7 +535,7 @@ mod indentation {
             .create_element("paired")
             .with_attribute(("attr1", "value1"))
             .with_attribute(("attr2", "value2"))
-            .write_text_content(BytesText::from_plain_str("text"))
+            .write_text_content(BytesText::from_plain("text"))
             .expect("failure");
 
         assert_eq!(
@@ -559,7 +559,7 @@ mod indentation {
                     writer
                         .create_element("fruit")
                         .with_attribute(("quantity", quant.to_string().as_str()))
-                        .write_text_content(BytesText::from_plain_str(item))?;
+                        .write_text_content(BytesText::from_plain(item))?;
                 }
                 writer
                     .create_element("inner")

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -616,7 +616,7 @@ fn test_read_write_roundtrip_escape() -> Result<()> {
             Eof => break,
             Text(e) => {
                 assert!(writer
-                    .write_event(Text(BytesText::from_escaped(e.escape().as_bytes())))
+                    .write_event(Text(BytesText::from_escaped(e.escape())))
                     .is_ok());
             }
             e => assert!(writer.write_event(e).is_ok()),
@@ -648,7 +648,7 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
             Eof => break,
             Text(e) => {
                 assert!(writer
-                    .write_event(Text(BytesText::from_plain_str(&e.unescape().unwrap())))
+                    .write_event(Text(BytesText::from_plain(&e.unescape().unwrap())))
                     .is_ok());
             }
             e => assert!(writer.write_event(e).is_ok()),


### PR DESCRIPTION
- [ ] The data being streamed from the reader would be converted from whichever encoding it is currently in to UTF-8 when copied to a buffer, or else validated as UTF-8 if that is the appropriate encoding, using streaming APIs
- [ ] UTF-8 would be the only encoding used within the library itself
- [x] All decoding functions would be removed from the API
- [ ] quick-xml would never have to allocate during parsing except from resizing a buffer or doing (un)escaping
- [ ] All API functions would be changed to return `&str` / `String` / `Cow<str>` rather than raw bytes
- [ ] Known character boundaries can be used to ensure the safety of `unsafe fn std::str::from_utf8_unchecked()`, which would not incur any overhead
