### PR TITLE
Change all event and Attributes constructors to accept strings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -150,6 +150,8 @@
   but since now escaping works on strings. Use `BytesText::from_plain_str` instead
 
 - [#428]: Removed `BytesText::escaped()`. Use `.as_ref()` provided by `Deref` impl instead.
+- [#428]: Removed `BytesText::from_escaped()`. Use constructors from strings instead,
+  because writer anyway works in UTF-8 only
 
 ### New Tests
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -154,7 +154,7 @@
   because writer anyway works in UTF-8 only
 - [#428]: Removed `BytesCData::new()`. Use constructors from strings instead,
   because writer anyway works in UTF-8 only
-- [#428]: Changed the event constructors to accept an `&str` slices instead of `&[u8]` slices.
+- [#428]: Changed the event and `Attributes` constructors to accept a `&str` slices instead of `&[u8]` slices.
   Handmade events has always been assumed to store their content UTF-8 encoded.
 
 ### New Tests

--- a/Changelog.md
+++ b/Changelog.md
@@ -129,13 +129,12 @@
 
 - [#415]: Changed custom entity unescaping API to accept closures rather than a mapping of entity to
   replacement text. This avoids needing to allocate a map and provides the user with more flexibility.
-- [#415]: Renamed many functions following the pattern `unescape_and_decode*` to `decode_and_unescape*`
-  to better communicate their function. Renamed functions following the pattern `*_with_custom_entities`
-  to `decode_and_unescape_with` to be more consistent across the API.
-- [#415]: `BytesText::escaped()` renamed to `BytesText::escape()`, `BytesText::unescaped()` renamed to
-  `BytesText::unescape()`, `BytesText::unescaped_with()` renamed to `BytesText::unescape_with()`,
-  `Attribute::escaped_value()` renamed to `Attribute::escape_value()`, and `Attribute::escaped_value_with()`
-  renamed to `Attribute::escape_value_with()` for consistency across the API.
+- [#415]: Renamed functions for consistency across the API:
+  |Old Name                |New Name
+  |------------------------|-------------------------------------------
+  |`*_with_custom_entities`|`*_with`
+  |`BytesText::unescaped()`|`BytesText::unescape()`
+  |`Attribute::unescaped_*`|`Attribute::unescape_*`
 
 - [#416]: `BytesStart::to_borrowed` renamed to `BytesStart::borrow`, the same method
   added to all events
@@ -149,6 +148,8 @@
 - [#423]: All escaping functions now accepts and returns strings instead of byte slices
 - [#423]: Removed `BytesText::from_plain` because it internally did escaping of a byte array,
   but since now escaping works on strings. Use `BytesText::from_plain_str` instead
+
+- [#428]: Removed `BytesText::escaped()`. Use `.as_ref()` provided by `Deref` impl instead.
 
 ### New Tests
 
@@ -180,6 +181,7 @@
 [#418]: https://github.com/tafia/quick-xml/pull/418
 [#421]: https://github.com/tafia/quick-xml/pull/421
 [#423]: https://github.com/tafia/quick-xml/pull/423
+[#428]: https://github.com/tafia/quick-xml/pull/428
 [#434]: https://github.com/tafia/quick-xml/pull/434
 [#437]: https://github.com/tafia/quick-xml/pull/437
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -152,6 +152,8 @@
 - [#428]: Removed `BytesText::escaped()`. Use `.as_ref()` provided by `Deref` impl instead.
 - [#428]: Removed `BytesText::from_escaped()`. Use constructors from strings instead,
   because writer anyway works in UTF-8 only
+- [#428]: Removed `BytesCData::new()`. Use constructors from strings instead,
+  because writer anyway works in UTF-8 only
 
 ### New Tests
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -154,6 +154,8 @@
   because writer anyway works in UTF-8 only
 - [#428]: Removed `BytesCData::new()`. Use constructors from strings instead,
   because writer anyway works in UTF-8 only
+- [#428]: Changed the event constructors to accept an `&str` slices instead of `&[u8]` slices.
+  Handmade events has always been assumed to store their content UTF-8 encoded.
 
 ### New Tests
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -156,6 +156,8 @@
   because writer anyway works in UTF-8 only
 - [#428]: Changed the event and `Attributes` constructors to accept a `&str` slices instead of `&[u8]` slices.
   Handmade events has always been assumed to store their content UTF-8 encoded.
+- [#428]: Removed `Decoder` parameter from `_and_decode` versions of functions for
+  `BytesText` (remember, that those functions was renamed in #415).
 
 ### New Tests
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ loop {
                 _ => (),
             }
         }
-        Ok(Event::Text(e)) => txt.push(e.decode_and_unescape(&reader).unwrap().into_owned()),
+        Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
 
         // There are several other `Event`s we do not consider here
         _ => (),

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ loop {
 
             // crates a new element ... alternatively we could reuse `e` by calling
             // `e.into_owned()`
-            let mut elem = BytesStart::owned_name(b"my_elem".to_vec());
+            let mut elem = BytesStart::owned_name("my_elem");
 
             // collect existing attributes
             elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
@@ -92,7 +92,7 @@ loop {
             assert!(writer.write_event(Event::Start(elem)).is_ok());
         },
         Ok(Event::End(e)) if e.name().as_ref() == b"this_tag" => {
-            assert!(writer.write_event(Event::End(BytesEnd::borrowed(b"my_elem"))).is_ok());
+            assert!(writer.write_event(Event::End(BytesEnd::borrowed("my_elem"))).is_ok());
         },
         Ok(Event::Eof) => break,
         // we can either move or borrow the event to write, depending on your use-case

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -28,7 +28,7 @@ fn parse_document(doc: &[u8]) -> XmlResult<()> {
                 }
             }
             Event::Text(e) => {
-                criterion::black_box(e.decode_and_unescape(&r)?);
+                criterion::black_box(e.unescape()?);
             }
             Event::CData(e) => {
                 criterion::black_box(e.into_inner());

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -174,7 +174,7 @@ fn one_event(c: &mut Criterion) {
                 .check_comments(false)
                 .trim_text(true);
             match r.read_event_into(&mut buf) {
-                Ok(Event::Comment(e)) => nbtxt += e.decode_and_unescape(&r).unwrap().len(),
+                Ok(Event::Comment(e)) => nbtxt += e.unescape().unwrap().len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
 

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -60,9 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(Event::Text(ref e)) => {
                 println!(
                     "text value: {}",
-                    e.decode_and_unescape_with(&reader, |ent| custom_entities
-                        .get(ent)
-                        .map(|s| s.as_str()))
+                    e.unescape_with(|ent| custom_entities.get(ent).map(|s| s.as_str()))
                         .unwrap()
                 );
             }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1042,13 +1042,10 @@ mod tests {
             assert_eq!(de.read, vec![]);
             assert_eq!(de.write, vec![]);
 
-            assert_eq!(
-                de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"root"))
-            );
+            assert_eq!(de.next().unwrap(), Start(BytesStart::borrowed_name("root")));
             assert_eq!(
                 de.peek().unwrap(),
-                &Start(BytesStart::borrowed_name(b"inner"))
+                &Start(BytesStart::borrowed_name("inner"))
             );
 
             // Should skip first <inner> tree
@@ -1057,11 +1054,11 @@ mod tests {
             assert_eq!(
                 de.write,
                 vec![
-                    Start(BytesStart::borrowed_name(b"inner")),
+                    Start(BytesStart::borrowed_name("inner")),
                     Text(BytesText::from_escaped_str("text")),
-                    Start(BytesStart::borrowed_name(b"inner")),
-                    End(BytesEnd::borrowed(b"inner")),
-                    End(BytesEnd::borrowed(b"inner")),
+                    Start(BytesStart::borrowed_name("inner")),
+                    End(BytesEnd::borrowed("inner")),
+                    End(BytesEnd::borrowed("inner")),
                 ]
             );
 
@@ -1073,11 +1070,8 @@ mod tests {
             //   </inner>
             //   <target/>
             // </root>
-            assert_eq!(
-                de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"next"))
-            );
-            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"next")));
+            assert_eq!(de.next().unwrap(), Start(BytesStart::borrowed_name("next")));
+            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("next")));
 
             // We finish writing. Next call to `next()` should start replay that messages:
             //
@@ -1094,17 +1088,17 @@ mod tests {
             assert_eq!(
                 de.read,
                 vec![
-                    Start(BytesStart::borrowed_name(b"inner")),
+                    Start(BytesStart::borrowed_name("inner")),
                     Text(BytesText::from_escaped_str("text")),
-                    Start(BytesStart::borrowed_name(b"inner")),
-                    End(BytesEnd::borrowed(b"inner")),
-                    End(BytesEnd::borrowed(b"inner")),
+                    Start(BytesStart::borrowed_name("inner")),
+                    End(BytesEnd::borrowed("inner")),
+                    End(BytesEnd::borrowed("inner")),
                 ]
             );
             assert_eq!(de.write, vec![]);
             assert_eq!(
                 de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"inner"))
+                Start(BytesStart::borrowed_name("inner"))
             );
 
             // Skip `#text` node and consume <inner/> after it
@@ -1112,9 +1106,9 @@ mod tests {
             assert_eq!(
                 de.read,
                 vec![
-                    Start(BytesStart::borrowed_name(b"inner")),
-                    End(BytesEnd::borrowed(b"inner")),
-                    End(BytesEnd::borrowed(b"inner")),
+                    Start(BytesStart::borrowed_name("inner")),
+                    End(BytesEnd::borrowed("inner")),
+                    End(BytesEnd::borrowed("inner")),
                 ]
             );
             assert_eq!(
@@ -1128,9 +1122,9 @@ mod tests {
 
             assert_eq!(
                 de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"inner"))
+                Start(BytesStart::borrowed_name("inner"))
             );
-            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"inner")));
+            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("inner")));
 
             // We finish writing. Next call to `next()` should start replay messages:
             //
@@ -1146,7 +1140,7 @@ mod tests {
                 de.read,
                 vec![
                     Text(BytesText::from_escaped_str("text")),
-                    End(BytesEnd::borrowed(b"inner")),
+                    End(BytesEnd::borrowed("inner")),
                 ]
             );
             assert_eq!(de.write, vec![]);
@@ -1154,13 +1148,13 @@ mod tests {
                 de.next().unwrap(),
                 Text(BytesText::from_escaped_str("text"))
             );
-            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"inner")));
+            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("inner")));
             assert_eq!(
                 de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"target"))
+                Start(BytesStart::borrowed_name("target"))
             );
-            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"target")));
-            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"root")));
+            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("target")));
+            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("root")));
         }
 
         /// Checks that `read_to_end()` behaves correctly after `skip()`
@@ -1184,10 +1178,7 @@ mod tests {
             assert_eq!(de.read, vec![]);
             assert_eq!(de.write, vec![]);
 
-            assert_eq!(
-                de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"root"))
-            );
+            assert_eq!(de.next().unwrap(), Start(BytesStart::borrowed_name("root")));
 
             // Skip the <skip> tree
             de.skip().unwrap();
@@ -1195,11 +1186,11 @@ mod tests {
             assert_eq!(
                 de.write,
                 vec![
-                    Start(BytesStart::borrowed_name(b"skip")),
+                    Start(BytesStart::borrowed_name("skip")),
                     Text(BytesText::from_escaped_str("text")),
-                    Start(BytesStart::borrowed_name(b"skip")),
-                    End(BytesEnd::borrowed(b"skip")),
-                    End(BytesEnd::borrowed(b"skip")),
+                    Start(BytesStart::borrowed_name("skip")),
+                    End(BytesEnd::borrowed("skip")),
+                    End(BytesEnd::borrowed("skip")),
                 ]
             );
 
@@ -1212,18 +1203,18 @@ mod tests {
             // </root>
             assert_eq!(
                 de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"target"))
+                Start(BytesStart::borrowed_name("target"))
             );
             de.read_to_end(QName(b"target")).unwrap();
             assert_eq!(de.read, vec![]);
             assert_eq!(
                 de.write,
                 vec![
-                    Start(BytesStart::borrowed_name(b"skip")),
+                    Start(BytesStart::borrowed_name("skip")),
                     Text(BytesText::from_escaped_str("text")),
-                    Start(BytesStart::borrowed_name(b"skip")),
-                    End(BytesEnd::borrowed(b"skip")),
-                    End(BytesEnd::borrowed(b"skip")),
+                    Start(BytesStart::borrowed_name("skip")),
+                    End(BytesEnd::borrowed("skip")),
+                    End(BytesEnd::borrowed("skip")),
                 ]
             );
 
@@ -1241,22 +1232,19 @@ mod tests {
             assert_eq!(
                 de.read,
                 vec![
-                    Start(BytesStart::borrowed_name(b"skip")),
+                    Start(BytesStart::borrowed_name("skip")),
                     Text(BytesText::from_escaped_str("text")),
-                    Start(BytesStart::borrowed_name(b"skip")),
-                    End(BytesEnd::borrowed(b"skip")),
-                    End(BytesEnd::borrowed(b"skip")),
+                    Start(BytesStart::borrowed_name("skip")),
+                    End(BytesEnd::borrowed("skip")),
+                    End(BytesEnd::borrowed("skip")),
                 ]
             );
             assert_eq!(de.write, vec![]);
 
-            assert_eq!(
-                de.next().unwrap(),
-                Start(BytesStart::borrowed_name(b"skip"))
-            );
+            assert_eq!(de.next().unwrap(), Start(BytesStart::borrowed_name("skip")));
             de.read_to_end(QName(b"skip")).unwrap();
 
-            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"root")));
+            assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("root")));
         }
 
         /// Checks that limiting buffer size works correctly
@@ -1306,34 +1294,31 @@ mod tests {
             "#,
         );
 
-        assert_eq!(
-            de.next().unwrap(),
-            Start(BytesStart::borrowed_name(b"root"))
-        );
+        assert_eq!(de.next().unwrap(), Start(BytesStart::borrowed_name("root")));
 
         assert_eq!(
             de.next().unwrap(),
-            Start(BytesStart::borrowed(br#"tag a="1""#, 3))
+            Start(BytesStart::borrowed(r#"tag a="1""#, 3))
         );
         assert_eq!(de.read_to_end(QName(b"tag")).unwrap(), ());
 
         assert_eq!(
             de.next().unwrap(),
-            Start(BytesStart::borrowed(br#"tag a="2""#, 3))
+            Start(BytesStart::borrowed(r#"tag a="2""#, 3))
         );
         assert_eq!(
             de.next().unwrap(),
             CData(BytesCData::from_str("cdata content"))
         );
-        assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"tag")));
+        assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("tag")));
 
         assert_eq!(
             de.next().unwrap(),
-            Start(BytesStart::borrowed(b"self-closed", 11))
+            Start(BytesStart::borrowed_name("self-closed"))
         );
         assert_eq!(de.read_to_end(QName(b"self-closed")).unwrap(), ());
 
-        assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed(b"root")));
+        assert_eq!(de.next().unwrap(), End(BytesEnd::borrowed("root")));
         assert_eq!(de.next().unwrap(), Eof);
     }
 
@@ -1402,17 +1387,17 @@ mod tests {
             events,
             vec![
                 Start(BytesStart::borrowed(
-                    br#"item name="hello" source="world.rs""#,
+                    r#"item name="hello" source="world.rs""#,
                     4
                 )),
                 Text(BytesText::from_escaped_str("Some text")),
-                End(BytesEnd::borrowed(b"item")),
-                Start(BytesStart::borrowed(b"item2", 5)),
-                End(BytesEnd::borrowed(b"item2")),
-                Start(BytesStart::borrowed(b"item3", 5)),
-                End(BytesEnd::borrowed(b"item3")),
-                Start(BytesStart::borrowed(br#"item4 value="world" "#, 5)),
-                End(BytesEnd::borrowed(b"item4")),
+                End(BytesEnd::borrowed("item")),
+                Start(BytesStart::borrowed("item2", 5)),
+                End(BytesEnd::borrowed("item2")),
+                Start(BytesStart::borrowed("item3", 5)),
+                End(BytesEnd::borrowed("item3")),
+                Start(BytesStart::borrowed(r#"item4 value="world" "#, 5)),
+                End(BytesEnd::borrowed("item4")),
             ]
         )
     }
@@ -1432,7 +1417,7 @@ mod tests {
 
         assert_eq!(
             reader.next().unwrap(),
-            DeEvent::Start(BytesStart::borrowed(b"item ", 4))
+            DeEvent::Start(BytesStart::borrowed("item ", 4))
         );
         reader.read_to_end(QName(b"item")).unwrap();
         assert_eq!(reader.next().unwrap(), DeEvent::Eof);

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -612,16 +612,15 @@ where
         unescape: bool,
         allow_start: bool,
     ) -> Result<Cow<'de, str>, DeError> {
-        let decoder = self.reader.decoder();
         match self.next()? {
-            DeEvent::Text(e) => Ok(e.decode(decoder, unescape)?),
-            DeEvent::CData(e) => Ok(e.decode(decoder)?),
+            DeEvent::Text(e) => Ok(e.decode(unescape)?),
+            DeEvent::CData(e) => Ok(e.decode()?),
             DeEvent::Start(e) if allow_start => {
                 // allow one nested level
                 let inner = self.next()?;
                 let t = match inner {
-                    DeEvent::Text(t) => t.decode(decoder, unescape)?,
-                    DeEvent::CData(t) => t.decode(decoder)?,
+                    DeEvent::Text(t) => t.decode(unescape)?,
+                    DeEvent::CData(t) => t.decode()?,
                     DeEvent::Start(s) => {
                         return Err(DeError::UnexpectedStart(s.name().as_ref().to_owned()))
                     }

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -134,7 +134,7 @@ where
 
 #[test]
 fn test_not_in() {
-    let tag = BytesStart::borrowed_name(b"tag");
+    let tag = BytesStart::borrowed_name("tag");
 
     assert_eq!(not_in(&[], &tag, Decoder::utf8()).unwrap(), true);
     assert_eq!(

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -845,7 +845,7 @@ pub struct BytesCData<'a> {
 impl<'a> BytesCData<'a> {
     /// Creates a new `BytesCData` from a byte sequence.
     #[inline]
-    pub fn new<C: Into<Cow<'a, [u8]>>>(content: C) -> Self {
+    pub(crate) fn wrap<C: Into<Cow<'a, [u8]>>>(content: C) -> Self {
         Self {
             content: content.into(),
         }
@@ -854,7 +854,7 @@ impl<'a> BytesCData<'a> {
     /// Creates a new `BytesCData` from a string
     #[inline]
     pub fn from_str(content: &'a str) -> Self {
-        Self::new(content.as_bytes())
+        Self::wrap(content.as_bytes())
     }
 
     /// Ensures that all data is owned to extend the object's lifetime if

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -786,11 +786,6 @@ impl<'a> BytesText<'a> {
         }
     }
 
-    /// Gets escaped content.
-    pub fn escape(&self) -> &[u8] {
-        self.content.as_ref()
-    }
-
     /// Gets content of this text buffer in the specified encoding and optionally
     /// unescapes it. Unlike [`Self::decode_and_unescape`] & Co., the lifetime
     /// of the returned `Cow` is bound to the original buffer / input

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -312,12 +312,12 @@ impl<'a> BytesStart<'a> {
 
     /// Returns an iterator over the attributes of this tag.
     pub fn attributes(&self) -> Attributes {
-        Attributes::new(&self.buf, self.name_len)
+        Attributes::wrap(&self.buf, self.name_len, false)
     }
 
     /// Returns an iterator over the HTML-like attributes of this tag (no mandatory quotes or `=`).
     pub fn html_attributes(&self) -> Attributes {
-        Attributes::html(self, self.name_len)
+        Attributes::wrap(&self.buf, self.name_len, true)
     }
 
     /// Gets the undecoded raw string with the attributes of this tag as a `&[u8]`,

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -517,9 +517,9 @@ impl<'a> BytesDecl<'a> {
     /// The caller is responsible for escaping attribute values. Shouldn't usually be relevant since
     /// the double quote character is not allowed in any of the attribute values.
     pub fn new(
-        version: &[u8],
-        encoding: Option<&[u8]>,
-        standalone: Option<&[u8]>,
+        version: &str,
+        encoding: Option<&str>,
+        standalone: Option<&str>,
     ) -> BytesDecl<'static> {
         // Compute length of the buffer based on supplied attributes
         // ' encoding=""'   => 12
@@ -535,21 +535,21 @@ impl<'a> BytesDecl<'a> {
             0
         };
         // 'xml version=""' => 14
-        let mut buf = Vec::with_capacity(14 + encoding_attr_len + standalone_attr_len);
+        let mut buf = String::with_capacity(14 + encoding_attr_len + standalone_attr_len);
 
-        buf.extend_from_slice(b"xml version=\"");
-        buf.extend_from_slice(version);
+        buf.push_str("xml version=\"");
+        buf.push_str(version);
 
         if let Some(encoding_val) = encoding {
-            buf.extend_from_slice(b"\" encoding=\"");
-            buf.extend_from_slice(encoding_val);
+            buf.push_str("\" encoding=\"");
+            buf.push_str(encoding_val);
         }
 
         if let Some(standalone_val) = standalone {
-            buf.extend_from_slice(b"\" standalone=\"");
-            buf.extend_from_slice(standalone_val);
+            buf.push_str("\" standalone=\"");
+            buf.push_str(standalone_val);
         }
-        buf.push(b'"');
+        buf.push('"');
 
         BytesDecl {
             content: BytesStart::owned(buf, 3),

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -675,7 +675,7 @@ pub struct BytesText<'a> {
 impl<'a> BytesText<'a> {
     /// Creates a new `BytesText` from an escaped byte sequence.
     #[inline]
-    pub fn from_escaped<C: Into<Cow<'a, [u8]>>>(content: C) -> Self {
+    pub(crate) fn wrap<C: Into<Cow<'a, [u8]>>>(content: C) -> Self {
         Self {
             content: content.into(),
         }
@@ -684,7 +684,7 @@ impl<'a> BytesText<'a> {
     /// Creates a new `BytesText` from an escaped string.
     #[inline]
     pub fn from_escaped_str<C: Into<Cow<'a, str>>>(content: C) -> Self {
-        Self::from_escaped(match content.into() {
+        Self::wrap(match content.into() {
             Cow::Owned(o) => Cow::Owned(o.into_bytes()),
             Cow::Borrowed(b) => Cow::Borrowed(b.as_bytes()),
         })
@@ -894,7 +894,7 @@ impl<'a> BytesCData<'a> {
     /// | `"`       | `&quot;`
     pub fn escape(self, decoder: Decoder) -> Result<BytesText<'a>> {
         let decoded = self.decode(decoder)?;
-        Ok(BytesText::from_escaped(match escape(&decoded) {
+        Ok(BytesText::wrap(match escape(&decoded) {
             // Because result is borrowed, no replacements was done and we can use original content
             Cow::Borrowed(_) => self.content,
             Cow::Owned(escaped) => Cow::Owned(escaped.into_bytes()),
@@ -916,7 +916,7 @@ impl<'a> BytesCData<'a> {
     /// | `&`       | `&amp;`
     pub fn partial_escape(self, decoder: Decoder) -> Result<BytesText<'a>> {
         let decoded = self.decode(decoder)?;
-        Ok(BytesText::from_escaped(match partial_escape(&decoded) {
+        Ok(BytesText::wrap(match partial_escape(&decoded) {
             // Because result is borrowed, no replacements was done and we can use original content
             Cow::Borrowed(_) => self.content,
             Cow::Owned(escaped) => Cow::Owned(escaped.into_bytes()),

--- a/src/name.rs
+++ b/src/name.rs
@@ -574,11 +574,11 @@ mod namespaces {
             let mut resolver = NamespaceResolver::default();
             let mut buffer = Vec::new();
 
-            resolver.push(&BytesStart::borrowed(b" xmlns='default'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns='default'", 0), &mut buffer);
             assert_eq!(buffer, b"default");
 
             // Check that tags without namespaces does not change result
-            resolver.push(&BytesStart::borrowed(b"", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed("", 0), &mut buffer);
             assert_eq!(buffer, b"default");
             resolver.pop(&mut buffer);
 
@@ -604,8 +604,8 @@ mod namespaces {
             let mut resolver = NamespaceResolver::default();
             let mut buffer = Vec::new();
 
-            resolver.push(&BytesStart::borrowed(b" xmlns='old'", 0), &mut buffer);
-            resolver.push(&BytesStart::borrowed(b" xmlns='new'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns='old'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns='new'", 0), &mut buffer);
 
             assert_eq!(buffer, b"oldnew");
             assert_eq!(
@@ -643,8 +643,8 @@ mod namespaces {
             let mut resolver = NamespaceResolver::default();
             let mut buffer = Vec::new();
 
-            resolver.push(&BytesStart::borrowed(b" xmlns='old'", 0), &mut buffer);
-            resolver.push(&BytesStart::borrowed(b" xmlns=''", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns='old'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns=''", 0), &mut buffer);
 
             assert_eq!(buffer, b"old");
             assert_eq!(
@@ -684,11 +684,11 @@ mod namespaces {
             let mut resolver = NamespaceResolver::default();
             let mut buffer = Vec::new();
 
-            resolver.push(&BytesStart::borrowed(b" xmlns:p='default'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns:p='default'", 0), &mut buffer);
             assert_eq!(buffer, b"pdefault");
 
             // Check that tags without namespaces does not change result
-            resolver.push(&BytesStart::borrowed(b"", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed("", 0), &mut buffer);
             assert_eq!(buffer, b"pdefault");
             resolver.pop(&mut buffer);
 
@@ -714,8 +714,8 @@ mod namespaces {
             let mut resolver = NamespaceResolver::default();
             let mut buffer = Vec::new();
 
-            resolver.push(&BytesStart::borrowed(b" xmlns:p='old'", 0), &mut buffer);
-            resolver.push(&BytesStart::borrowed(b" xmlns:p='new'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns:p='old'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns:p='new'", 0), &mut buffer);
 
             assert_eq!(buffer, b"poldpnew");
             assert_eq!(
@@ -753,8 +753,8 @@ mod namespaces {
             let mut resolver = NamespaceResolver::default();
             let mut buffer = Vec::new();
 
-            resolver.push(&BytesStart::borrowed(b" xmlns:p='old'", 0), &mut buffer);
-            resolver.push(&BytesStart::borrowed(b" xmlns:p=''", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns:p='old'", 0), &mut buffer);
+            resolver.push(&BytesStart::borrowed(" xmlns:p=''", 0), &mut buffer);
 
             assert_eq!(buffer, b"poldp");
             assert_eq!(

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -48,7 +48,7 @@ impl<R: BufRead> Reader<R> {
     /// loop {
     ///     match reader.read_event_into(&mut buf) {
     ///         Ok(Event::Start(ref e)) => count += 1,
-    ///         Ok(Event::Text(e)) => txt.push(e.decode_and_unescape(&reader).unwrap().into_owned()),
+    ///         Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
     ///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
     ///         Ok(Event::Eof) => break,
     ///         _ => (),
@@ -207,7 +207,7 @@ impl<R: BufRead> Reader<R> {
         let s = match self.read_event_into(buf) {
             Err(e) => return Err(e),
 
-            Ok(Event::Text(e)) => e.decode_and_unescape(self)?.into_owned(),
+            Ok(Event::Text(e)) => e.unescape()?.into_owned(),
             Ok(Event::End(e)) if e.name() == end => return Ok("".to_string()),
             Ok(Event::Eof) => return Err(Error::UnexpectedEof("Text".to_string())),
             _ => return Err(Error::TextNotFound),

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -124,7 +124,7 @@ impl<R: BufRead> Reader<R> {
     /// reader.trim_text(true);
     /// let mut buf = Vec::new();
     ///
-    /// let start = BytesStart::borrowed_name(b"outer");
+    /// let start = BytesStart::borrowed_name("outer");
     /// let end   = start.to_end().into_owned();
     ///
     /// // First, we read a start event...

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -514,9 +514,9 @@ impl<R> Reader<R> {
                 };
 
                 Ok(if first {
-                    Event::StartText(BytesText::from_escaped(content).into())
+                    Event::StartText(BytesText::wrap(content).into())
                 } else {
-                    Event::Text(BytesText::from_escaped(content))
+                    Event::Text(BytesText::wrap(content))
                 })
             }
             Ok(None) => Ok(Event::Eof),
@@ -587,7 +587,7 @@ impl<R> Reader<R> {
                         return Err(Error::UnexpectedToken("--".to_string()));
                     }
                 }
-                Ok(Event::Comment(BytesText::from_escaped(&buf[3..len - 2])))
+                Ok(Event::Comment(BytesText::wrap(&buf[3..len - 2])))
             }
             BangType::CData if uncased_starts_with(buf, b"![CDATA[") => {
                 Ok(Event::CData(BytesCData::new(&buf[8..])))
@@ -598,7 +598,7 @@ impl<R> Reader<R> {
                     .position(|b| !is_whitespace(*b))
                     .unwrap_or_else(|| len - 8);
                 debug_assert!(start < len - 8, "DocType must have a name");
-                Ok(Event::DocType(BytesText::from_escaped(&buf[8 + start..])))
+                Ok(Event::DocType(BytesText::wrap(&buf[8 + start..])))
             }
             _ => Err(bang_type.to_err()),
         }
@@ -663,7 +663,7 @@ impl<R> Reader<R> {
 
                 Ok(Event::Decl(event))
             } else {
-                Ok(Event::PI(BytesText::from_escaped(&buf[1..len - 1])))
+                Ok(Event::PI(BytesText::wrap(&buf[1..len - 1])))
             }
         } else {
             self.buf_position -= len;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -269,7 +269,7 @@ impl EncodingRef {
 ///                 _ => (),
 ///             }
 ///         }
-///         Ok(Event::Text(e)) => txt.push(e.decode_and_unescape(&reader).unwrap().into_owned()),
+///         Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
 ///
 ///         // There are several other `Event`s we do not consider here
 ///         _ => (),

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -590,7 +590,7 @@ impl<R> Reader<R> {
                 Ok(Event::Comment(BytesText::wrap(&buf[3..len - 2])))
             }
             BangType::CData if uncased_starts_with(buf, b"![CDATA[") => {
-                Ok(Event::CData(BytesCData::new(&buf[8..])))
+                Ok(Event::CData(BytesCData::wrap(&buf[8..])))
             }
             BangType::DocType if uncased_starts_with(buf, b"!DOCTYPE") => {
                 let start = buf[8..]

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -472,7 +472,7 @@ impl<R: BufRead> NsReader<R> {
     /// let mut buf = Vec::new();
     ///
     /// let ns = Namespace(b"namespace 1");
-    /// let start = BytesStart::borrowed(br#"outer xmlns="namespace 1""#, 5);
+    /// let start = BytesStart::borrowed(r#"outer xmlns="namespace 1""#, 5);
     /// let end   = start.to_end().into_owned();
     ///
     /// // First, we read a start event...
@@ -693,7 +693,7 @@ impl<'i> NsReader<&'i [u8]> {
     /// reader.trim_text(true);
     ///
     /// let ns = Namespace(b"namespace 1");
-    /// let start = BytesStart::borrowed(br#"outer xmlns="namespace 1""#, 5);
+    /// let start = BytesStart::borrowed(r#"outer xmlns="namespace 1""#, 5);
     /// let end   = start.to_end().into_owned();
     ///
     /// // First, we read a start event...

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -329,7 +329,7 @@ impl<R: BufRead> NsReader<R> {
     ///             }
     ///         }
     ///         Event::Text(e) => {
-    ///             txt.push(e.decode_and_unescape(&reader).unwrap().into_owned())
+    ///             txt.push(e.unescape().unwrap().into_owned())
     ///         }
     ///         Event::Eof => break,
     ///         _ => (),
@@ -388,7 +388,7 @@ impl<R: BufRead> NsReader<R> {
     ///         (_, Event::Start(_)) => unreachable!(),
     ///
     ///         (_, Event::Text(e)) => {
-    ///             txt.push(e.decode_and_unescape(&reader).unwrap().into_owned())
+    ///             txt.push(e.unescape().unwrap().into_owned())
     ///         }
     ///         (_, Event::Eof) => break,
     ///         _ => (),
@@ -566,7 +566,7 @@ impl<'i> NsReader<&'i [u8]> {
     ///             }
     ///         }
     ///         Event::Text(e) => {
-    ///             txt.push(e.decode_and_unescape(&reader).unwrap().into_owned())
+    ///             txt.push(e.unescape().unwrap().into_owned())
     ///         }
     ///         Event::Eof => break,
     ///         _ => (),
@@ -624,7 +624,7 @@ impl<'i> NsReader<&'i [u8]> {
     ///         (_, Event::Start(_)) => unreachable!(),
     ///
     ///         (_, Event::Text(e)) => {
-    ///             txt.push(e.decode_and_unescape(&reader).unwrap().into_owned())
+    ///             txt.push(e.unescape().unwrap().into_owned())
     ///         }
     ///         (_, Event::Eof) => break,
     ///         _ => (),

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -93,7 +93,7 @@ impl<'a> Reader<&'a [u8]> {
     /// "#);
     /// reader.trim_text(true);
     ///
-    /// let start = BytesStart::borrowed_name(b"outer");
+    /// let start = BytesStart::borrowed_name("outer");
     /// let end   = start.to_end().into_owned();
     ///
     /// // First, we read a start event...

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -113,7 +113,7 @@ impl<'r, W: Write> Serializer<'r, W> {
     /// Writes self-closed tag `<tag_name/>` into inner writer
     fn write_self_closed(&mut self, tag_name: &str) -> Result<(), DeError> {
         self.writer
-            .write_event(Event::Empty(BytesStart::borrowed_name(tag_name.as_bytes())))?;
+            .write_event(Event::Empty(BytesStart::borrowed_name(tag_name)))?;
         Ok(())
     }
 
@@ -124,10 +124,10 @@ impl<'r, W: Write> Serializer<'r, W> {
         value: &T,
     ) -> Result<(), DeError> {
         self.writer
-            .write_event(Event::Start(BytesStart::borrowed_name(tag_name.as_bytes())))?;
+            .write_event(Event::Start(BytesStart::borrowed_name(tag_name)))?;
         value.serialize(&mut *self)?;
         self.writer
-            .write_event(Event::End(BytesEnd::borrowed(tag_name.as_bytes())))?;
+            .write_event(Event::End(BytesEnd::borrowed(tag_name)))?;
         Ok(())
     }
 }
@@ -306,7 +306,7 @@ impl<'r, 'w, W: Write> ser::Serializer for &'w mut Serializer<'r, W> {
         if let Some(tag) = self.root_tag {
             // TODO: Write self-closed tag if map is empty
             self.writer
-                .write_event(Event::Start(BytesStart::borrowed_name(tag.as_bytes())))?;
+                .write_event(Event::Start(BytesStart::borrowed_name(tag)))?;
         }
         Ok(Map::new(self))
     }

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -54,7 +54,7 @@ where
         if let Some(tag) = self.parent.root_tag {
             self.parent
                 .writer
-                .write_event(Event::End(BytesEnd::borrowed(tag.as_bytes())))?;
+                .write_event(Event::End(BytesEnd::borrowed(tag)))?;
         }
         Ok(())
     }
@@ -100,7 +100,6 @@ where
 {
     /// Create a new `Struct`
     pub fn new(parent: &'w mut Serializer<'r, W>, name: &'r str) -> Self {
-        let name = name.as_bytes();
         Struct {
             parent,
             attrs: BytesStart::borrowed_name(name),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -26,7 +26,7 @@ use std::io::Write;
 ///
 ///             // crates a new element ... alternatively we could reuse `e` by calling
 ///             // `e.into_owned()`
-///             let mut elem = BytesStart::owned_name(b"my_elem".to_vec());
+///             let mut elem = BytesStart::owned_name("my_elem");
 ///
 ///             // collect existing attributes
 ///             elem.extend_attributes(e.attributes().map(|attr| attr.unwrap()));
@@ -38,7 +38,7 @@ use std::io::Write;
 ///             assert!(writer.write_event(Event::Start(elem)).is_ok());
 ///         },
 ///         Ok(Event::End(e)) if e.name().as_ref() == b"this_tag" => {
-///             assert!(writer.write_event(Event::End(BytesEnd::borrowed(b"my_elem"))).is_ok());
+///             assert!(writer.write_event(Event::End(BytesEnd::borrowed("my_elem"))).is_ok());
 ///         },
 ///         Ok(Event::Eof) => break,
 ///         // we can either move or borrow the event to write, depending on your use-case
@@ -213,7 +213,7 @@ impl<W: Write> Writer<W> {
     #[must_use]
     pub fn create_element<'a, N>(&'a mut self, name: &'a N) -> ElementWriter<W>
     where
-        N: 'a + AsRef<[u8]> + ?Sized,
+        N: 'a + AsRef<str> + ?Sized,
     {
         ElementWriter {
             writer: self,
@@ -347,7 +347,7 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let tag = BytesStart::borrowed_name(b"self-closed")
+        let tag = BytesStart::borrowed_name("self-closed")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         writer
             .write_event(Event::Empty(tag))
@@ -364,7 +364,7 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let start = BytesStart::borrowed_name(b"paired")
+        let start = BytesStart::borrowed_name("paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         let end = start.to_end();
         writer
@@ -386,10 +386,10 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let start = BytesStart::borrowed_name(b"paired")
+        let start = BytesStart::borrowed_name("paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         let end = start.to_end();
-        let inner = BytesStart::borrowed_name(b"inner");
+        let inner = BytesStart::borrowed_name("inner");
 
         writer
             .write_event(Event::Start(start.clone()))
@@ -414,7 +414,7 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let start = BytesStart::borrowed_name(b"paired")
+        let start = BytesStart::borrowed_name("paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         let end = start.to_end();
         let text = BytesText::from_plain_str("text");
@@ -440,11 +440,11 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let start = BytesStart::borrowed_name(b"paired")
+        let start = BytesStart::borrowed_name("paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         let end = start.to_end();
         let text = BytesText::from_plain_str("text");
-        let inner = BytesStart::borrowed_name(b"inner");
+        let inner = BytesStart::borrowed_name("inner");
 
         writer
             .write_event(Event::Start(start.clone()))
@@ -471,10 +471,10 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let start = BytesStart::borrowed_name(b"paired")
+        let start = BytesStart::borrowed_name("paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
         let end = start.to_end();
-        let inner = BytesStart::borrowed_name(b"inner");
+        let inner = BytesStart::borrowed_name("inner");
 
         writer
             .write_event(Event::Start(start.clone()))
@@ -507,7 +507,7 @@ mod indentation {
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
         writer
-            .create_element(b"empty")
+            .create_element("empty")
             .with_attribute(("attr1", "value1"))
             .with_attribute(("attr2", "value2"))
             .write_empty()

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -364,12 +364,11 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let name = b"paired";
-        let start = BytesStart::borrowed_name(name)
+        let start = BytesStart::borrowed_name(b"paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
-        let end = BytesEnd::borrowed(name);
+        let end = start.to_end();
         writer
-            .write_event(Event::Start(start))
+            .write_event(Event::Start(start.clone()))
             .expect("write start tag failed");
         writer
             .write_event(Event::End(end))
@@ -387,14 +386,13 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let name = b"paired";
-        let start = BytesStart::borrowed_name(name)
+        let start = BytesStart::borrowed_name(b"paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
-        let end = BytesEnd::borrowed(name);
+        let end = start.to_end();
         let inner = BytesStart::borrowed_name(b"inner");
 
         writer
-            .write_event(Event::Start(start))
+            .write_event(Event::Start(start.clone()))
             .expect("write start tag failed");
         writer
             .write_event(Event::Empty(inner))
@@ -416,14 +414,13 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let name = b"paired";
-        let start = BytesStart::borrowed_name(name)
+        let start = BytesStart::borrowed_name(b"paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
-        let end = BytesEnd::borrowed(name);
+        let end = start.to_end();
         let text = BytesText::from_plain_str("text");
 
         writer
-            .write_event(Event::Start(start))
+            .write_event(Event::Start(start.clone()))
             .expect("write start tag failed");
         writer
             .write_event(Event::Text(text))
@@ -443,15 +440,14 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let name = b"paired";
-        let start = BytesStart::borrowed_name(name)
+        let start = BytesStart::borrowed_name(b"paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
-        let end = BytesEnd::borrowed(name);
+        let end = start.to_end();
         let text = BytesText::from_plain_str("text");
         let inner = BytesStart::borrowed_name(b"inner");
 
         writer
-            .write_event(Event::Start(start))
+            .write_event(Event::Start(start.clone()))
             .expect("write start tag failed");
         writer
             .write_event(Event::Text(text))
@@ -475,17 +471,16 @@ mod indentation {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
 
-        let name = b"paired";
-        let start = BytesStart::borrowed_name(name)
+        let start = BytesStart::borrowed_name(b"paired")
             .with_attributes(vec![("attr1", "value1"), ("attr2", "value2")].into_iter());
-        let end = BytesEnd::borrowed(name);
+        let end = start.to_end();
         let inner = BytesStart::borrowed_name(b"inner");
 
         writer
             .write_event(Event::Start(start.clone()))
             .expect("write start 1 tag failed");
         writer
-            .write_event(Event::Start(start))
+            .write_event(Event::Start(start.clone()))
             .expect("write start 2 tag failed");
         writer
             .write_event(Event::Empty(inner))

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -106,7 +106,7 @@ impl<W: Write> Writer<W> {
             Event::Empty(ref e) => self.write_wrapped(b"<", e, b"/>"),
             Event::Text(ref e) => {
                 next_should_line_break = false;
-                self.write(&e.escape())
+                self.write(&e)
             }
             Event::Comment(ref e) => self.write_wrapped(b"<!--", e, b"-->"),
             Event::CData(ref e) => {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -98,7 +98,7 @@ fn test_koi8_r_encoding() {
     loop {
         match r.read_event() {
             Ok(Text(e)) => {
-                e.decode_and_unescape(&r).unwrap();
+                e.unescape().unwrap();
             }
             Ok(Eof) => break,
             _ => (),
@@ -157,7 +157,7 @@ fn fuzz_101() {
                 }
             }
             Ok(Text(e)) => {
-                if e.decode_and_unescape(&reader).is_err() {
+                if e.unescape().is_err() {
                     break;
                 }
             }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -340,7 +340,7 @@ fn test_write_attrs() -> Result<()> {
 fn test_new_xml_decl_full() {
     let mut writer = Writer::new(Vec::new());
     writer
-        .write_event(Decl(BytesDecl::new(b"1.2", Some(b"utf-X"), Some(b"yo"))))
+        .write_event(Decl(BytesDecl::new("1.2", Some("utf-X"), Some("yo"))))
         .expect("writing xml decl should succeed");
 
     let result = writer.into_inner();
@@ -355,7 +355,7 @@ fn test_new_xml_decl_full() {
 fn test_new_xml_decl_standalone() {
     let mut writer = Writer::new(Vec::new());
     writer
-        .write_event(Decl(BytesDecl::new(b"1.2", None, Some(b"yo"))))
+        .write_event(Decl(BytesDecl::new("1.2", None, Some("yo"))))
         .expect("writing xml decl should succeed");
 
     let result = writer.into_inner();
@@ -370,7 +370,7 @@ fn test_new_xml_decl_standalone() {
 fn test_new_xml_decl_encoding() {
     let mut writer = Writer::new(Vec::new());
     writer
-        .write_event(Decl(BytesDecl::new(b"1.2", Some(b"utf-X"), None)))
+        .write_event(Decl(BytesDecl::new("1.2", Some("utf-X"), None)))
         .expect("writing xml decl should succeed");
 
     let result = writer.into_inner();
@@ -385,7 +385,7 @@ fn test_new_xml_decl_encoding() {
 fn test_new_xml_decl_version() {
     let mut writer = Writer::new(Vec::new());
     writer
-        .write_event(Decl(BytesDecl::new(b"1.2", None, None)))
+        .write_event(Decl(BytesDecl::new("1.2", None, None)))
         .expect("writing xml decl should succeed");
 
     let result = writer.into_inner();
@@ -403,7 +403,7 @@ fn test_new_xml_decl_empty() {
     // An empty version should arguably be an error, but we don't expect anyone to actually supply
     // an empty version.
     writer
-        .write_event(Decl(BytesDecl::new(b"", Some(b""), Some(b""))))
+        .write_event(Decl(BytesDecl::new("", Some(""), Some(""))))
         .expect("writing xml decl should succeed");
 
     let result = writer.into_inner();

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -578,38 +578,6 @@ fn test_read_write_roundtrip() -> Result<()> {
 }
 
 #[test]
-fn test_read_write_roundtrip_escape() -> Result<()> {
-    let input = r#"
-        <?xml version="1.0" encoding="UTF-8"?>
-        <section ns:label="header">
-            <section ns:label="empty element section" />
-            <section ns:label="start/end section"></section>
-            <section ns:label="with text">data &lt;escaped&gt;</section>
-            </section>
-    "#;
-
-    let mut reader = Reader::from_str(input);
-    reader.trim_text(false).expand_empty_elements(false);
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
-    loop {
-        match reader.read_event()? {
-            Eof => break,
-            Text(e) => {
-                let t = e.escape();
-                assert!(writer
-                    .write_event(Text(BytesText::from_escaped(t.to_vec())))
-                    .is_ok());
-            }
-            e => assert!(writer.write_event(e).is_ok()),
-        }
-    }
-
-    let result = writer.into_inner().into_inner();
-    assert_eq!(String::from_utf8(result).unwrap(), input.to_string());
-    Ok(())
-}
-
-#[test]
 fn test_read_write_roundtrip_escape_text() -> Result<()> {
     let input = r#"
         <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -506,7 +506,7 @@ fn test_escaped_content() {
                 "content unexpected: expecting '&lt;test&gt;', got '{:?}'",
                 from_utf8(&*e)
             );
-            match e.decode_and_unescape(&r) {
+            match e.unescape() {
                 Ok(c) => assert_eq!(c, "<test>"),
                 Err(e) => panic!(
                     "cannot escape content at position {}: {:?}",
@@ -595,7 +595,7 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
         match reader.read_event()? {
             Eof => break,
             Text(e) => {
-                let t = e.decode_and_unescape(&reader).unwrap();
+                let t = e.unescape().unwrap();
                 assert!(writer
                     .write_event(Text(BytesText::from_plain_str(&t)))
                     .is_ok());
@@ -737,7 +737,7 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event() {
-                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal().unwrap()),
                 Ok(Eof) => break,
                 _ => (),
             }
@@ -760,7 +760,7 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event() {
-                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal().unwrap()),
                 Ok(Eof) => break,
                 _ => (),
             }
@@ -778,7 +778,7 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event() {
-                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal().unwrap()),
                 Ok(Eof) => break,
                 _ => (),
             }
@@ -798,7 +798,7 @@ mod decode_with_bom_removal {
 
         loop {
             match reader.read_event() {
-                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal(reader.decoder()).unwrap()),
+                Ok(StartText(e)) => txt.push(e.decode_with_bom_removal().unwrap()),
                 Ok(Eof) => break,
                 _ => (),
             }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -319,12 +319,12 @@ fn test_write_attrs() -> Result<()> {
             Start(elem) => {
                 let mut attrs = elem.attributes().collect::<AttrResult<Vec<_>>>()?;
                 attrs.extend_from_slice(&[("a", "b").into(), ("c", "d").into()]);
-                let mut elem = BytesStart::owned(b"copy".to_vec(), 4);
+                let mut elem = BytesStart::owned_name("copy");
                 elem.extend_attributes(attrs);
                 elem.push_attribute(("x", "y\"z"));
                 Start(elem)
             }
-            End(_) => End(BytesEnd::borrowed(b"copy")),
+            End(_) => End(BytesEnd::borrowed("copy")),
             e => e,
         };
         assert!(writer.write_event(event).is_ok());

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -416,7 +416,7 @@ fn test_bytes(input: &[u8], output: &[u8], trim: bool) {
             Ok((_, Event::CData(e))) => format!("CData({})", decoder.decode(&e).unwrap()),
             Ok((_, Event::Text(e))) => match unescape(&decoder.decode(&e).unwrap()) {
                 Ok(c) => format!("Characters({})", &c),
-                Err(err) => format!("FailedUnescape({:?}; {})", e.escape(), err),
+                Err(err) => format!("FailedUnescape({:?}; {})", e.as_ref(), err),
             },
             Ok((_, Event::Eof)) => format!("EndDocument"),
             Err(e) => format!("Error: {}", e),


### PR DESCRIPTION
This PR is extended version of #424. It changes all [events'](https://docs.rs/quick-xml/latest/quick_xml/events/index.html#structs) constructors to accept `&str` / `String` and removes all public constructors that accepts byte arrays. Internally these constructors are still used, so all tests still passed. On now we have our hands untied in changing the internal representation of events (well, almost, `BytesStart::set_name` still accepts `&[u8]`).

I did not include name changes in this PR, because I want to make more radical renames instead of just removing `_str` suffix. I'll made corresponding PR tomorrow.