### PR TITLE
Fix #443: Keep LF eol for all test documents, explicitly mark encoding for UTF-16 documents

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Unit tests assume that all xml files have unix style line endings
-*.xml text eol=cr
+/tests/documents/* text eol=lf
+
+/tests/documents/utf16be.xml binary
+/tests/documents/utf16le.xml binary
+/tests/documents/sample_5_utf16bom.xml binary

--- a/Changelog.md
+++ b/Changelog.md
@@ -190,6 +190,7 @@
 - [#407]: Improved benchmark suite to cover whole-document parsing, escaping and unescaping text
 - [#418]: Parameterized macrobenchmarks and comparative benchmarks, added throughput measurements via criterion
 - [#434]: Added more tests for serde deserializer
+- [#443]: Now all documents in `/tests/documents` are checked out with LF eol in working copy (except sample_5_utf16bom.xml)
 
 [#8]: https://github.com/Mingun/fast-xml/pull/8
 [#9]: https://github.com/Mingun/fast-xml/pull/9
@@ -216,6 +217,7 @@
 [#437]: https://github.com/tafia/quick-xml/pull/437
 [#439]: https://github.com/tafia/quick-xml/pull/439
 [#440]: https://github.com/tafia/quick-xml/pull/440
+[#443]: https://github.com/tafia/quick-xml/pull/443
 
 
 ## 0.23.0 -- 2022-05-08

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -235,10 +235,6 @@ fn test_writer_borrow() -> Result<()> {
 #[test]
 fn test_writer_indent() -> Result<()> {
     let txt = include_str!("../tests/documents/test_writer_indent.xml");
-    // Normalize newlines on Windows to just \n, which is what the reader and
-    // writer use.
-    let normalized_txt = txt.replace("\r\n", "\n");
-    let txt = normalized_txt.as_str();
     let mut reader = Reader::from_str(txt);
     reader.trim_text(true);
     let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 4);
@@ -250,12 +246,6 @@ fn test_writer_indent() -> Result<()> {
     }
 
     let result = writer.into_inner().into_inner();
-    // println!("{:?}", String::from_utf8_lossy(&result));
-
-    #[cfg(windows)]
-    assert!(result.into_iter().eq(txt.bytes().filter(|b| *b != 13)));
-
-    #[cfg(not(windows))]
     assert_eq!(result, txt.as_bytes());
 
     Ok(())
@@ -275,11 +265,6 @@ fn test_writer_indent_cdata() -> Result<()> {
     }
 
     let result = writer.into_inner().into_inner();
-
-    #[cfg(windows)]
-    assert!(result.into_iter().eq(txt.bytes().filter(|b| *b != 13)));
-
-    #[cfg(not(windows))]
     assert_eq!(result, txt.as_bytes());
 
     Ok(())


### PR DESCRIPTION
To bring Windows working copy to the correct state you would need to run

```console
git add --renormalize .
git reset --hard
```

The first command makes working copy dirty because documents have CRLF eols.
The second removes that changes.