### PR TITLE
Show required features in the docs on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,11 @@ serialize = ["serde"]
 escape-html = []
 
 [package.metadata.docs.rs]
+# document all features
 all-features = true
+# defines the configuration attribute `docs_rs` to enable feature requirements
+# See https://stackoverflow.com/questions/61417452
+rustdoc-args = ["--cfg", "docs_rs"]
 
 [[test]]
 name = "serde_attrs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
+// Enable feature requirements in the docs from 1.57
+// See https://stackoverflow.com/questions/61417452
+#![cfg_attr(docs_rs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "serialize")]
 pub mod de;


### PR DESCRIPTION
Currently, this is nightly-only feature.

See https://stackoverflow.com/questions/61417452