### PR TITLE
Remove excessive serde tests and fix a bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -58,6 +58,7 @@
 - [#421]: Fixed unknown bug in serde deserialization of externally tagged enums
   when an enum variant represented as a `Text` event (i.e. `<xml>tag</xml>`)
   and a document encoding is not an UTF-8
+- [#434]: Fixed incorrect error generated in some cases by serde deserializer
 
 ### Misc Changes
 
@@ -158,6 +159,7 @@
 - [#363]: Add tests for `Reader::read_event_impl` to ensure that proper events generated for corresponding inputs
 - [#407]: Improved benchmark suite to cover whole-document parsing, escaping and unescaping text
 - [#418]: Parameterized macrobenchmarks and comparative benchmarks, added throughput measurements via criterion
+- [#434]: Added more tests for serde deserialier
 
 [#8]: https://github.com/Mingun/fast-xml/pull/8
 [#9]: https://github.com/Mingun/fast-xml/pull/9
@@ -178,6 +180,7 @@
 [#418]: https://github.com/tafia/quick-xml/pull/418
 [#421]: https://github.com/tafia/quick-xml/pull/421
 [#423]: https://github.com/tafia/quick-xml/pull/423
+[#434]: https://github.com/tafia/quick-xml/pull/434
 [#437]: https://github.com/tafia/quick-xml/pull/437
 
 ## 0.23.0 -- 2022-05-08

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -298,7 +298,13 @@ where
                     };
                     key.map(Some)
                 }
-                _ => Ok(None),
+                // Stop iteration after reaching a closing tag
+                DeEvent::End(e) if e.name() == self.start.name() => Ok(None),
+                // This is a unmatched closing tag, so the XML is invalid
+                DeEvent::End(e) => Err(DeError::UnexpectedEnd(e.name().as_ref().to_owned())),
+                // We cannot get `Eof` legally, because we always inside of the
+                // opened tag `self.start`
+                DeEvent::Eof => Err(DeError::UnexpectedEof),
             }
         }
     }

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -110,48 +110,6 @@ fn nested_collection() {
     );
 }
 
-#[test]
-fn collection_of_enums() {
-    #[derive(Debug, Deserialize, PartialEq)]
-    enum MyEnum {
-        A(String),
-        B { name: String, flag: bool },
-        C,
-    }
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct MyEnums {
-        // TODO: This should be #[serde(flatten)], but right now serde don't support flattening of sequences
-        // See https://github.com/serde-rs/serde/issues/1905
-        #[serde(rename = "$value")]
-        items: Vec<MyEnum>,
-    }
-
-    let s = r#"
-    <enums>
-        <A>test</A>
-        <B name="hello" flag="t" />
-        <C />
-    </enums>
-    "#;
-
-    let project: MyEnums = from_str(s).unwrap();
-
-    assert_eq!(
-        project,
-        MyEnums {
-            items: vec![
-                MyEnum::A("test".to_string()),
-                MyEnum::B {
-                    name: "hello".to_string(),
-                    flag: true,
-                },
-                MyEnum::C,
-            ],
-        }
-    );
-}
-
 /// Test for https://github.com/tafia/quick-xml/issues/231
 #[test]
 fn implicit_value() {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -73,43 +73,6 @@ fn multiple_roots_attributes() {
     );
 }
 
-#[test]
-fn nested_collection() {
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct Project {
-        name: String,
-
-        #[serde(rename = "item", default)]
-        items: Vec<Item>,
-    }
-
-    let project: Project = from_str(
-        r#"
-        <project name="my_project">
-            <item name="hello1" source="world1.rs" />
-            <item name="hello2" source="world2.rs" />
-        </project>
-        "#,
-    )
-    .unwrap();
-    assert_eq!(
-        project,
-        Project {
-            name: "my_project".to_string(),
-            items: vec![
-                Item {
-                    name: "hello1".to_string(),
-                    source: "world1.rs".to_string(),
-                },
-                Item {
-                    name: "hello2".to_string(),
-                    source: "world2.rs".to_string(),
-                },
-            ],
-        }
-    );
-}
-
 /// Test for https://github.com/tafia/quick-xml/issues/231
 #[test]
 fn implicit_value() {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -3922,6 +3922,12 @@ mod flatten_struct {
 mod enum_ {
     use super::*;
 
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Nested {
+        //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
+        float: String,
+    }
+
     mod externally_tagged {
         use super::*;
         use pretty_assertions::assert_eq;
@@ -3945,12 +3951,6 @@ mod enum_ {
                 nested: Nested,
                 string: String,
             },
-        }
-
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct Nested {
-            //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
-            float: String,
         }
 
         /// Workaround for serde bug https://github.com/serde-rs/serde/issues/1904
@@ -4118,12 +4118,6 @@ mod enum_ {
         #[derive(Debug, Deserialize, PartialEq)]
         struct NewtypeContent {
             value: bool,
-        }
-
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct Nested {
-            //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
-            float: String,
         }
 
         mod unit {
@@ -4304,12 +4298,6 @@ mod enum_ {
                 nested: Nested,
                 string: String,
             },
-        }
-
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct Nested {
-            //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
-            float: String,
         }
 
         /// Workaround for serde bug https://github.com/serde-rs/serde/issues/1904
@@ -4522,12 +4510,6 @@ mod enum_ {
                 // will have no difference from `Struct` variant
                 string2: String,
             },
-        }
-
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct Nested {
-            //TODO: change to f64 after fixing https://github.com/serde-rs/serde/issues/1183
-            float: String,
         }
 
         /// Workaround for serde bug https://github.com/serde-rs/serde/issues/1904

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -3480,6 +3480,18 @@ macro_rules! maplike_errors {
         mod non_closed {
             use super::*;
 
+            /// For struct we expect that error about not closed tag appears
+            /// earlier than error about missing fields
+            #[test]
+            fn missing_field() {
+                let data = from_str::<$type>(r#"<root>"#);
+
+                match data {
+                    Err(DeError::UnexpectedEof) => (),
+                    _ => panic!("Expected `UnexpectedEof`, found {:?}", data),
+                }
+            }
+
             #[test]
             fn attributes() {
                 let data = from_str::<$type>(r#"<root float="42" string="answer">"#);
@@ -3514,6 +3526,18 @@ macro_rules! maplike_errors {
         mod mismatched_end {
             use super::*;
             use quick_xml::Error::EndEventMismatch;
+
+            /// For struct we expect that error about mismatched tag appears
+            /// earlier than error about missing fields
+            #[test]
+            fn missing_field() {
+                let data = from_str::<$type>(r#"<root></mismatched>"#);
+
+                match data {
+                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => (),
+                    _ => panic!("Expected `InvalidXml(EndEventMismatch)`, found {:?}", data),
+                }
+            }
 
             #[test]
             fn attributes() {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -43,36 +43,6 @@ fn string_borrow() {
     assert_eq!(borrowed_item.text, "Hello world");
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
-struct Item {
-    name: String,
-    source: String,
-}
-
-#[test]
-fn multiple_roots_attributes() {
-    let item: Vec<Item> = from_str(
-        r#"
-            <item name="hello1" source="world1.rs" />
-            <item name="hello2" source="world2.rs" />
-        "#,
-    )
-    .unwrap();
-    assert_eq!(
-        item,
-        vec![
-            Item {
-                name: "hello1".to_string(),
-                source: "world1.rs".to_string(),
-            },
-            Item {
-                name: "hello2".to_string(),
-                source: "world2.rs".to_string(),
-            },
-        ]
-    );
-}
-
 /// Test for https://github.com/tafia/quick-xml/issues/231
 #[test]
 fn implicit_value() {


### PR DESCRIPTION
This PR removes tests which have better alternatives in `seq` submodule since #387.

Also, while working on namespaces support, I accidently found a bug in a deserializer, so I've added a test and a fix for it.