### PR TITLE
Fix #435: replay only events from time of creating SeqAccess struct

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -553,13 +553,10 @@ where
         } else {
             TagFilter::Exclude(self.map.fields)
         };
-        let seq = visitor.visit_seq(MapValueSeqAccess {
+        visitor.visit_seq(MapValueSeqAccess {
             map: self.map,
             filter,
-        });
-        #[cfg(feature = "overlapped-lists")]
-        self.map.de.start_replay();
-        seq
+        })
     }
 
     #[inline]
@@ -588,6 +585,16 @@ where
     /// When feature `overlapped-lists` is activated, all tags, that not pass
     /// this check, will be skipped.
     filter: TagFilter<'de>,
+}
+
+#[cfg(feature = "overlapped-lists")]
+impl<'de, 'a, 'm, R> Drop for MapValueSeqAccess<'de, 'a, 'm, R>
+where
+    R: XmlRead<'de>,
+{
+    fn drop(&mut self) {
+        self.map.de.start_replay();
+    }
 }
 
 impl<'de, 'a, 'm, R> SeqAccess<'de> for MapValueSeqAccess<'de, 'a, 'm, R>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -828,10 +828,7 @@ where
     where
         V: Visitor<'de>,
     {
-        let seq = visitor.visit_seq(seq::TopLevelSeqAccess::new(self)?);
-        #[cfg(feature = "overlapped-lists")]
-        self.start_replay();
-        seq
+        visitor.visit_seq(seq::TopLevelSeqAccess::new(self)?)
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -483,6 +483,14 @@ where
         self.reader.next()
     }
 
+    /// Returns the mark after which all events, skipped by [`Self::skip()`] call,
+    /// should be replayed after calling [`Self::start_replay()`].
+    #[cfg(feature = "overlapped-lists")]
+    #[inline]
+    fn skip_checkpoint(&self) -> usize {
+        self.write.len()
+    }
+
     /// Extracts XML tree of events from and stores them in the skipped events
     /// buffer from which they can be retrieved later. You MUST call
     /// [`Self::start_replay()`] after calling this to give access to the skipped
@@ -530,8 +538,8 @@ where
         Ok(())
     }
 
-    /// Moves all buffered events to the end of [`Self::write`] buffer and swaps
-    /// read and write buffers.
+    /// Moves buffered events, skipped after given `checkpoint` from [`Self::write`]
+    /// skip buffer to [`Self::read`] buffer.
     ///
     /// After calling this method, [`Self::peek()`] and [`Self::next()`] starts
     /// return events that was skipped previously by calling [`Self::skip()`],
@@ -541,9 +549,15 @@ where
     /// This method MUST be called if any number of [`Self::skip()`] was called
     /// after [`Self::new()`] or `start_replay()` or you'll lost events.
     #[cfg(feature = "overlapped-lists")]
-    fn start_replay(&mut self) {
-        self.write.append(&mut self.read);
-        std::mem::swap(&mut self.read, &mut self.write);
+    fn start_replay(&mut self, checkpoint: usize) {
+        if checkpoint == 0 {
+            self.write.append(&mut self.read);
+            std::mem::swap(&mut self.read, &mut self.write);
+        } else {
+            let mut read = self.write.split_off(checkpoint);
+            read.append(&mut self.read);
+            self.read = read;
+        }
     }
 
     fn next_start(&mut self) -> Result<Option<BytesStart<'de>>, DeError> {
@@ -1021,6 +1035,10 @@ mod tests {
             assert_eq!(de.next().unwrap(), Start(BytesStart::new("root")));
             assert_eq!(de.peek().unwrap(), &Start(BytesStart::new("inner")));
 
+            // Mark that start_replay() should begin replay from this point
+            let checkpoint = de.skip_checkpoint();
+            assert_eq!(checkpoint, 0);
+
             // Should skip first <inner> tree
             de.skip().unwrap();
             assert_eq!(de.read, vec![]);
@@ -1057,7 +1075,7 @@ mod tests {
             //
             //   <target/>
             // </root>
-            de.start_replay();
+            de.start_replay(checkpoint);
             assert_eq!(
                 de.read,
                 vec![
@@ -1070,6 +1088,10 @@ mod tests {
             );
             assert_eq!(de.write, vec![]);
             assert_eq!(de.next().unwrap(), Start(BytesStart::new("inner")));
+
+            // Mark that start_replay() should begin replay from this point
+            let checkpoint = de.skip_checkpoint();
+            assert_eq!(checkpoint, 0);
 
             // Skip `#text` node and consume <inner/> after it
             de.skip().unwrap();
@@ -1102,7 +1124,7 @@ mod tests {
             //
             //   <target/>
             // </root>
-            de.start_replay();
+            de.start_replay(checkpoint);
             assert_eq!(
                 de.read,
                 vec![
@@ -1141,6 +1163,10 @@ mod tests {
             assert_eq!(de.write, vec![]);
 
             assert_eq!(de.next().unwrap(), Start(BytesStart::new("root")));
+
+            // Mark that start_replay() should begin replay from this point
+            let checkpoint = de.skip_checkpoint();
+            assert_eq!(checkpoint, 0);
 
             // Skip the <skip> tree
             de.skip().unwrap();
@@ -1187,7 +1213,7 @@ mod tests {
             // and after that stream that messages:
             //
             // </root>
-            de.start_replay();
+            de.start_replay(checkpoint);
             assert_eq!(
                 de.read,
                 vec![
@@ -1232,6 +1258,10 @@ mod tests {
 
             assert_eq!(de.next().unwrap(), Start(BytesStart::new("root")));
 
+            // start_replay() should start replay from this point
+            let checkpoint1 = de.skip_checkpoint();
+            assert_eq!(checkpoint1, 0);
+
             // Should skip first and second <skipped-N/> elements
             de.skip().unwrap(); // skipped-1
             de.skip().unwrap(); // skipped-2
@@ -1268,6 +1298,10 @@ mod tests {
                 ]
             );
 
+            // start_replay() should start replay from this point
+            let checkpoint2 = de.skip_checkpoint();
+            assert_eq!(checkpoint2, 4);
+
             // Should skip third and forth <skipped-N/> elements
             de.skip().unwrap(); // skipped-3
             de.skip().unwrap(); // skipped-4
@@ -1275,11 +1309,12 @@ mod tests {
             assert_eq!(
                 de.write,
                 vec![
+                    // checkpoint 1
                     Start(BytesStart::new("skipped-1")),
                     End(BytesEnd::new("skipped-1")),
                     Start(BytesStart::new("skipped-2")),
                     End(BytesEnd::new("skipped-2")),
-                    // split point
+                    // checkpoint 2
                     Start(BytesStart::new("skipped-3")),
                     End(BytesEnd::new("skipped-3")),
                     Start(BytesStart::new("skipped-4")),
@@ -1313,7 +1348,8 @@ mod tests {
                 ]
             );
 
-            de.start_replay();
+            // Start replay events from checkpoint 2
+            de.start_replay(checkpoint2);
             assert_eq!(
                 de.read,
                 vec![
@@ -1369,7 +1405,8 @@ mod tests {
                 ]
             );
 
-            de.start_replay();
+            // Start replay events from checkpoint 1
+            de.start_replay(checkpoint1);
             assert_eq!(
                 de.read,
                 vec![

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -100,6 +100,16 @@ where
     }
 }
 
+#[cfg(feature = "overlapped-lists")]
+impl<'de, 'a, R> Drop for TopLevelSeqAccess<'de, 'a, R>
+where
+    R: XmlRead<'de>,
+{
+    fn drop(&mut self) {
+        self.de.start_replay();
+    }
+}
+
 impl<'de, 'a, R> SeqAccess<'de> for TopLevelSeqAccess<'de, 'a, R>
 where
     R: XmlRead<'de>,

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -82,6 +82,12 @@ where
     /// When feature `overlapped-lists` is activated, all tags, that not pass
     /// this check, will be skipped.
     filter: TagFilter<'de>,
+
+    /// Checkpoint after which all skipped events should be returned. All events,
+    /// that was skipped before creating this checkpoint, will still stay buffered
+    /// and will not be returned
+    #[cfg(feature = "overlapped-lists")]
+    checkpoint: usize,
 }
 
 impl<'a, 'de, R> TopLevelSeqAccess<'de, 'a, R>
@@ -96,7 +102,13 @@ where
         } else {
             TagFilter::Exclude(&[])
         };
-        Ok(Self { de, filter })
+        Ok(Self {
+            #[cfg(feature = "overlapped-lists")]
+            checkpoint: de.skip_checkpoint(),
+
+            de,
+            filter,
+        })
     }
 }
 
@@ -106,7 +118,7 @@ where
     R: XmlRead<'de>,
 {
     fn drop(&mut self) {
-        self.de.start_replay();
+        self.de.start_replay(self.checkpoint);
     }
 }
 

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -765,6 +765,40 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        outer: [List; 3],
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                          <outer><item/><item/><item/></outer>
+                          <unknown/>
+                          <outer><item/><item/><item/></outer>
+                          <outer><item/><item/><item/></outer>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests non-sequential field is defined in the struct
@@ -821,6 +855,41 @@ mod seq {
                             <node/>
                             <item/>
                             <item/>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        node: (),
+                        outer: [List; 3],
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <outer><item/><item/><item/></outer>
+                            <node/>
+                            <outer><item/><item/><item/></outer>
+                            <outer><item/><item/><item/></outer>
                         </root>
                         "#,
                     );
@@ -913,6 +982,41 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        outer: [List; 3],
+                        node: (),
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <outer><item/><item/><item/></outer>
+                            <node/>
+                            <outer><item/><item/><item/></outer>
+                            <outer><item/><item/><item/></outer>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests two lists are deserialized simultaneously.
@@ -954,6 +1058,42 @@ mod seq {
                             <item/>
                             <element/>
                             <item/>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    data.unwrap();
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        outer: [List; 3],
+                        element: [(); 2],
+                    }
+
+                    let data = from_str::<Pair>(
+                        r#"
+                        <root>
+                            <outer><item/><item/><item/></outer>
+                            <element/>
+                            <outer><item/><item/><item/></outer>
+                            <element/>
+                            <outer><item/><item/><item/></outer>
                         </root>
                         "#,
                     );
@@ -1300,6 +1440,47 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        outer: Vec<List>,
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <outer><item/></outer>
+                            <unknown/>
+                            <outer><item/></outer>
+                            <outer><item/></outer>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Root {
+                            outer: vec![
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                            ],
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests non-sequential field is defined in the struct
@@ -1391,6 +1572,49 @@ mod seq {
                         }
                         e => panic!(
                             r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        node: (),
+                        outer: Vec<List>,
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <outer><item/></outer>
+                            <node/>
+                            <outer><item/></outer>
+                            <outer><item/></outer>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Root {
+                            node: (),
+                            outer: vec![
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                            ],
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
                             e
                         ),
                     }
@@ -1490,6 +1714,49 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        outer: Vec<List>,
+                        node: (),
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <outer><item/></outer>
+                            <node/>
+                            <outer><item/></outer>
+                            <outer><item/></outer>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Root {
+                            outer: vec![
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                            ],
+                            node: (),
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests two lists are deserialized simultaneously.
@@ -1556,6 +1823,48 @@ mod seq {
                         Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `item`"),
                         e => panic!(
                             r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
+
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Pair {
+                        outer: Vec<List>,
+                        element: Vec<()>,
+                    }
+
+                    let data = from_str::<Pair>(
+                        r#"
+                        <root>
+                            <outer><item/></outer>
+                            <element/>
+                            <outer><item/></outer>
+                            <outer><item/></outer>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Pair {
+                            outer: vec![
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                                List { item: vec![()] },
+                            ],
+                            element: vec![()],
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
                             e
                         ),
                     }
@@ -1824,6 +2133,19 @@ mod seq {
             Other,
         }
 
+        #[derive(Debug, PartialEq, Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        enum Choice4 {
+            One {
+                inner: [(); 1],
+            },
+            Two {
+                inner: [(); 1],
+            },
+            #[serde(other)]
+            Other,
+        }
+
         /// This module contains tests where size of the list have a compile-time size
         mod fixed_size {
             use super::*;
@@ -2048,6 +2370,52 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        node: (),
+                        #[serde(rename = "$value")]
+                        item: [Choice4; 3],
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <one><inner/></one>
+                            <node/>
+                            <two><inner/></two>
+                            <three><inner/></three>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Root {
+                            node: (),
+                            item: [
+                                Choice4::One { inner: [()] },
+                                Choice4::Two { inner: [()] },
+                                Choice4::Other,
+                            ],
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests non-sequential field is defined in the struct
@@ -2144,6 +2512,52 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        #[serde(rename = "$value")]
+                        item: [Choice4; 3],
+                        node: (),
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <one><inner/></one>
+                            <node/>
+                            <two><inner/></two>
+                            <three><inner/></three>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Root {
+                            item: [
+                                Choice4::One { inner: [()] },
+                                Choice4::Two { inner: [()] },
+                                Choice4::Other,
+                            ],
+                            node: (),
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests two lists are deserialized simultaneously.
@@ -2216,77 +2630,169 @@ mod seq {
                         );
                     }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a fixed-name one
-                    #[test]
-                    fn overlapped_fixed_before() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <element/>
-                                <one/>
-                                <two/>
-                                <element/>
-                                <three/>
-                            </root>
-                            "#,
-                        );
+                    mod overlapped {
+                        use super::*;
+                        use pretty_assertions::assert_eq;
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
-                                element: [(), ()],
-                            }
-                        );
-
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => {
-                                assert_eq!(e, "invalid length 1, expected an array of length 2")
-                            }
-                            e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
-                                e
-                            ),
+                        #[derive(Debug, PartialEq, Deserialize)]
+                        struct Root {
+                            #[serde(rename = "$value")]
+                            item: [Choice4; 3],
+                            element: [(); 2],
                         }
-                    }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a variable-name one
-                    #[test]
-                    fn overlapped_fixed_after() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <one/>
-                                <element/>
-                                <two/>
-                                <three/>
-                                <element/>
-                            </root>
-                            "#,
-                        );
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a fixed-name one
+                        #[test]
+                        fn fixed_before() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one/>
+                                    <two/>
+                                    <element/>
+                                    <three/>
+                                </root>
+                                "#,
+                            );
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
-                                element: [(), ()],
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                    element: [(), ()],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 2")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                    e
+                                ),
                             }
-                        );
+                        }
 
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => {
-                                assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a variable-name one
+                        #[test]
+                        fn fixed_after() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <one/>
+                                    <element/>
+                                    <two/>
+                                    <three/>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                    element: [(), ()],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 3")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                    e
+                                ),
                             }
-                            e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
-                                e
-                            ),
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_before() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one><inner/></one>
+                                    <two><inner/></two>
+                                    <element/>
+                                    <three><inner/></three>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    item: [
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                    element: [(); 2],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 2")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                    e
+                                ),
+                            }
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_after() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <one><inner/></one>
+                                    <element/>
+                                    <two><inner/></two>
+                                    <three><inner/></three>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    item: [
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                    element: [(); 2],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 3")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                    e
+                                ),
+                            }
                         }
                     }
                 }
@@ -2356,77 +2862,169 @@ mod seq {
                         );
                     }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a fixed-name one
-                    #[test]
-                    fn overlapped_fixed_before() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <element/>
-                                <one/>
-                                <two/>
-                                <element/>
-                                <three/>
-                            </root>
-                            "#,
-                        );
+                    mod overlapped {
+                        use super::*;
+                        use pretty_assertions::assert_eq;
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
-                                element: [(), ()],
-                            }
-                        );
-
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => {
-                                assert_eq!(e, "invalid length 1, expected an array of length 2")
-                            }
-                            e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
-                                e
-                            ),
+                        #[derive(Debug, PartialEq, Deserialize)]
+                        struct Root {
+                            element: [(); 2],
+                            #[serde(rename = "$value")]
+                            item: [Choice4; 3],
                         }
-                    }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a variable-name one
-                    #[test]
-                    fn overlapped_fixed_after() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <one/>
-                                <element/>
-                                <two/>
-                                <three/>
-                                <element/>
-                            </root>
-                            "#,
-                        );
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a fixed-name one
+                        #[test]
+                        fn fixed_before() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one/>
+                                    <two/>
+                                    <element/>
+                                    <three/>
+                                </root>
+                                "#,
+                            );
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                item: [Choice::One, Choice::Two, Choice::Other("three".into())],
-                                element: [(), ()],
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                    element: [(), ()],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 2")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                    e
+                                ),
                             }
-                        );
+                        }
 
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => {
-                                assert_eq!(e, "invalid length 1, expected an array of length 3")
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a variable-name one
+                        #[test]
+                        fn fixed_after() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <one/>
+                                    <element/>
+                                    <two/>
+                                    <three/>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    item: [Choice::One, Choice::Two, Choice::Other("three".into())],
+                                    element: [(), ()],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 3")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                    e
+                                ),
                             }
-                            e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
-                                e
-                            ),
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_before() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one><inner/></one>
+                                    <two><inner/></two>
+                                    <element/>
+                                    <three><inner/></three>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    element: [(); 2],
+                                    item: [
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 2")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                    e
+                                ),
+                            }
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_after() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <one><inner/></one>
+                                    <element/>
+                                    <two><inner/></two>
+                                    <three><inner/></three>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    element: [(); 2],
+                                    item: [
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "invalid length 1, expected an array of length 3")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                    e
+                                ),
+                            }
                         }
                     }
                 }
@@ -2867,6 +3465,52 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        node: (),
+                        #[serde(rename = "$value")]
+                        item: Vec<Choice4>,
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <one><inner/></one>
+                            <node/>
+                            <two><inner/></two>
+                            <three><inner/></three>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Root {
+                            node: (),
+                            item: vec![
+                                Choice4::One { inner: [()] },
+                                Choice4::Two { inner: [()] },
+                                Choice4::Other,
+                            ],
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "duplicate field `$value`")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests non-sequential field is defined in the struct
@@ -2961,6 +3605,52 @@ mod seq {
                         ),
                     }
                 }
+
+                /// Test for https://github.com/tafia/quick-xml/issues/435
+                #[test]
+                fn overlapped_with_nested_list() {
+                    #[derive(Debug, PartialEq, Deserialize)]
+                    struct Root {
+                        #[serde(rename = "$value")]
+                        item: Vec<Choice4>,
+                        node: (),
+                    }
+
+                    let data = from_str::<Root>(
+                        r#"
+                        <root>
+                            <one><inner/></one>
+                            <node/>
+                            <two><inner/></two>
+                            <three><inner/></three>
+                        </root>
+                        "#,
+                    );
+
+                    #[cfg(feature = "overlapped-lists")]
+                    assert_eq!(
+                        data.unwrap(),
+                        Root {
+                            item: vec![
+                                Choice4::One { inner: [()] },
+                                Choice4::Two { inner: [()] },
+                                Choice4::Other,
+                            ],
+                            node: (),
+                        }
+                    );
+
+                    #[cfg(not(feature = "overlapped-lists"))]
+                    match data {
+                        Err(DeError::Custom(e)) => {
+                            assert_eq!(e, "duplicate field `$value`")
+                        }
+                        e => panic!(
+                            r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                            e
+                        ),
+                    }
+                }
             }
 
             /// In those tests two lists are deserialized simultaneously.
@@ -3033,73 +3723,177 @@ mod seq {
                         );
                     }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a fixed-name one
-                    #[test]
-                    fn overlapped_fixed_before() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <element/>
-                                <one/>
-                                <two/>
-                                <element/>
-                                <three/>
-                            </root>
-                            "#,
-                        );
+                    mod overlapped {
+                        use super::*;
+                        use pretty_assertions::assert_eq;
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
-                                element: vec![(), ()],
-                            }
-                        );
-
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `element`"),
-                            e => panic!(
-                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
-                                e
-                            ),
+                        #[derive(Debug, PartialEq, Deserialize)]
+                        struct Root {
+                            #[serde(rename = "$value")]
+                            item: Vec<Choice4>,
+                            element: Vec<()>,
                         }
-                    }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a variable-name one
-                    #[test]
-                    fn overlapped_fixed_after() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <one/>
-                                <element/>
-                                <two/>
-                                <three/>
-                                <element/>
-                            </root>
-                            "#,
-                        );
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a fixed-name one
+                        #[test]
+                        fn fixed_before() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one/>
+                                    <two/>
+                                    <element/>
+                                    <three/>
+                                </root>
+                                "#,
+                            );
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
-                                element: vec![(), ()],
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    item: vec![
+                                        Choice::One,
+                                        Choice::Two,
+                                        Choice::Other("three".into())
+                                    ],
+                                    element: vec![(), ()],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `element`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                    e
+                                ),
                             }
-                        );
+                        }
 
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
-                            e => panic!(
-                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
-                                e
-                            ),
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a variable-name one
+                        #[test]
+                        fn fixed_after() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <one/>
+                                    <element/>
+                                    <two/>
+                                    <three/>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    item: vec![
+                                        Choice::One,
+                                        Choice::Two,
+                                        Choice::Other("three".into())
+                                    ],
+                                    element: vec![(), ()],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `$value`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                    e
+                                ),
+                            }
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_before() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one><inner/></one>
+                                    <two><inner/></two>
+                                    <element/>
+                                    <three><inner/></three>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    item: vec![
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                    element: vec![(); 2],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `element`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                    e
+                                ),
+                            }
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_after() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <one><inner/></one>
+                                    <element/>
+                                    <two><inner/></two>
+                                    <three><inner/></three>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    item: vec![
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                    element: vec![(); 2],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `$value`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                    e
+                                ),
+                            }
                         }
                     }
                 }
@@ -3169,73 +3963,177 @@ mod seq {
                         );
                     }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a fixed-name one
-                    #[test]
-                    fn overlapped_fixed_before() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <element/>
-                                <one/>
-                                <two/>
-                                <element/>
-                                <three/>
-                            </root>
-                            "#,
-                        );
+                    mod overlapped {
+                        use super::*;
+                        use pretty_assertions::assert_eq;
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                element: vec![(), ()],
-                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
-                            }
-                        );
-
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `element`"),
-                            e => panic!(
-                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
-                                e
-                            ),
+                        #[derive(Debug, PartialEq, Deserialize)]
+                        struct Root {
+                            element: Vec<()>,
+                            #[serde(rename = "$value")]
+                            item: Vec<Choice4>,
                         }
-                    }
 
-                    /// A list with fixed-name elements are mixed with a list with variable-name
-                    /// elements in an XML, and the first element is a variable-name one
-                    #[test]
-                    fn overlapped_fixed_after() {
-                        let data = from_str::<Pair>(
-                            r#"
-                            <root>
-                                <one/>
-                                <element/>
-                                <two/>
-                                <three/>
-                                <element/>
-                            </root>
-                            "#,
-                        );
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a fixed-name one
+                        #[test]
+                        fn fixed_before() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one/>
+                                    <two/>
+                                    <element/>
+                                    <three/>
+                                </root>
+                                "#,
+                            );
 
-                        #[cfg(feature = "overlapped-lists")]
-                        assert_eq!(
-                            data.unwrap(),
-                            Pair {
-                                element: vec![(), ()],
-                                item: vec![Choice::One, Choice::Two, Choice::Other("three".into())],
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    element: vec![(), ()],
+                                    item: vec![
+                                        Choice::One,
+                                        Choice::Two,
+                                        Choice::Other("three".into())
+                                    ],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `element`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                    e
+                                ),
                             }
-                        );
+                        }
 
-                        #[cfg(not(feature = "overlapped-lists"))]
-                        match data {
-                            Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
-                            e => panic!(
-                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
-                                e
-                            ),
+                        /// A list with fixed-name elements are mixed with a list with variable-name
+                        /// elements in an XML, and the first element is a variable-name one
+                        #[test]
+                        fn fixed_after() {
+                            let data = from_str::<Pair>(
+                                r#"
+                                <root>
+                                    <one/>
+                                    <element/>
+                                    <two/>
+                                    <three/>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Pair {
+                                    element: vec![(), ()],
+                                    item: vec![
+                                        Choice::One,
+                                        Choice::Two,
+                                        Choice::Other("three".into())
+                                    ],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `$value`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                    e
+                                ),
+                            }
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_before() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <element/>
+                                    <one><inner/></one>
+                                    <two><inner/></two>
+                                    <element/>
+                                    <three><inner/></three>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    element: vec![(); 2],
+                                    item: vec![
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `element`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                    e
+                                ),
+                            }
+                        }
+
+                        /// Test for https://github.com/tafia/quick-xml/issues/435
+                        #[test]
+                        fn with_nested_list_fixed_after() {
+                            let data = from_str::<Root>(
+                                r#"
+                                <root>
+                                    <one><inner/></one>
+                                    <element/>
+                                    <two><inner/></two>
+                                    <three><inner/></three>
+                                    <element/>
+                                </root>
+                                "#,
+                            );
+
+                            #[cfg(feature = "overlapped-lists")]
+                            assert_eq!(
+                                data.unwrap(),
+                                Root {
+                                    element: vec![(); 2],
+                                    item: vec![
+                                        Choice4::One { inner: [()] },
+                                        Choice4::Two { inner: [()] },
+                                        Choice4::Other,
+                                    ],
+                                }
+                            );
+
+                            #[cfg(not(feature = "overlapped-lists"))]
+                            match data {
+                                Err(DeError::Custom(e)) => {
+                                    assert_eq!(e, "duplicate field `$value`")
+                                }
+                                e => panic!(
+                                    r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                    e
+                                ),
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes #435. The reason of the bug is that nested lists produces two calls of `start_replay()` of skipped events, but not all events should be replayed after first call.

This PR add marks that determines which events should be replayed after calling `start_replay()`. The mark is created when new replay scope is started (when `deserialize_seq` / `deserialize_tuple` / `deserialize_tuple_struct` is called) and used when `start_replay()` is called.