### PR TITLE
Async support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,14 @@ documentation = "https://docs.rs/quick-xml"
 repository = "https://github.com/tafia/quick-xml"
 
 keywords = ["xml", "serde", "parser", "writer", "html"]
-categories = ["encoding", "parsing", "parser-implementations"]
+categories = ["asynchronous", "encoding", "parsing", "parser-implementations"]
 license = "MIT"
 
 [dependencies]
 document-features = { version = "0.2", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }
+tokio = { version = "1.20", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.5"
 
 [dev-dependencies]
@@ -23,6 +24,8 @@ pretty_assertions = "1.2"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde-value = "0.7"
+tokio = { version = "1.20", default-features = false, features = ["macros", "rt"] }
+tokio-test = "0.4"
 
 [lib]
 bench = false
@@ -37,6 +40,13 @@ harness = false
 
 [features]
 default = []
+
+## Enables support for asynchronous reading from `tokio`'s IO-Traits by enabling
+## [reading events] from types implementing [`tokio::io::AsyncBufRead`].
+##
+## [reading events]: crate::reader::Reader::read_event_into_async
+async-tokio = ["tokio"]
+
 ## Enables support of non-UTF-8 encoded documents. Encoding will be inferred from
 ## the XML declaration if it will be found, otherwise UTF-8 is assumed.
 ##
@@ -123,3 +133,7 @@ required-features = ["serialize"]
 [[test]]
 name = "serde-migrated"
 required-features = ["serialize"]
+
+[[test]]
+name = "async-tokio"
+required-features = ["async-tokio"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@
   |`attribute_namespace`   |`resolve_attribute`
 - [#439]: Added utilities `detect_encoding()`, `decode()`, and `decode_with_bom_removal()`
   under the `quick-xml::encoding` namespace.
+- [#450]: Added support of asynchronous [tokio](https://tokio.rs/) readers
 
 
 ### Bug Fixes
@@ -218,6 +219,7 @@
 [#439]: https://github.com/tafia/quick-xml/pull/439
 [#440]: https://github.com/tafia/quick-xml/pull/440
 [#443]: https://github.com/tafia/quick-xml/pull/443
+[#450]: https://github.com/tafia/quick-xml/pull/450
 
 
 ## 0.23.0 -- 2022-05-08

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -1,0 +1,388 @@
+//! This is an implementation of [`Reader`] for reading from a [`AsyncBufRead`]
+//! as underlying byte stream. This reader fully implements async/await so reading
+//! can use non-blocking I/O.
+
+use std::future::Future;
+use std::pin::Pin;
+use tokio::io::{self, AsyncBufRead, AsyncBufReadExt};
+
+use crate::events::Event;
+use crate::name::{QName, ResolveResult};
+use crate::reader::buffered_reader::impl_buffered_source;
+use crate::reader::{is_whitespace, BangType, NsReader, ParseState, ReadElementState, Reader};
+use crate::{Error, Result};
+
+/// A struct for read XML asynchronously from an [`AsyncBufRead`].
+///
+/// Having own struct allows us to implement anything without risk of name conflicts
+/// and does not suffer from the impossibility of having `async` in traits.
+struct TokioAdapter<'a, R>(&'a mut R);
+
+impl<'a, R: AsyncBufRead + Unpin> TokioAdapter<'a, R> {
+    impl_buffered_source!('b, 0, async, await);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl<R: AsyncBufRead + Unpin> Reader<R> {
+    /// An asynchronous version of [`read_event_into()`]. Reads the next event into
+    /// given buffer.
+    ///
+    /// > This function should be defined as
+    /// > ```ignore
+    /// > pub async fn read_event_into_async<'b>(
+    /// >     &mut self,
+    /// >     buf: &'b mut Vec<u8>
+    /// > ) -> Result<Event<'b>>;
+    /// > ```
+    /// > but Rust does not allow to write that for recursive asynchronous function
+    ///
+    /// This is the main entry point for reading XML `Event`s when using an async reader.
+    ///
+    /// See the documentation of [`read_event_into()`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::events::Event;
+    /// use quick_xml::Reader;
+    ///
+    /// // This explicitly uses `from_reader("...".as_bytes())` to use a buffered
+    /// // reader instead of relying on the zero-copy optimizations for reading
+    /// // from byte slices, which is provides the sync interface anyway.
+    /// let mut reader = Reader::from_reader(r#"
+    ///     <tag1 att1 = "test">
+    ///        <tag2><!--Test comment-->Test</tag2>
+    ///        <tag2>Test 2</tag2>
+    ///     </tag1>
+    /// "#.as_bytes());
+    /// reader.trim_text(true);
+    ///
+    /// let mut count = 0;
+    /// let mut buf = Vec::new();
+    /// let mut txt = Vec::new();
+    /// loop {
+    ///     match reader.read_event_into_async(&mut buf).await {
+    ///         Ok(Event::Start(_)) => count += 1,
+    ///         Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
+    ///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+    ///         Ok(Event::Eof) => break,
+    ///         _ => (),
+    ///     }
+    ///     buf.clear();
+    /// }
+    /// assert_eq!(count, 3);
+    /// assert_eq!(txt, vec!["Test".to_string(), "Test 2".to_string()]);
+    /// # }) // tokio_test::block_on
+    /// ```
+    ///
+    /// [`read_event_into()`]: Reader::read_event_into
+    pub fn read_event_into_async<'reader, 'b: 'reader>(
+        &'reader mut self,
+        buf: &'b mut Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<Event<'b>>> + 'reader>> {
+        Box::pin(async move {
+            read_event_impl!(self, buf, read_until_open_async, read_until_close_async, await)
+        })
+    }
+
+    /// An asynchronous version of [`read_to_end_into()`].
+    /// Reads asynchronously until end element is found using provided buffer as
+    /// intermediate storage for events content. This function is supposed to be
+    /// called after you already read a [`Start`] event.
+    ///
+    /// See the documentation of [`read_to_end_into()`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// This example shows, how you can skip XML content after you read the
+    /// start event.
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::events::{BytesStart, Event};
+    /// use quick_xml::Reader;
+    ///
+    /// let mut reader = Reader::from_reader(r#"
+    ///     <outer>
+    ///         <inner>
+    ///             <inner></inner>
+    ///             <inner/>
+    ///             <outer></outer>
+    ///             <outer/>
+    ///         </inner>
+    ///     </outer>
+    /// "#.as_bytes());
+    /// reader.trim_text(true);
+    /// let mut buf = Vec::new();
+    ///
+    /// let start = BytesStart::new("outer");
+    /// let end   = start.to_end().into_owned();
+    ///
+    /// // First, we read a start event...
+    /// assert_eq!(reader.read_event_into_async(&mut buf).await.unwrap(), Event::Start(start));
+    ///
+    /// //...then, we could skip all events to the corresponding end event.
+    /// // This call will correctly handle nested <outer> elements.
+    /// // Note, however, that this method does not handle namespaces.
+    /// reader.read_to_end_into_async(end.name(), &mut buf).await.unwrap();
+    ///
+    /// // At the end we should get an Eof event, because we ate the whole XML
+    /// assert_eq!(reader.read_event_into_async(&mut buf).await.unwrap(), Event::Eof);
+    /// # }) // tokio_test::block_on
+    /// ```
+    ///
+    /// [`read_to_end_into()`]: Self::read_to_end_into
+    /// [`Start`]: Event::Start
+    pub async fn read_to_end_into_async<'n>(
+        &mut self,
+        // We should name that lifetime due to https://github.com/rust-lang/rust/issues/63033`
+        end: QName<'n>,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        read_to_end!(self, end, buf, read_event_into_async, { buf.clear(); }, await)
+    }
+
+    /// Read until '<' is found and moves reader to an `Opened` state.
+    ///
+    /// Return a `StartText` event if `first` is `true` and a `Text` event otherwise
+    async fn read_until_open_async<'b>(
+        &mut self,
+        buf: &'b mut Vec<u8>,
+        first: bool,
+    ) -> Result<Event<'b>> {
+        read_until_open!(self, buf, first, TokioAdapter(&mut self.reader), read_event_into_async, await)
+    }
+
+    /// Private function to read until `>` is found. This function expects that
+    /// it was called just after encounter a `<` symbol.
+    async fn read_until_close_async<'b>(&mut self, buf: &'b mut Vec<u8>) -> Result<Event<'b>> {
+        read_until_close!(self, buf, TokioAdapter(&mut self.reader), await)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl<R: AsyncBufRead + Unpin> NsReader<R> {
+    /// An asynchronous version of [`read_event_into()`]. Reads the next event into
+    /// given buffer.
+    ///
+    /// This method manages namespaces but doesn't resolve them automatically.
+    /// You should call [`resolve_element()`] if you want to get a namespace.
+    ///
+    /// You also can use [`read_resolved_event_into_async()`] instead if you want
+    /// to resolve namespace as soon as you get an event.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::events::Event;
+    /// use quick_xml::name::{Namespace, ResolveResult::*};
+    /// use quick_xml::NsReader;
+    ///
+    /// let mut reader = NsReader::from_reader(r#"
+    ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
+    ///        <y:tag2><!--Test comment-->Test</y:tag2>
+    ///        <y:tag2>Test 2</y:tag2>
+    ///     </x:tag1>
+    /// "#.as_bytes());
+    /// reader.trim_text(true);
+    ///
+    /// let mut count = 0;
+    /// let mut buf = Vec::new();
+    /// let mut txt = Vec::new();
+    /// loop {
+    ///     match reader.read_event_into_async(&mut buf).await.unwrap() {
+    ///         Event::Start(e) => {
+    ///             count += 1;
+    ///             let (ns, local) = reader.resolve_element(e.name());
+    ///             match local.as_ref() {
+    ///                 b"tag1" => assert_eq!(ns, Bound(Namespace(b"www.xxxx"))),
+    ///                 b"tag2" => assert_eq!(ns, Bound(Namespace(b"www.yyyy"))),
+    ///                 _ => unreachable!(),
+    ///             }
+    ///         }
+    ///         Event::Text(e) => {
+    ///             txt.push(e.unescape().unwrap().into_owned())
+    ///         }
+    ///         Event::Eof => break,
+    ///         _ => (),
+    ///     }
+    ///     buf.clear();
+    /// }
+    /// assert_eq!(count, 3);
+    /// assert_eq!(txt, vec!["Test".to_string(), "Test 2".to_string()]);
+    /// # }) // tokio_test::block_on
+    /// ```
+    ///
+    /// [`read_event_into()`]: NsReader::read_event_into
+    /// [`resolve_element()`]: Self::resolve_element
+    /// [`read_resolved_event_into_async()`]: Self::read_resolved_event_into_async
+    pub async fn read_event_into_async<'b>(&mut self, buf: &'b mut Vec<u8>) -> Result<Event<'b>> {
+        self.pop();
+        let event = self.reader.read_event_into_async(buf).await;
+        self.process_event(event)
+    }
+
+    /// An asynchronous version of [`read_to_end_into()`].
+    /// Reads asynchronously until end element is found using provided buffer as
+    /// intermediate storage for events content. This function is supposed to be
+    /// called after you already read a [`Start`] event.
+    ///
+    /// See the documentation of [`read_to_end_into()`] for more information.
+    ///
+    /// # Examples
+    ///
+    /// This example shows, how you can skip XML content after you read the
+    /// start event.
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::name::{Namespace, ResolveResult};
+    /// use quick_xml::events::{BytesStart, Event};
+    /// use quick_xml::NsReader;
+    ///
+    /// let mut reader = NsReader::from_reader(r#"
+    ///     <outer xmlns="namespace 1">
+    ///         <inner xmlns="namespace 2">
+    ///             <outer></outer>
+    ///         </inner>
+    ///         <inner>
+    ///             <inner></inner>
+    ///             <inner/>
+    ///             <outer></outer>
+    ///             <p:outer xmlns:p="ns"></p:outer>
+    ///             <outer/>
+    ///         </inner>
+    ///     </outer>
+    /// "#.as_bytes());
+    /// reader.trim_text(true);
+    /// let mut buf = Vec::new();
+    ///
+    /// let ns = Namespace(b"namespace 1");
+    /// let start = BytesStart::from_content(r#"outer xmlns="namespace 1""#, 5);
+    /// let end   = start.to_end().into_owned();
+    ///
+    /// // First, we read a start event...
+    /// assert_eq!(
+    ///     reader.read_resolved_event_into_async(&mut buf).await.unwrap(),
+    ///     (ResolveResult::Bound(ns), Event::Start(start))
+    /// );
+    ///
+    /// //...then, we could skip all events to the corresponding end event.
+    /// // This call will correctly handle nested <outer> elements.
+    /// // Note, however, that this method does not handle namespaces.
+    /// reader.read_to_end_into_async(end.name(), &mut buf).await.unwrap();
+    ///
+    /// // At the end we should get an Eof event, because we ate the whole XML
+    /// assert_eq!(
+    ///     reader.read_resolved_event_into_async(&mut buf).await.unwrap(),
+    ///     (ResolveResult::Unbound, Event::Eof)
+    /// );
+    /// # }) // tokio_test::block_on
+    /// ```
+    ///
+    /// [`read_to_end_into()`]: Self::read_to_end_into
+    /// [`Start`]: Event::Start
+    pub async fn read_to_end_into_async<'n>(
+        &mut self,
+        // We should name that lifetime due to https://github.com/rust-lang/rust/issues/63033`
+        end: QName<'n>,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        // According to the https://www.w3.org/TR/xml11/#dt-etag, end name should
+        // match literally the start name. See `Reader::check_end_names` documentation
+        self.reader.read_to_end_into_async(end, buf).await
+    }
+
+    /// An asynchronous version of [`read_resolved_event_into()`]. Reads the next
+    /// event into given buffer asynchronously and resolves its namespace (if applicable).
+    ///
+    /// Namespace is resolved only for [`Start`], [`Empty`] and [`End`] events.
+    /// For all other events the concept of namespace is not defined, so
+    /// a [`ResolveResult::Unbound`] is returned.
+    ///
+    /// If you are not interested in namespaces, you can use [`read_event_into_async()`]
+    /// which will not automatically resolve namespaces for you.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::events::Event;
+    /// use quick_xml::name::{Namespace, QName, ResolveResult::*};
+    /// use quick_xml::NsReader;
+    ///
+    /// let mut reader = NsReader::from_reader(r#"
+    ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
+    ///        <y:tag2><!--Test comment-->Test</y:tag2>
+    ///        <y:tag2>Test 2</y:tag2>
+    ///     </x:tag1>
+    /// "#.as_bytes());
+    /// reader.trim_text(true);
+    ///
+    /// let mut count = 0;
+    /// let mut buf = Vec::new();
+    /// let mut txt = Vec::new();
+    /// loop {
+    ///     match reader.read_resolved_event_into_async(&mut buf).await.unwrap() {
+    ///         (Bound(Namespace(b"www.xxxx")), Event::Start(e)) => {
+    ///             count += 1;
+    ///             assert_eq!(e.local_name(), QName(b"tag1").into());
+    ///         }
+    ///         (Bound(Namespace(b"www.yyyy")), Event::Start(e)) => {
+    ///             count += 1;
+    ///             assert_eq!(e.local_name(), QName(b"tag2").into());
+    ///         }
+    ///         (_, Event::Start(_)) => unreachable!(),
+    ///
+    ///         (_, Event::Text(e)) => {
+    ///             txt.push(e.unescape().unwrap().into_owned())
+    ///         }
+    ///         (_, Event::Eof) => break,
+    ///         _ => (),
+    ///     }
+    ///     buf.clear();
+    /// }
+    /// assert_eq!(count, 3);
+    /// assert_eq!(txt, vec!["Test".to_string(), "Test 2".to_string()]);
+    /// # }) // tokio_test::block_on
+    /// ```
+    ///
+    /// [`read_resolved_event_into()`]: NsReader::read_resolved_event_into
+    /// [`Start`]: Event::Start
+    /// [`Empty`]: Event::Empty
+    /// [`End`]: Event::End
+    /// [`read_event_into_async()`]: Self::read_event_into_async
+    pub async fn read_resolved_event_into_async<'ns, 'b>(
+        // Name 'ns lifetime, because otherwise we get an error
+        // "implicit elided lifetime not allowed here" on ResolveResult
+        &'ns mut self,
+        buf: &'b mut Vec<u8>,
+    ) -> Result<(ResolveResult<'ns>, Event<'b>)> {
+        let event = self.read_event_into_async(buf).await;
+        self.resolve_event(event)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::TokioAdapter;
+    use crate::reader::test::check;
+
+    check!(
+        #[tokio::test]
+        read_event_into_async,
+        read_until_close_async,
+        TokioAdapter,
+        &mut Vec::new(),
+        async, await
+    );
+}

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -146,26 +146,9 @@ impl<R: BufRead> Reader<R> {
     /// [`check_end_names`]: Self::check_end_names
     /// [the specification]: https://www.w3.org/TR/xml11/#dt-etag
     pub fn read_to_end_into(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<()> {
-        let mut depth = 0;
-        loop {
+        read_to_end!(self, end, buf, {
             buf.clear();
-            match self.read_event_into(buf) {
-                Err(e) => return Err(e),
-
-                Ok(Event::Start(e)) if e.name() == end => depth += 1,
-                Ok(Event::End(e)) if e.name() == end => {
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                    depth -= 1;
-                }
-                Ok(Event::Eof) => {
-                    let name = self.decoder().decode(end.as_ref());
-                    return Err(Error::UnexpectedEof(format!("</{:?}>", name)));
-                }
-                _ => (),
-            }
-        }
+        })
     }
 
     /// Reads optional text between start and end tags.

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -426,7 +426,13 @@ mod test {
         input
     }
 
-    check!(identity, &mut Vec::new());
+    check!(
+        #[test]
+        read_event_impl,
+        read_until_close,
+        identity,
+        &mut Vec::new()
+    );
 
     #[cfg(feature = "encoding")]
     mod encoding {

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -211,6 +211,9 @@ macro_rules! impl_buffered_source {
     };
 }
 
+// Make it public for use in async implementations
+pub(super) use impl_buffered_source;
+
 /// Implementation of `XmlSource` for any `BufRead` reader using a user-given
 /// `Vec<u8>` as buffer that will be borrowed by events.
 impl<'b, R: BufRead> XmlSource<'b, &'b mut Vec<u8>> for R {

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -421,7 +421,12 @@ mod test {
     use crate::reader::test::check;
     use crate::reader::XmlSource;
 
-    check!(&mut Vec::new());
+    /// Default buffer constructor just pass the byte array from the test
+    fn identity<T>(input: T) -> T {
+        input
+    }
+
+    check!(identity, &mut Vec::new());
 
     #[cfg(feature = "encoding")]
     mod encoding {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -771,7 +771,12 @@ pub(crate) fn is_whitespace(b: u8) -> bool {
 mod test {
     /// Checks the internal implementation of the various reader methods
     macro_rules! check {
-        ($buf:expr) => {
+        (
+            // constructor of the XML source on which internal functions will be called
+            $source:path,
+            // constructor of the buffer to which read data will stored
+            $buf:expr
+        ) => {
             mod read_bytes_until {
                 use super::*;
                 // Use Bytes for printing bytes as strings for ASCII range
@@ -787,7 +792,7 @@ mod test {
                     //                ^= 0
 
                     assert_eq!(
-                        input
+                        $source(&mut input)
                             .read_bytes_until(b'*', buf, &mut position)
                             .unwrap()
                             .map(Bytes),
@@ -806,7 +811,7 @@ mod test {
                     //                      ^= 6
 
                     assert_eq!(
-                        input
+                        $source(&mut input)
                             .read_bytes_until(b'*', buf, &mut position)
                             .unwrap()
                             .map(Bytes),
@@ -826,7 +831,7 @@ mod test {
                     //                 ^= 1
 
                     assert_eq!(
-                        input
+                        $source(&mut input)
                             .read_bytes_until(b'*', buf, &mut position)
                             .unwrap()
                             .map(Bytes),
@@ -846,7 +851,7 @@ mod test {
                     //                    ^= 4
 
                     assert_eq!(
-                        input
+                        $source(&mut input)
                             .read_bytes_until(b'*', buf, &mut position)
                             .unwrap()
                             .map(Bytes),
@@ -866,7 +871,7 @@ mod test {
                     //                       ^= 7
 
                     assert_eq!(
-                        input
+                        $source(&mut input)
                             .read_bytes_until(b'*', buf, &mut position)
                             .unwrap()
                             .map(Bytes),
@@ -897,7 +902,7 @@ mod test {
                         let mut input = b"![]]>other content".as_ref();
                         //                ^= 0
 
-                        match input.read_bang_element(buf, &mut position) {
+                        match $source(&mut input).read_bang_element(buf, &mut position) {
                             Err(Error::UnexpectedEof(s)) if s == "CData" => {}
                             x => assert!(
                                 false,
@@ -917,7 +922,7 @@ mod test {
                         let mut input = b"![CDATA[other content".as_ref();
                         //                ^= 0
 
-                        match input.read_bang_element(buf, &mut position) {
+                        match $source(&mut input).read_bang_element(buf, &mut position) {
                             Err(Error::UnexpectedEof(s)) if s == "CData" => {}
                             x => assert!(
                                 false,
@@ -937,7 +942,7 @@ mod test {
                         //                           ^= 11
 
                         assert_eq!(
-                            input
+                            $source(&mut input)
                                 .read_bang_element(buf, &mut position)
                                 .unwrap()
                                 .map(|(ty, data)| (ty, Bytes(data))),
@@ -957,7 +962,7 @@ mod test {
                         //                                            ^= 28
 
                         assert_eq!(
-                            input
+                            $source(&mut input)
                                 .read_bang_element(buf, &mut position)
                                 .unwrap()
                                 .map(|(ty, data)| (ty, Bytes(data))),
@@ -998,7 +1003,7 @@ mod test {
                         let mut input = b"!- -->other content".as_ref();
                         //                ^= 0
 
-                        match input.read_bang_element(buf, &mut position) {
+                        match $source(&mut input).read_bang_element(buf, &mut position) {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
                             x => assert!(
                                 false,
@@ -1016,7 +1021,7 @@ mod test {
                         let mut input = b"!->other content".as_ref();
                         //                ^= 0
 
-                        match input.read_bang_element(buf, &mut position) {
+                        match $source(&mut input).read_bang_element(buf, &mut position) {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
                             x => assert!(
                                 false,
@@ -1034,7 +1039,7 @@ mod test {
                         let mut input = b"!--other content".as_ref();
                         //                ^= 0
 
-                        match input.read_bang_element(buf, &mut position) {
+                        match $source(&mut input).read_bang_element(buf, &mut position) {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
                             x => assert!(
                                 false,
@@ -1052,7 +1057,7 @@ mod test {
                         let mut input = b"!-->other content".as_ref();
                         //                ^= 0
 
-                        match input.read_bang_element(buf, &mut position) {
+                        match $source(&mut input).read_bang_element(buf, &mut position) {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
                             x => assert!(
                                 false,
@@ -1070,7 +1075,7 @@ mod test {
                         let mut input = b"!--->other content".as_ref();
                         //                ^= 0
 
-                        match input.read_bang_element(buf, &mut position) {
+                        match $source(&mut input).read_bang_element(buf, &mut position) {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
                             x => assert!(
                                 false,
@@ -1089,7 +1094,7 @@ mod test {
                         //                      ^= 6
 
                         assert_eq!(
-                            input
+                            $source(&mut input)
                                 .read_bang_element(buf, &mut position)
                                 .unwrap()
                                 .map(|(ty, data)| (ty, Bytes(data))),
@@ -1106,7 +1111,7 @@ mod test {
                         //                                 ^= 17
 
                         assert_eq!(
-                            input
+                            $source(&mut input)
                                 .read_bang_element(buf, &mut position)
                                 .unwrap()
                                 .map(|(ty, data)| (ty, Bytes(data))),
@@ -1134,7 +1139,7 @@ mod test {
                             let mut input = b"!D other content".as_ref();
                             //                ^= 0
 
-                            match input.read_bang_element(buf, &mut position) {
+                            match $source(&mut input).read_bang_element(buf, &mut position) {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
                                 x => assert!(
                                     false,
@@ -1152,7 +1157,7 @@ mod test {
                             let mut input = b"!DOCTYPEother content".as_ref();
                             //                ^= 0
 
-                            match input.read_bang_element(buf, &mut position) {
+                            match $source(&mut input).read_bang_element(buf, &mut position) {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
                                 x => assert!(
                                     false,
@@ -1171,7 +1176,7 @@ mod test {
                             //                         ^= 9
 
                             assert_eq!(
-                                input
+                                $source(&mut input)
                                     .read_bang_element(buf, &mut position)
                                     .unwrap()
                                     .map(|(ty, data)| (ty, Bytes(data))),
@@ -1187,7 +1192,7 @@ mod test {
                             let mut input = b"!DOCTYPE other content".as_ref();
                             //                ^= 0
 
-                            match input.read_bang_element(buf, &mut position) {
+                            match $source(&mut input).read_bang_element(buf, &mut position) {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
                                 x => assert!(
                                     false,
@@ -1213,7 +1218,7 @@ mod test {
                             let mut input = b"!d other content".as_ref();
                             //                ^= 0
 
-                            match input.read_bang_element(buf, &mut position) {
+                            match $source(&mut input).read_bang_element(buf, &mut position) {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
                                 x => assert!(
                                     false,
@@ -1231,7 +1236,7 @@ mod test {
                             let mut input = b"!doctypeother content".as_ref();
                             //                ^= 0
 
-                            match input.read_bang_element(buf, &mut position) {
+                            match $source(&mut input).read_bang_element(buf, &mut position) {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
                                 x => assert!(
                                     false,
@@ -1250,7 +1255,7 @@ mod test {
                             //                         ^= 9
 
                             assert_eq!(
-                                input
+                                $source(&mut input)
                                     .read_bang_element(buf, &mut position)
                                     .unwrap()
                                     .map(|(ty, data)| (ty, Bytes(data))),
@@ -1266,7 +1271,7 @@ mod test {
                             let mut input = b"!doctype other content".as_ref();
                             //                ^= 0
 
-                            match input.read_bang_element(buf, &mut position) {
+                            match $source(&mut input).read_bang_element(buf, &mut position) {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
                                 x => assert!(
                                     false,
@@ -1293,7 +1298,7 @@ mod test {
                     let mut input = b"".as_ref();
                     //                ^= 0
 
-                    assert_eq!(input.read_element(buf, &mut position).unwrap().map(Bytes), None);
+                    assert_eq!($source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes), None);
                     assert_eq!(position, 0);
                 }
 
@@ -1310,7 +1315,7 @@ mod test {
                         //                 ^= 1
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b""))
                         );
                         assert_eq!(position, 1);
@@ -1324,7 +1329,7 @@ mod test {
                         //                    ^= 4
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b"tag"))
                         );
                         assert_eq!(position, 4);
@@ -1338,7 +1343,7 @@ mod test {
                         //                  ^= 2
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b":"))
                         );
                         assert_eq!(position, 2);
@@ -1352,7 +1357,7 @@ mod test {
                         //                     ^= 5
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b":tag"))
                         );
                         assert_eq!(position, 5);
@@ -1366,7 +1371,7 @@ mod test {
                         //                                                        ^= 38
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(br#"tag  attr-1=">"  attr2  =  '>'  3attr"#))
                         );
                         assert_eq!(position, 38);
@@ -1386,7 +1391,7 @@ mod test {
                         //                  ^= 2
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b"/"))
                         );
                         assert_eq!(position, 2);
@@ -1400,7 +1405,7 @@ mod test {
                         //                     ^= 5
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b"tag/"))
                         );
                         assert_eq!(position, 5);
@@ -1414,7 +1419,7 @@ mod test {
                         //                   ^= 3
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b":/"))
                         );
                         assert_eq!(position, 3);
@@ -1428,7 +1433,7 @@ mod test {
                         //                      ^= 6
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(b":tag/"))
                         );
                         assert_eq!(position, 6);
@@ -1442,7 +1447,7 @@ mod test {
                         //                                                           ^= 41
 
                         assert_eq!(
-                            input.read_element(buf, &mut position).unwrap().map(Bytes),
+                            $source(&mut input).read_element(buf, &mut position).unwrap().map(Bytes),
                             Some(Bytes(br#"tag  attr-1="/>"  attr2  =  '/>'  3attr/"#))
                         );
                         assert_eq!(position, 41);

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -19,7 +19,7 @@ use crate::reader::{Reader, XmlSource};
 /// Consumes a [`BufRead`] and streams XML `Event`s.
 pub struct NsReader<R> {
     /// An XML reader
-    reader: Reader<R>,
+    pub(super) reader: Reader<R>,
     /// Buffer that contains names of namespace prefixes (the part between `xmlns:`
     /// and an `=`) and namespace values.
     buffer: Vec<u8>,
@@ -63,14 +63,14 @@ impl<R> NsReader<R> {
         self.process_event(event)
     }
 
-    fn pop(&mut self) {
+    pub(super) fn pop(&mut self) {
         if self.pending_pop {
             self.ns_resolver.pop(&mut self.buffer);
             self.pending_pop = false;
         }
     }
 
-    fn process_event<'i>(&mut self, event: Result<Event<'i>>) -> Result<Event<'i>> {
+    pub(super) fn process_event<'i>(&mut self, event: Result<Event<'i>>) -> Result<Event<'i>> {
         match event {
             Ok(Event::Start(e)) => {
                 self.ns_resolver.push(&e, &mut self.buffer);
@@ -93,7 +93,7 @@ impl<R> NsReader<R> {
         }
     }
 
-    fn resolve_event<'i>(
+    pub(super) fn resolve_event<'i>(
         &mut self,
         event: Result<Event<'i>>,
     ) -> Result<(ResolveResult, Event<'i>)> {
@@ -538,6 +538,10 @@ impl<'i> NsReader<&'i [u8]> {
     /// You also can use [`read_resolved_event()`] instead if you want to resolve namespace
     /// as soon as you get an event.
     ///
+    /// There is no asynchronous `read_event_async()` version of this function,
+    /// because it is not necessary -- the contents are already in memory and no IO
+    /// is needed, therefore there is no potential for blocking.
+    ///
     /// # Examples
     ///
     /// ```
@@ -594,6 +598,10 @@ impl<'i> NsReader<&'i [u8]> {
     ///
     /// If you are not interested in namespaces, you can use [`read_event()`]
     /// which will not automatically resolve namespaces for you.
+    ///
+    /// There is no asynchronous `read_resolved_event_async()` version of this function,
+    /// because it is not necessary -- the contents are already in memory and no IO
+    /// is needed, therefore there is no potential for blocking.
     ///
     /// # Examples
     ///
@@ -660,6 +668,10 @@ impl<'i> NsReader<&'i [u8]> {
     /// The `end` parameter should contain name of the end element _in the reader
     /// encoding_. It is good practice to always get that parameter using
     /// [`BytesStart::to_end()`] method.
+    ///
+    /// There is no asynchronous `read_to_end_async()` version of this function,
+    /// because it is not necessary -- the contents are already in memory and no IO
+    /// is needed, therefore there is no potential for blocking.
     ///
     /// # Namespaces
     ///

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -246,7 +246,12 @@ mod test {
     use crate::reader::test::check;
     use crate::reader::XmlSource;
 
-    check!(());
+    /// Default buffer constructor just pass the byte array from the test
+    fn identity<T>(input: T) -> T {
+        input
+    }
+
+    check!(identity, ());
 
     #[cfg(feature = "encoding")]
     mod encoding {

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -251,7 +251,13 @@ mod test {
         input
     }
 
-    check!(identity, ());
+    check!(
+        #[test]
+        read_event_impl,
+        read_until_close,
+        identity,
+        ()
+    );
 
     #[cfg(feature = "encoding")]
     mod encoding {

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -34,6 +34,10 @@ impl<'a> Reader<&'a [u8]> {
 
     /// Read an event that borrows from the input rather than a buffer.
     ///
+    /// There is no asynchronous `read_event_async()` version of this function,
+    /// because it is not necessary -- the contents are already in memory and no IO
+    /// is needed, therefore there is no potential for blocking.
+    ///
     /// # Examples
     ///
     /// ```
@@ -82,6 +86,10 @@ impl<'a> Reader<&'a [u8]> {
     ///
     /// The correctness of the skipped events does not checked, if you disabled
     /// the [`check_end_names`] option.
+    ///
+    /// There is no asynchronous `read_to_end_async()` version of this function,
+    /// because it is not necessary -- the contents are already in memory and no IO
+    /// is needed, therefore there is no potential for blocking.
     ///
     /// # Namespaces
     ///

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -138,25 +138,7 @@ impl<'a> Reader<&'a [u8]> {
     /// [`check_end_names`]: Self::check_end_names
     /// [the specification]: https://www.w3.org/TR/xml11/#dt-etag
     pub fn read_to_end(&mut self, end: QName) -> Result<()> {
-        let mut depth = 0;
-        loop {
-            match self.read_event() {
-                Err(e) => return Err(e),
-
-                Ok(Event::Start(e)) if e.name() == end => depth += 1,
-                Ok(Event::End(e)) if e.name() == end => {
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                    depth -= 1;
-                }
-                Ok(Event::Eof) => {
-                    let name = self.decoder().decode(end.as_ref());
-                    return Err(Error::UnexpectedEof(format!("</{:?}>", name)));
-                }
-                _ => (),
-            }
-        }
+        read_to_end!(self, end, (), {})
     }
 }
 

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -138,7 +138,7 @@ impl<'a> Reader<&'a [u8]> {
     /// [`check_end_names`]: Self::check_end_names
     /// [the specification]: https://www.w3.org/TR/xml11/#dt-etag
     pub fn read_to_end(&mut self, end: QName) -> Result<()> {
-        read_to_end!(self, end, (), {})
+        read_to_end!(self, end, (), read_event_impl, {})
     }
 }
 

--- a/tests/async-tokio.rs
+++ b/tests/async-tokio.rs
@@ -1,0 +1,20 @@
+use quick_xml::events::Event::*;
+use quick_xml::Reader;
+
+#[tokio::test]
+async fn test_sample() {
+    let src = include_str!("documents/sample_rss.xml");
+    let mut reader = Reader::from_reader(src.as_bytes());
+    let mut buf = Vec::new();
+    let mut count = 0;
+    loop {
+        match reader.read_event_into_async(&mut buf).await.unwrap() {
+            Start(_) => count += 1,
+            Decl(e) => println!("{:?}", e.version()),
+            Eof => break,
+            _ => (),
+        }
+        buf.clear();
+    }
+    println!("{}", count);
+}


### PR DESCRIPTION
First of all, I would like to thank @999eagle for her work. It was very useful for quickly obtaining a working result and its iterative improvement.

After week of experimenting and prepare work I think, that the result suits me. I tried to focus on those points:
- maximum reuse the code. For that all key methods rewritten using macros, so the sync and async code is the same
- try to minimize intermediate wrappers, because it is painful to pass long named types to functions, like in that example: https://github.com/tafia/quick-xml/blob/9ccc68620fb4f525d0316abe8e3cfac624780b56/src/reader/mod.rs#L324-L326

I have considered several options
- original suggestion with three intermediate structs: `SliceReader`, `BufferedReader` and `AsyncReader`:
  ```rust
  impl                  Reader<SliceReader> { ... }// for &[u8]
  impl<R: BufRead>      Reader<BufferedReader<R>> { ... }
  impl<R: AsyncBufRead> Reader<AsyncReader<R>> { ... }
  ```
  I have realized that we have enough only two of them therefore...
- two intermediate newtype structs, `SyncReader` and `AsyncReader`
  ```rust
  impl<R>               Reader<SyncReader<R>> { ... }// for &[u8] and BufRead
  impl<R: AsyncBufRead> Reader<AsyncReader<R>> { ... }
  ```
  After further experiments, it became clear that we can do without `SyncReader`, so...
- _(this one)_ sync code stays the same. Async code is implemented using an adapter struct, which I've name `TokioAdapter` (former `AsyncReader`)
  ```rust
  impl                  Reader<&[u8]> { ... }
  impl<R: BufRead>      Reader<R> { ... }
  impl<R: AsyncBufRead> Reader<AsyncReader<R>> { ... }
  ```
- do not introduce intermediate structs and just implement everything for `Reader<R>`
  ```rust
  impl                  Reader<&[u8]> { ... }
  impl<R: BufRead>      Reader<R> { ... }
  impl<R: AsyncBufRead> Reader<R> { ... }
  ```
  In this option the conflicts of names for internal methods would appear. In principle, there is nothing unsolvable, but if we decide to realize support for other asynchronous library, it will be perhaps not really convenient. However, my attempts to implement support for [`futures`](https://lib.rs/crates/futures) were unsuccessful -- API differs a little. Besides, there is nothing difficult in principle, but so far it seems that it is possible to do without it as as there are [adapters](https://lib.rs/crates/async-compat)

As it seemed, all realization differs slightly. I especially like the 4th option, as it eliminates the need for a long type if you need to pass `Reader` to the function. I think, I'll make also another PR with that variant.

I decided to not implement `from_file` for async reader, because it is required additional tokio feature and it seems that it can be easely done outside the crate.

Also, I did not implement `read_text_into_async` API, because it available not on all readers and I think, it should be reworked to return all intermediate notes as text as required for #257 and also was discussed in #154.

I'm not sure, whether we have to `Send` for inner type, as was originally implemented by @999eagle in #417, currently I do not require that. It seems, that compiler should automatically guarantee that when it can, but how to check that?

@999eagle, could you also review that?

Closes #417 
Closes #425