### PR TITLE
Some minor changes that prepare ground for incoming async support

### DIFF
--- a/src/de/escape.rs
+++ b/src/de/escape.rs
@@ -85,7 +85,7 @@ impl<'de, 'a> serde::Deserializer<'de> for EscapedDeserializer<'a> {
         ))
     }
 
-    /// Forwards deserialization to the [`Self::deserialize_bytes`]
+    /// Forwards deserialization to the [`deserialize_bytes`](#method.deserialize_bytes)
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -516,7 +516,7 @@ where
     forward!(deserialize_any);
     forward!(deserialize_ignored_any);
 
-    /// Tuple representation is the same as [sequences](Self::deserialize_seq).
+    /// Tuple representation is the same as [sequences](#method.deserialize_seq).
     fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
     where
         V: Visitor<'de>,
@@ -524,7 +524,7 @@ where
         self.deserialize_seq(visitor)
     }
 
-    /// Named tuple representation is the same as [unnamed tuples](Self::deserialize_tuple).
+    /// Named tuple representation is the same as [unnamed tuples](#method.deserialize_tuple).
     fn deserialize_tuple_struct<V>(
         self,
         _name: &'static str,
@@ -680,7 +680,7 @@ where
     forward!(deserialize_any);
     forward!(deserialize_ignored_any);
 
-    /// Representation of tuples the same as [sequences](Self::deserialize_seq).
+    /// Representation of tuples the same as [sequences](#method.deserialize_seq).
     fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
     where
         V: Visitor<'de>,
@@ -688,7 +688,7 @@ where
         self.deserialize_seq(visitor)
     }
 
-    /// Representation of named tuples the same as [unnamed tuples](Self::deserialize_tuple).
+    /// Representation of named tuples the same as [unnamed tuples](#method.deserialize_tuple).
     fn deserialize_tuple_struct<V>(
         self,
         _name: &'static str,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -952,7 +952,7 @@ impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
 /// XML input source that reads from a slice of bytes and can borrow from it.
 ///
 /// You cannot create it, it is created automatically when you call
-/// [`Deserializer::from_str`] or [`Deserializer::from_slice`]
+/// [`Deserializer::from_str`].
 pub struct SliceReader<'de> {
     reader: Reader<&'de [u8]>,
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -5,7 +5,9 @@ use std::borrow::Cow;
 #[cfg(feature = "encoding")]
 use encoding_rs::{Encoding, UTF_16BE, UTF_16LE, UTF_8};
 
-use crate::{Error, Result};
+#[cfg(feature = "encoding")]
+use crate::Error;
+use crate::Result;
 
 /// Decoder of byte slices into strings.
 ///

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -429,6 +429,11 @@ impl<'b, R: BufRead> XmlSource<'b, &'b mut Vec<u8>> for R {
 
 #[cfg(test)]
 mod test {
+    use crate::reader::test::check;
+    use crate::reader::XmlSource;
+
+    check!(&mut Vec::new());
+
     #[cfg(feature = "encoding")]
     mod encoding {
         use crate::events::Event;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -935,7 +935,7 @@ mod test {
     macro_rules! check {
         ($buf:expr) => {
             mod read_bytes_until {
-                use crate::reader::XmlSource;
+                use super::*;
                 // Use Bytes for printing bytes as strings for ASCII range
                 use crate::utils::Bytes;
                 use pretty_assertions::assert_eq;
@@ -1039,10 +1039,13 @@ mod test {
             }
 
             mod read_bang_element {
+                use super::*;
+
                 /// Checks that reading CDATA content works correctly
                 mod cdata {
+                    use super::*;
                     use crate::errors::Error;
-                    use crate::reader::{BangType, XmlSource};
+                    use crate::reader::BangType;
                     use crate::utils::Bytes;
                     use pretty_assertions::assert_eq;
 
@@ -1143,8 +1146,9 @@ mod test {
                 ///
                 /// [specification]: https://www.w3.org/TR/xml11/#dt-comment
                 mod comment {
+                    use super::*;
                     use crate::errors::Error;
-                    use crate::reader::{BangType, XmlSource};
+                    use crate::reader::BangType;
                     use crate::utils::Bytes;
                     use pretty_assertions::assert_eq;
 
@@ -1276,9 +1280,12 @@ mod test {
 
                 /// Checks that reading DOCTYPE definition works correctly
                 mod doctype {
+                    use super::*;
+
                     mod uppercase {
+                        use super::*;
                         use crate::errors::Error;
-                        use crate::reader::{BangType, XmlSource};
+                        use crate::reader::BangType;
                         use crate::utils::Bytes;
                         use pretty_assertions::assert_eq;
 
@@ -1355,8 +1362,9 @@ mod test {
                     }
 
                     mod lowercase {
+                        use super::*;
                         use crate::errors::Error;
-                        use crate::reader::{BangType, XmlSource};
+                        use crate::reader::BangType;
                         use crate::utils::Bytes;
                         use pretty_assertions::assert_eq;
 
@@ -1435,7 +1443,7 @@ mod test {
             }
 
             mod read_element {
-                use crate::reader::XmlSource;
+                use super::*;
                 use crate::utils::Bytes;
                 use pretty_assertions::assert_eq;
 
@@ -1452,7 +1460,7 @@ mod test {
                 }
 
                 mod open {
-                    use crate::reader::XmlSource;
+                    use super::*;
                     use crate::utils::Bytes;
                     use pretty_assertions::assert_eq;
 
@@ -1528,7 +1536,7 @@ mod test {
                 }
 
                 mod self_closed {
-                    use crate::reader::XmlSource;
+                    use super::*;
                     use crate::utils::Bytes;
                     use pretty_assertions::assert_eq;
 
@@ -1798,11 +1806,15 @@ mod test {
 
     /// Tests for reader that generates events that borrow from the provided buffer
     mod buffered {
+        use crate::reader::XmlSource;
+
         check!(&mut Vec::new());
     }
 
     /// Tests for reader that generates events that borrow from the input
     mod borrowed {
+        use crate::reader::XmlSource;
+
         check!(());
     }
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -451,7 +451,7 @@ impl<R> Reader<R> {
     }
 }
 
-/// Private methods
+/// Private sync reading methods
 impl<R> Reader<R> {
     /// Read text into the given buffer, and return an event that borrows from
     /// either that buffer or from the input itself, based on the type of the
@@ -545,7 +545,10 @@ impl<R> Reader<R> {
             Err(e) => Err(e),
         }
     }
+}
 
+/// Parse methods, independent from a way of reading data
+impl<R> Reader<R> {
     /// Trims whitespaces from `bytes`, if required, and returns a [`StartText`]
     /// or a [`Text`] event. When [`StartText`] is returned, the method can change
     /// the encoding of the reader, detecting it from the beginning of the stream.
@@ -693,15 +696,6 @@ impl<R> Reader<R> {
         }
     }
 
-    #[inline]
-    fn close_expanded_empty(&mut self) -> Result<Event<'static>> {
-        self.tag_state = TagState::Closed;
-        let name = self
-            .opened_buffer
-            .split_off(self.opened_starts.pop().unwrap());
-        Ok(Event::End(BytesEnd::wrap(name.into())))
-    }
-
     /// reads `BytesElement` starting with any character except `/`, `!` or ``?`
     /// return `Start` or `Empty` event
     fn read_start<'b>(&mut self, buf: &'b [u8]) -> Result<Event<'b>> {
@@ -725,6 +719,15 @@ impl<R> Reader<R> {
             }
             Ok(Event::Start(BytesStart::wrap(buf, name_end)))
         }
+    }
+
+    #[inline]
+    fn close_expanded_empty(&mut self) -> Result<Event<'static>> {
+        self.tag_state = TagState::Closed;
+        let name = self
+            .opened_buffer
+            .split_off(self.opened_starts.pop().unwrap());
+        Ok(Event::End(BytesEnd::wrap(name.into())))
     }
 }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -932,6 +932,7 @@ pub(crate) fn is_whitespace(b: u8) -> bool {
 
 #[cfg(test)]
 mod test {
+    /// Checks the internal implementation of the various reader methods
     macro_rules! check {
         ($buf:expr) => {
             mod read_bytes_until {
@@ -1804,17 +1805,8 @@ mod test {
         };
     }
 
-    /// Tests for reader that generates events that borrow from the provided buffer
-    mod buffered {
-        use crate::reader::XmlSource;
-
-        check!(&mut Vec::new());
-    }
-
-    /// Tests for reader that generates events that borrow from the input
-    mod borrowed {
-        use crate::reader::XmlSource;
-
-        check!(());
-    }
+    // Export a macro for the child modules:
+    // - buffered_reader
+    // - slice_reader
+    pub(super) use check;
 }

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -509,9 +509,7 @@ impl<R: BufRead> NsReader<R> {
 impl NsReader<BufReader<File>> {
     /// Creates an XML reader from a file path.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        Ok(Self::from_reader(reader))
+        Ok(Self::new(Reader::from_file(path)?))
     }
 }
 

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -232,6 +232,10 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
 
 #[cfg(test)]
 mod test {
+    use crate::reader::test::check;
+    use crate::reader::XmlSource;
+
+    check!(());
 
     #[cfg(feature = "encoding")]
     mod encoding {


### PR DESCRIPTION
- Minor fixes in the documentation (including internal, `cargo doc --all-features --document-private-items`)
- Remove dependency from sync-only trait from `check!` macro
- Prepare code to use in async implementation with minimal duplication
- Some aesthetic changes (order of functions, impl blocks, etc.)