### PR TITLE
Implement `read_text` - a method that returns a text between two tags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,7 @@
   under the `quick-xml::encoding` namespace.
 - [#450]: Added support of asynchronous [tokio](https://tokio.rs/) readers
 - [#455]: Change return type of all `read_to_end*` methods to return a span between tags
+- [#455]: Added `Reader::read_text` method to return a raw content (including markup) between tags
 
 
 ### Bug Fixes

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,7 @@
 - [#439]: Added utilities `detect_encoding()`, `decode()`, and `decode_with_bom_removal()`
   under the `quick-xml::encoding` namespace.
 - [#450]: Added support of asynchronous [tokio](https://tokio.rs/) readers
+- [#455]: Change return type of all `read_to_end*` methods to return a span between tags
 
 
 ### Bug Fixes
@@ -222,6 +223,7 @@
 [#440]: https://github.com/tafia/quick-xml/pull/440
 [#443]: https://github.com/tafia/quick-xml/pull/443
 [#450]: https://github.com/tafia/quick-xml/pull/450
+[#455]: https://github.com/tafia/quick-xml/pull/455
 
 
 ## 0.23.0 -- 2022-05-08

--- a/Changelog.md
+++ b/Changelog.md
@@ -184,6 +184,8 @@
 - [#440]: Removed `Deserializer::from_slice` and `quick_xml::de::from_slice` methods because deserializing from a byte
   array cannot guarantee borrowing due to possible copying while decoding.
 
+- [#455]: Removed `Reader::read_text_into` which is only not a better wrapper over match on `Event::Text`
+
 ### New Tests
 
 - [#9]: Added tests for incorrect nested tags in input

--- a/Changelog.md
+++ b/Changelog.md
@@ -139,6 +139,7 @@
   |`*_with_custom_entities`|`*_with`
   |`BytesText::unescaped()`|`BytesText::unescape()`
   |`Attribute::unescaped_*`|`Attribute::unescape_*`
+- [#329]: Also, that functions now borrow from the input instead of event / attribute
 
 - [#416]: `BytesStart::to_borrowed` renamed to `BytesStart::borrow`, the same method
   added to all events
@@ -199,6 +200,7 @@
 [#180]: https://github.com/tafia/quick-xml/issues/180
 [#191]: https://github.com/tafia/quick-xml/issues/191
 [#324]: https://github.com/tafia/quick-xml/issues/324
+[#329]: https://github.com/tafia/quick-xml/issues/329
 [#363]: https://github.com/tafia/quick-xml/issues/363
 [#387]: https://github.com/tafia/quick-xml/pull/387
 [#391]: https://github.com/tafia/quick-xml/pull/391

--- a/examples/read_texts.rs
+++ b/examples/read_texts.rs
@@ -1,6 +1,5 @@
 fn main() {
     use quick_xml::events::Event;
-    use quick_xml::name::QName;
     use quick_xml::Reader;
 
     let xml = "<tag1>text1</tag1><tag1>text2</tag1>\
@@ -9,23 +8,18 @@ fn main() {
     let mut reader = Reader::from_str(xml);
     reader.trim_text(true);
 
-    let mut txt = Vec::new();
-    let mut buf = Vec::new();
-
     loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) if e.name().as_ref() == b"tag2" => {
-                txt.push(
-                    reader
-                        .read_text_into(QName(b"tag2"), &mut Vec::new())
-                        .expect("Cannot decode text value"),
-                );
+        match reader.read_event() {
+            Ok(Event::Start(e)) if e.name().as_ref() == b"tag2" => {
+                // read_text_into for buffered readers not implemented
+                let txt = reader
+                    .read_text(e.name())
+                    .expect("Cannot decode text value");
                 println!("{:?}", txt);
             }
             Ok(Event::Eof) => break, // exits the loop when reaching end of file
             Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
             _ => (), // There are several other `Event`s we do not consider here
         }
-        buf.clear();
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -951,7 +951,8 @@ impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
     fn read_to_end(&mut self, name: QName) -> Result<(), DeError> {
         match self.reader.read_to_end_into(name, &mut self.buf) {
             Err(Error::UnexpectedEof(_)) => Err(DeError::UnexpectedEof),
-            other => Ok(other?),
+            Err(e) => Err(e.into()),
+            Ok(_) => Ok(()),
         }
     }
 
@@ -991,7 +992,8 @@ impl<'de> XmlRead<'de> for SliceReader<'de> {
     fn read_to_end(&mut self, name: QName) -> Result<(), DeError> {
         match self.reader.read_to_end(name) {
             Err(Error::UnexpectedEof(_)) => Err(DeError::UnexpectedEof),
-            other => Ok(other?),
+            Err(e) => Err(e.into()),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -365,54 +365,6 @@ impl<R: BufRead> Reader<R> {
             buf.clear();
         }))
     }
-
-    /// Reads optional text between start and end tags.
-    ///
-    /// If the next event is a [`Text`] event, returns the decoded and unescaped content as a
-    /// `String`. If the next event is an [`End`] event, returns the empty string. In all other
-    /// cases, returns an error.
-    ///
-    /// Any text will be decoded using the XML encoding specified in the XML declaration (or UTF-8
-    /// if none is specified).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use pretty_assertions::assert_eq;
-    /// use quick_xml::Reader;
-    /// use quick_xml::events::Event;
-    ///
-    /// let mut xml = Reader::from_reader(b"
-    ///     <a>&lt;b&gt;</a>
-    ///     <a></a>
-    /// " as &[u8]);
-    /// xml.trim_text(true);
-    ///
-    /// let expected = ["<b>", ""];
-    /// for &content in expected.iter() {
-    ///     match xml.read_event_into(&mut Vec::new()) {
-    ///         Ok(Event::Start(ref e)) => {
-    ///             assert_eq!(&xml.read_text_into(e.name(), &mut Vec::new()).unwrap(), content);
-    ///         },
-    ///         e => panic!("Expecting Start event, found {:?}", e),
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// [`Text`]: Event::Text
-    /// [`End`]: Event::End
-    pub fn read_text_into(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<String> {
-        let s = match self.read_event_into(buf) {
-            Err(e) => return Err(e),
-
-            Ok(Event::Text(e)) => e.unescape()?.into_owned(),
-            Ok(Event::End(e)) if e.name() == end => return Ok("".to_string()),
-            Ok(Event::Eof) => return Err(Error::UnexpectedEof("Text".to_string())),
-            _ => return Err(Error::TextNotFound),
-        };
-        self.read_to_end_into(end, buf)?;
-        Ok(s)
-    }
 }
 
 impl Reader<BufReader<File>> {


### PR DESCRIPTION
This method introduces `Reader::read_text` and `NsReader::read_text` methods, that returns text between open and closed tags.

At the same time it removes `Reader::read_text_into`, because:
- it is have the name similar to the newly added method, but behaves totally different
- it is trivially to implement it manually
- as was noted in #154, the behavior of this method should be changed to match the behavior of the new method, but this is hard to implement currently, because when we read events, we store in the user-provided buffer only data, that required for event content, but omitting the part corresponding to markup. But new method requires that bytes too. Implementing this behavior requires further investigations, therefore, I have decided so far to make an implementation only for the borrowing reader.