### PR TITLE
Use local name when choosing enum variant based on element name

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,7 @@
   when an enum variant represented as a `Text` event (i.e. `<xml>tag</xml>`)
   and a document encoding is not an UTF-8
 - [#434]: Fixed incorrect error generated in some cases by serde deserializer
+- [#445]: Use local name without namespace prefix when selecting enum variants based on element names
 
 ### Misc Changes
 

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -39,7 +39,7 @@ where
             // Escape sequences does not processed inside CDATA section
             DeEvent::CData(t) => EscapedDeserializer::new(Cow::Borrowed(t), decoder, false),
             DeEvent::Start(e) => {
-                EscapedDeserializer::new(Cow::Borrowed(e.name().into_inner()), decoder, false)
+                EscapedDeserializer::new(Cow::Borrowed(e.local_name().into_inner()), decoder, false)
             }
             _ => {
                 return Err(DeError::Unsupported(

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -3732,6 +3732,22 @@ mod struct_ {
         );
     }
 
+    #[test]
+    fn namespaces() {
+        let data: Struct = from_str(
+            // Comment for prevent unnecessary formatting - we use the same style in all tests
+            r#"<root xmlns:namespace="http://name.space"><namespace:float>42</namespace:float><string>answer</string></root>"#,
+        )
+        .unwrap();
+        assert_eq!(
+            data,
+            Struct {
+                float: 42.0,
+                string: "answer".into()
+            }
+        );
+    }
+
     maplike_errors!(Struct);
 }
 
@@ -3917,6 +3933,22 @@ mod enum_ {
                 let data: Node = from_str(
                     // Comment for prevent unnecessary formatting - we use the same style in all tests
                     r#"<Struct float="42" string="answer"/>"#,
+                )
+                .unwrap();
+                assert_eq!(
+                    data,
+                    Node::Struct {
+                        float: 42.0,
+                        string: "answer".into()
+                    }
+                );
+            }
+
+            #[test]
+            fn namespaces() {
+                let data: Node = from_str(
+                    // Comment for prevent unnecessary formatting - we use the same style in all tests
+                    r#"<namespace:Struct xmlns:namespace="http://name.space"><float>42</float><string>answer</string></namespace:Struct>"#,
                 )
                 .unwrap();
                 assert_eq!(


### PR DESCRIPTION
This is consistent to how struct fields are identified in `MapAccess::next_key_seed` as demonstrated by the two test cases.