### PR TITLE
Use borrowing `read_event` instead of buffering `read_event_into` where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,8 @@ use quick_xml::events::Event;
 
 let xml = r#"<tag1 att1 = "test">
                 <tag2><!--Test comment-->Test</tag2>
-                <tag2>
-                    Test 2
-                </tag2>
-            </tag1>"#;
-
+                <tag2>Test 2</tag2>
+             </tag1>"#;
 let mut reader = Reader::from_str(xml);
 reader.trim_text(true);
 
@@ -43,20 +40,24 @@ loop {
     // when the input is a &str or a &[u8], we don't actually need to use another
     // buffer, we could directly call `reader.read_event()`
     match reader.read_event_into(&mut buf) {
-        Ok(Event::Start(ref e)) => {
-            match e.name() {
+        Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        // exits the loop when reaching end of file
+        Ok(Event::Eof) => break,
+
+        Ok(Event::Start(e)) => {
+            match e.name().as_ref() {
                 b"tag1" => println!("attributes values: {:?}",
-                                    e.attributes().map(|a| a.unwrap().value).collect::<Vec<_>>()),
+                                    e.attributes().map(|a| a.unwrap().value)
+                                    .collect::<Vec<_>>()),
                 b"tag2" => count += 1,
                 _ => (),
             }
-        },
-        Ok(Event::Text(e)) => txt.push(e.unescape_and_decode(&reader).unwrap().into_owned()),
-        Ok(Event::Eof) => break, // exits the loop when reaching end of file
-        Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-        _ => (), // There are several other `Event`s we do not consider here
-    }
+        }
+        Ok(Event::Text(e)) => txt.push(e.decode_and_unescape(&reader).unwrap().into_owned()),
 
+        // There are several other `Event`s we do not consider here
+        _ => (),
+    }
     // if we don't keep a borrow elsewhere, we can clear the buffer to keep memory usage low
     buf.clear();
 }
@@ -65,24 +66,21 @@ loop {
 ### Writer
 
 ```rust
-use quick_xml::Writer;
-use quick_xml::Reader;
 use quick_xml::events::{Event, BytesEnd, BytesStart};
+use quick_xml::{Reader, Writer};
 use std::io::Cursor;
-use std::iter;
 
 let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;
 let mut reader = Reader::from_str(xml);
 reader.trim_text(true);
 let mut writer = Writer::new(Cursor::new(Vec::new()));
-let mut buf = Vec::new();
 loop {
-    match reader.read_event_into(&mut buf) {
-        Ok(Event::Start(ref e)) if e.name() == b"this_tag" => {
+    match reader.read_event() {
+        Ok(Event::Start(e)) if e.name().as_ref() == b"this_tag" => {
 
             // crates a new element ... alternatively we could reuse `e` by calling
             // `e.into_owned()`
-            let mut elem = BytesStart::owned(b"my_elem".to_vec(), "my_elem".len());
+            let mut elem = BytesStart::owned_name(b"my_elem".to_vec());
 
             // collect existing attributes
             elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
@@ -93,15 +91,14 @@ loop {
             // writes the event to the writer
             assert!(writer.write_event(Event::Start(elem)).is_ok());
         },
-        Ok(Event::End(ref e)) if e.name() == b"this_tag" => {
+        Ok(Event::End(e)) if e.name().as_ref() == b"this_tag" => {
             assert!(writer.write_event(Event::End(BytesEnd::borrowed(b"my_elem"))).is_ok());
         },
         Ok(Event::Eof) => break,
-	// you can use either `e` or `&e` if you don't want to move the event
-        Ok(e) => assert!(writer.write_event(&e).is_ok()),
+        // we can either move or borrow the event to write, depending on your use-case
+        Ok(e) => assert!(writer.write_event(e).is_ok()),
         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
     }
-    buf.clear();
 }
 
 let result = writer.into_inner().into_inner();

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -27,12 +27,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut reader = Reader::from_str(DATA);
     reader.trim_text(true);
 
-    let mut buf = Vec::new();
     let mut custom_entities: HashMap<String, String> = HashMap::new();
     let entity_re = Regex::new(r#"<!ENTITY\s+([^ \t\r\n]+)\s+"([^"]*)"\s*>"#)?;
 
     loop {
-        match reader.read_event_into(&mut buf) {
+        match reader.read_event() {
             Ok(Event::DocType(ref e)) => {
                 for cap in entity_re.captures_iter(&e) {
                     custom_entities.insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! High performance XML reader/writer.
 //!
-//! ## Description
+//! # Description
 //!
 //! quick-xml contains two modes of operation:
 //!
 //! A streaming API based on the [StAX] model. This is suited for larger XML documents which
 //! cannot completely read into memory at once.
 //!
-//! The user has to expicitely _ask_ for the next XML event, similar
+//! The user has to explicitly _ask_ for the next XML event, similar
 //! to a database cursor.
 //! This is achieved by the following two structs:
 //!
@@ -20,104 +20,10 @@
 //! Furthermore, quick-xml also contains optional [Serde] support to directly serialize and deserialize from
 //! structs, without having to deal with the XML events.
 //!
-//! ## Examples
+//! # Examples
 //!
-//! ### Reader
-//!
-//! ```rust
-//! use quick_xml::Reader;
-//! use quick_xml::events::Event;
-//!
-//! let xml = r#"<tag1 att1 = "test">
-//!                 <tag2><!--Test comment-->Test</tag2>
-//!                 <tag2>
-//!                     Test 2
-//!                 </tag2>
-//!             </tag1>"#;
-//!
-//! let mut reader = Reader::from_str(xml);
-//! reader.trim_text(true);
-//!
-//! let mut count = 0;
-//! let mut txt = Vec::new();
-//! let mut buf = Vec::new();
-//!
-//! // The `Reader` does not implement `Iterator` because it outputs borrowed data (`Cow`s)
-//! loop {
-//!     match reader.read_event_into(&mut buf) {
-//!     // for triggering namespaced events, use this instead:
-//!     // match reader.read_namespaced_event(&mut buf) {
-//!         Ok(Event::Start(ref e)) => {
-//!         // for namespaced:
-//!         // Ok((ref namespace_value, Event::Start(ref e)))
-//!             match e.name().as_ref() {
-//!                 b"tag1" => println!("attributes values: {:?}",
-//!                                     e.attributes().map(|a| a.unwrap().value)
-//!                                     .collect::<Vec<_>>()),
-//!                 b"tag2" => count += 1,
-//!                 _ => (),
-//!             }
-//!         },
-//!         // unescape and decode the text event using the reader encoding
-//!         Ok(Event::Text(e)) => txt.push(e.decode_and_unescape(&reader).unwrap().into_owned()),
-//!         Ok(Event::Eof) => break, // exits the loop when reaching end of file
-//!         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-//!         _ => (), // There are several other `Event`s we do not consider here
-//!     }
-//!
-//!     // if we don't keep a borrow elsewhere, we can clear the buffer to keep memory usage low
-//!     buf.clear();
-//! }
-//! ```
-//!
-//! ### Writer
-//!
-//! ```rust
-//! # use pretty_assertions::assert_eq;
-//! use quick_xml::Writer;
-//! use quick_xml::events::{Event, BytesEnd, BytesStart};
-//! use quick_xml::Reader;
-//! use std::io::Cursor;
-//! use std::iter;
-//!
-//! let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;
-//! let mut reader = Reader::from_str(xml);
-//! reader.trim_text(true);
-//! let mut writer = Writer::new(Cursor::new(Vec::new()));
-//! let mut buf = Vec::new();
-//! loop {
-//!     match reader.read_event_into(&mut buf) {
-//!         Ok(Event::Start(ref e)) if e.name().as_ref() == b"this_tag" => {
-//!
-//!             // crates a new element ... alternatively we could reuse `e` by calling
-//!             // `e.into_owned()`
-//!             let mut elem = BytesStart::owned(b"my_elem".to_vec(), "my_elem".len());
-//!
-//!             // collect existing attributes
-//!             elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
-//!
-//!             // copy existing attributes, adds a new my-key="some value" attribute
-//!             elem.push_attribute(("my-key", "some value"));
-//!
-//!             // writes the event to the writer
-//!             assert!(writer.write_event(Event::Start(elem)).is_ok());
-//!         },
-//!         Ok(Event::End(ref e)) if e.name().as_ref() == b"this_tag" => {
-//!             assert!(writer.write_event(Event::End(BytesEnd::borrowed(b"my_elem"))).is_ok());
-//!         },
-//!         Ok(Event::Eof) => break,
-//!         Ok(e) => assert!(writer.write_event(e).is_ok()),
-//!         // or using the buffer
-//!         // Ok(e) => assert!(writer.write(&buf).is_ok()),
-//!         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-//!     }
-//!     buf.clear();
-//! }
-//!
-//! let result = writer.into_inner().into_inner();
-//! let expected = r#"<my_elem k1="v1" k2="v2" my-key="some value"><child>text</child></my_elem>"#;
-//! assert_eq!(result, expected.as_bytes());
-//! ```
+//! - For a reading example see [`Reader`]
+//! - For a writing example see [`Writer`]
 //!
 //! # Features
 //!

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -118,15 +118,25 @@ impl EncodingRef {
 /// let xml = r#"<tag1 att1 = "test">
 ///                 <tag2><!--Test comment-->Test</tag2>
 ///                 <tag2>Test 2</tag2>
-///             </tag1>"#;
+///              </tag1>"#;
 /// let mut reader = Reader::from_str(xml);
 /// reader.trim_text(true);
+///
 /// let mut count = 0;
 /// let mut txt = Vec::new();
 /// let mut buf = Vec::new();
+///
+/// // The `Reader` does not implement `Iterator` because it outputs borrowed data (`Cow`s)
 /// loop {
+///     // NOTE: this is the generic case when we don't know about the input BufRead.
+///     // when the input is a &str or a &[u8], we don't actually need to use another
+///     // buffer, we could directly call `reader.read_event()`
 ///     match reader.read_event_into(&mut buf) {
-///         Ok(Event::Start(ref e)) => {
+///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+///         // exits the loop when reaching end of file
+///         Ok(Event::Eof) => break,
+///
+///         Ok(Event::Start(e)) => {
 ///             match e.name().as_ref() {
 ///                 b"tag1" => println!("attributes values: {:?}",
 ///                                     e.attributes().map(|a| a.unwrap().value)
@@ -134,12 +144,13 @@ impl EncodingRef {
 ///                 b"tag2" => count += 1,
 ///                 _ => (),
 ///             }
-///         },
+///         }
 ///         Ok(Event::Text(e)) => txt.push(e.decode_and_unescape(&reader).unwrap().into_owned()),
-///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-///         Ok(Event::Eof) => break,
+///
+///         // There are several other `Event`s we do not consider here
 ///         _ => (),
 ///     }
+///     // if we don't keep a borrow elsewhere, we can clear the buffer to keep memory usage low
 ///     buf.clear();
 /// }
 /// ```

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -10,24 +10,23 @@ use std::io::Write;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # use pretty_assertions::assert_eq;
-/// use quick_xml::{Reader, Writer};
 /// use quick_xml::events::{Event, BytesEnd, BytesStart};
+/// use quick_xml::{Reader, Writer};
 /// use std::io::Cursor;
 ///
 /// let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;
 /// let mut reader = Reader::from_str(xml);
 /// reader.trim_text(true);
 /// let mut writer = Writer::new(Cursor::new(Vec::new()));
-/// let mut buf = Vec::new();
 /// loop {
-///     match reader.read_event_into(&mut buf) {
-///         Ok(Event::Start(ref e)) if e.name().as_ref() == b"this_tag" => {
+///     match reader.read_event() {
+///         Ok(Event::Start(e)) if e.name().as_ref() == b"this_tag" => {
 ///
 ///             // crates a new element ... alternatively we could reuse `e` by calling
 ///             // `e.into_owned()`
-///             let mut elem = BytesStart::owned(b"my_elem".to_vec(), "my_elem".len());
+///             let mut elem = BytesStart::owned_name(b"my_elem".to_vec());
 ///
 ///             // collect existing attributes
 ///             elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
@@ -38,15 +37,14 @@ use std::io::Write;
 ///             // writes the event to the writer
 ///             assert!(writer.write_event(Event::Start(elem)).is_ok());
 ///         },
-///         Ok(Event::End(ref e)) if e.name().as_ref() == b"this_tag" => {
+///         Ok(Event::End(e)) if e.name().as_ref() == b"this_tag" => {
 ///             assert!(writer.write_event(Event::End(BytesEnd::borrowed(b"my_elem"))).is_ok());
 ///         },
 ///         Ok(Event::Eof) => break,
 ///         // we can either move or borrow the event to write, depending on your use-case
-///         Ok(e) => assert!(writer.write_event(&e).is_ok()),
-///         Err(e) => panic!("{}", e),
+///         Ok(e) => assert!(writer.write_event(e).is_ok()),
+///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
 ///     }
-///     buf.clear();
 /// }
 ///
 /// let result = writer.into_inner().into_inner();

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -12,8 +12,7 @@ use pretty_assertions::assert_eq;
 
 macro_rules! next_eq_name {
     ($r:expr, $t:tt, $bytes:expr) => {
-        let mut buf = Vec::new();
-        match $r.read_event_into(&mut buf).unwrap() {
+        match $r.read_event().unwrap() {
             $t(ref e) if e.name().as_ref() == $bytes => (),
             e => panic!(
                 "expecting {}({:?}), found {:?}",
@@ -22,14 +21,12 @@ macro_rules! next_eq_name {
                 e
             ),
         }
-        buf.clear();
     };
 }
 
 macro_rules! next_eq_content {
     ($r:expr, $t:tt, $bytes:expr) => {
-        let mut buf = Vec::new();
-        match $r.read_event_into(&mut buf).unwrap() {
+        match $r.read_event().unwrap() {
             $t(ref e) if e.as_ref() == $bytes => (),
             e => panic!(
                 "expecting {}({:?}), found {:?}",
@@ -38,7 +35,6 @@ macro_rules! next_eq_content {
                 e
             ),
         }
-        buf.clear();
     };
 }
 
@@ -130,8 +126,7 @@ fn test_comment() {
 fn test_xml_decl() {
     let mut r = Reader::from_str("<?xml version=\"1.0\" encoding='utf-8'?>");
     r.trim_text(true);
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf).unwrap() {
+    match r.read_event().unwrap() {
         Decl(ref e) => {
             match e.version() {
                 Ok(v) => assert_eq!(
@@ -207,9 +202,8 @@ fn test_writer() -> Result<()> {
     let mut reader = Reader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -226,9 +220,8 @@ fn test_writer_borrow() -> Result<()> {
     let mut reader = Reader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             e => assert!(writer.write_event(&e).is_ok()), // either `e` or `&e`
         }
@@ -249,9 +242,8 @@ fn test_writer_indent() -> Result<()> {
     let mut reader = Reader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -275,9 +267,8 @@ fn test_writer_indent_cdata() -> Result<()> {
     let mut reader = Reader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -301,9 +292,8 @@ fn test_write_empty_element_attrs() -> Result<()> {
     let mut reader = Reader::from_str(str_from);
     reader.expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -323,9 +313,8 @@ fn test_write_attrs() -> Result<()> {
     let mut reader = Reader::from_str(str_from);
     reader.trim_text(true);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        let event = match reader.read_event_into(&mut buf)? {
+        let event = match reader.read_event()? {
             Eof => break,
             Start(elem) => {
                 let mut attrs = elem.attributes().collect::<AttrResult<Vec<_>>>()?;
@@ -430,8 +419,7 @@ fn test_buf_position_err_end_element() {
     let mut r = Reader::from_str("</a>");
     r.trim_text(true).check_end_names(true);
 
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         Err(_) if r.buffer_position() == 2 => (), // error at char 2: no opening tag
         Err(e) => panic!(
             "expecting buf_pos = 2, found {}, err: {:?}",
@@ -450,8 +438,7 @@ fn test_buf_position_err_comment() {
     next_eq!(r, Start, b"a");
     assert_eq!(r.buffer_position(), 3);
 
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         // error at char 4: no closing --> tag found
         Err(e) => assert_eq!(
             r.buffer_position(),
@@ -469,12 +456,10 @@ fn test_buf_position_err_comment_2_buf() {
     let mut r = Reader::from_str("<a><!--b>");
     r.trim_text(true).check_end_names(true);
 
-    let mut buf = Vec::new();
-    let _ = r.read_event_into(&mut buf).unwrap();
+    let _ = r.read_event().unwrap();
     assert_eq!(r.buffer_position(), 3);
 
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         // error at char 4: no closing --> tag found
         Err(e) => assert_eq!(
             r.buffer_position(),
@@ -495,8 +480,7 @@ fn test_buf_position_err_comment_trim_text() {
     next_eq!(r, Start, b"a");
     assert_eq!(r.buffer_position(), 3);
 
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         // error at char 7: no closing --> tag found
         Err(e) => assert_eq!(
             r.buffer_position(),
@@ -514,8 +498,7 @@ fn test_escaped_content() {
     let mut r = Reader::from_str("<a>&lt;test&gt;</a>");
     r.trim_text(true);
     next_eq!(r, Start, b"a");
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         Ok(Text(e)) => {
             assert_eq!(
                 &*e,
@@ -556,9 +539,8 @@ fn test_read_write_roundtrip_results_in_identity() -> Result<()> {
     let mut reader = Reader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -583,9 +565,8 @@ fn test_read_write_roundtrip() -> Result<()> {
     let mut reader = Reader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             e => assert!(writer.write_event(e).is_ok()),
         }
@@ -610,9 +591,8 @@ fn test_read_write_roundtrip_escape() -> Result<()> {
     let mut reader = Reader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             Text(e) => {
                 let t = e.escape();
@@ -643,9 +623,8 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
     let mut reader = Reader::from_str(input);
     reader.trim_text(false).expand_empty_elements(false);
     let mut writer = Writer::new(Cursor::new(Vec::new()));
-    let mut buf = Vec::new();
     loop {
-        match reader.read_event_into(&mut buf)? {
+        match reader.read_event()? {
             Eof => break,
             Text(e) => {
                 let t = e.decode_and_unescape(&reader).unwrap();
@@ -666,8 +645,7 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
 fn test_closing_bracket_in_single_quote_attr() {
     let mut r = Reader::from_str("<a attr='>' check='2'></a>");
     r.trim_text(true);
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             assert_eq!(
@@ -695,8 +673,7 @@ fn test_closing_bracket_in_single_quote_attr() {
 fn test_closing_bracket_in_double_quote_attr() {
     let mut r = Reader::from_str(r#"<a attr=">" check="2"></a>"#);
     r.trim_text(true);
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             assert_eq!(
@@ -724,8 +701,7 @@ fn test_closing_bracket_in_double_quote_attr() {
 fn test_closing_bracket_in_double_quote_mixed() {
     let mut r = Reader::from_str(r#"<a attr="'>'" check="'2'"></a>"#);
     r.trim_text(true);
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             assert_eq!(
@@ -753,8 +729,7 @@ fn test_closing_bracket_in_double_quote_mixed() {
 fn test_closing_bracket_in_single_quote_mixed() {
     let mut r = Reader::from_str(r#"<a attr='">"' check='"2"'></a>"#);
     r.trim_text(true);
-    let mut buf = Vec::new();
-    match r.read_event_into(&mut buf) {
+    match r.read_event() {
         Ok(Start(e)) => {
             let mut attrs = e.attributes();
             assert_eq!(
@@ -791,10 +766,9 @@ mod decode_with_bom_removal {
         reader.trim_text(true);
 
         let mut txt = Vec::new();
-        let mut buf = Vec::new();
 
         loop {
-            match reader.read_event_into(&mut buf) {
+            match reader.read_event() {
                 Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
                 Ok(Eof) => break,
                 _ => (),
@@ -811,14 +785,13 @@ mod decode_with_bom_removal {
     #[cfg(feature = "encoding")]
     #[ignore = "Non-ASCII compatible encodings not properly supported yet. See https://github.com/tafia/quick-xml/issues/158"]
     fn removes_utf16be_bom() {
-        let mut reader = Reader::from_file("./tests/documents/utf16be.xml").unwrap();
+        let mut reader = Reader::from_bytes(include_bytes!("./documents/utf16be.xml"));
         reader.trim_text(true);
 
         let mut txt = Vec::new();
-        let mut buf = Vec::new();
 
         loop {
-            match reader.read_event_into(&mut buf) {
+            match reader.read_event() {
                 Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
                 Ok(Eof) => break,
                 _ => (),
@@ -830,14 +803,13 @@ mod decode_with_bom_removal {
     #[test]
     #[cfg(feature = "encoding")]
     fn removes_utf16le_bom() {
-        let mut reader = Reader::from_file("./tests/documents/utf16le.xml").unwrap();
+        let mut reader = Reader::from_bytes(include_bytes!("./documents/utf16le.xml"));
         reader.trim_text(true);
 
         let mut txt = Vec::new();
-        let mut buf = Vec::new();
 
         loop {
-            match reader.read_event_into(&mut buf) {
+            match reader.read_event() {
                 Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
                 Ok(Eof) => break,
                 _ => (),
@@ -855,10 +827,9 @@ mod decode_with_bom_removal {
         reader.trim_text(true);
 
         let mut txt = Vec::new();
-        let mut buf = Vec::new();
 
         loop {
-            match reader.read_event_into(&mut buf) {
+            match reader.read_event() {
                 Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
                 Ok(Eof) => break,
                 _ => (),


### PR DESCRIPTION
This PR changes almost all usages of `read_event_into` in tests by `read_event`. The notable exception is the `Reader`'s documentation where I've left `read_event_into` as an example.

The same changes was proposed in #425, but their was mixed with another changes, that makes that another changes less visible in the `read_event_into->read_event` noise.

This PR also removes direct examples from the `lib.rs`, because they just duplicate examples in the `Reader` and `Writer`. The examples in the Readme also was synchronized with thoses two.