### PR TITLE
Make reader and writer modules public, fix a small bug + polishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ async-tokio = ["tokio"]
 ## [standard compliant]: https://www.w3.org/TR/xml11/#charencoding
 encoding = ["encoding_rs"]
 
+## Enables support for recognizing all [HTML 5 entities](https://dev.w3.org/html5/html-author/charref)
+escape-html = []
+
 ## This feature enables support for deserializing lists where tags are overlapped
 ## with tags that do not correspond to the list.
 ##
@@ -107,9 +110,6 @@ overlapped-lists = []
 
 ## Enables support for [`serde`] serialization and deserialization
 serialize = ["serde"]
-
-## Enables support for recognizing all [HTML 5 entities](https://dev.w3.org/html5/html-author/charref)
-escape-html = []
 
 [package.metadata.docs.rs]
 # document all features

--- a/Changelog.md
+++ b/Changelog.md
@@ -188,6 +188,9 @@
 
 - [#455]: Removed `Reader::read_text_into` which is only not a better wrapper over match on `Event::Text`
 
+- [#456]: Reader and writer stuff grouped under `reader` and `writer` modules.
+  You still can use re-exported definitions from a crate root
+
 ### New Tests
 
 - [#9]: Added tests for incorrect nested tags in input
@@ -230,6 +233,7 @@
 [#445]: https://github.com/tafia/quick-xml/pull/445
 [#450]: https://github.com/tafia/quick-xml/pull/450
 [#455]: https://github.com/tafia/quick-xml/pull/455
+[#456]: https://github.com/tafia/quick-xml/pull/456
 
 
 ## 0.23.0 -- 2022-05-08

--- a/Changelog.md
+++ b/Changelog.md
@@ -65,6 +65,7 @@
   and a document encoding is not an UTF-8
 - [#434]: Fixed incorrect error generated in some cases by serde deserializer
 - [#445]: Use local name without namespace prefix when selecting enum variants based on element names
+  in a serde deserializer
 
 ### Misc Changes
 
@@ -181,6 +182,7 @@
   |`BytesText::from_plain_str(&str)`                 |_(as above)_
   |`BytesCData::new(impl Into<Cow<[u8]>>)`           |`BytesCData::new(impl Into<Cow<str>>)`
   |`BytesCData::from_str(&str)`                      |_(as above)_
+
 - [#440]: Removed `Deserializer::from_slice` and `quick_xml::de::from_slice` methods because deserializing from a byte
   array cannot guarantee borrowing due to possible copying while decoding.
 
@@ -225,6 +227,7 @@
 [#439]: https://github.com/tafia/quick-xml/pull/439
 [#440]: https://github.com/tafia/quick-xml/pull/440
 [#443]: https://github.com/tafia/quick-xml/pull/443
+[#445]: https://github.com/tafia/quick-xml/pull/445
 [#450]: https://github.com/tafia/quick-xml/pull/450
 [#455]: https://github.com/tafia/quick-xml/pull/455
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Syntax is inspired by [xml-rs](https://github.com/netvl/xml-rs).
 ### Reader
 
 ```rust
-use quick_xml::Reader;
 use quick_xml::events::Event;
+use quick_xml::reader::Reader;
 
 let xml = r#"<tag1 att1 = "test">
                 <tag2><!--Test comment-->Test</tag2>
@@ -66,7 +66,8 @@ loop {
 
 ```rust
 use quick_xml::events::{Event, BytesEnd, BytesStart};
-use quick_xml::{Reader, Writer};
+use quick_xml::reader::Reader;
+use quick_xml::writer::Writer;
 use std::io::Cursor;
 
 let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -1,7 +1,7 @@
 use criterion::{self, criterion_group, criterion_main, Criterion, Throughput};
 use quick_xml::events::Event;
+use quick_xml::reader::{NsReader, Reader};
 use quick_xml::Result as XmlResult;
-use quick_xml::{NsReader, Reader};
 
 static RPM_PRIMARY: &str = include_str!("../tests/documents/rpm_primary.xml");
 static RPM_PRIMARY2: &str = include_str!("../tests/documents/rpm_primary2.xml");

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use quick_xml::escape::{escape, unescape};
 use quick_xml::events::Event;
 use quick_xml::name::QName;
-use quick_xml::{NsReader, Reader};
+use quick_xml::reader::{NsReader, Reader};
 
 static SAMPLE: &str = include_str!("../tests/documents/sample_rss.xml");
 static PLAYERS: &str = include_str!("../tests/documents/players.xml");

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -1,6 +1,7 @@
 use criterion::{self, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use pretty_assertions::assert_eq;
-use quick_xml::{self, events::Event, Reader};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
 use serde::Deserialize;
 use serde_xml_rs;
 use xml::reader::{EventReader, XmlEvent};

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use quick_xml::events::Event;
-use quick_xml::Reader;
+use quick_xml::reader::Reader;
 use regex::bytes::Regex;
 
 const DATA: &str = r#"

--- a/examples/nested_readers.rs
+++ b/examples/nested_readers.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use quick_xml::events::Event;
-use quick_xml::Reader;
+use quick_xml::reader::Reader;
 
 // a structure to capture the rows we've extracted
 // from a ECMA-376 table in document.xml

--- a/examples/read_buffered.rs
+++ b/examples/read_buffered.rs
@@ -5,7 +5,7 @@
 
 fn main() -> Result<(), quick_xml::Error> {
     use quick_xml::events::Event;
-    use quick_xml::Reader;
+    use quick_xml::reader::Reader;
 
     let mut reader = Reader::from_file("tests/documents/document.xml")?;
     reader.trim_text(true);

--- a/examples/read_texts.rs
+++ b/examples/read_texts.rs
@@ -1,6 +1,6 @@
 fn main() {
     use quick_xml::events::Event;
-    use quick_xml::Reader;
+    use quick_xml::reader::Reader;
 
     let xml = "<tag1>text1</tag1><tag1>text2</tag1>\
                <tag1>text3</tag1><tag1><tag2>text4</tag2></tag1>";

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,8 +1,8 @@
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 
-use quick_xml::Reader;
 use quick_xml::events::Event;
+use quick_xml::reader::Reader;
 use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -219,7 +219,7 @@ use crate::{
     errors::Error,
     events::{BytesCData, BytesEnd, BytesStart, BytesText, Event},
     name::QName,
-    Reader,
+    reader::Reader,
 };
 use serde::de::{self, Deserialize, DeserializeOwned, Visitor};
 use std::borrow::Cow;

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -190,9 +190,10 @@ impl<'a> BytesStart<'a> {
     ///
     /// # Example
     ///
-    /// ```rust
-    /// # use quick_xml::{Error, Writer};
+    /// ```
     /// use quick_xml::events::{BytesStart, Event};
+    /// # use quick_xml::writer::Writer;
+    /// # use quick_xml::Error;
     ///
     /// struct SomeStruct<'a> {
     ///     attrs: BytesStart<'a>,
@@ -957,8 +958,8 @@ pub enum Event<'a> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// use std::borrow::Cow;
-    /// use quick_xml::Reader;
     /// use quick_xml::events::Event;
+    /// use quick_xml::reader::Reader;
     ///
     /// // XML in UTF-8 with BOM
     /// let xml = b"\xEF\xBB\xBF<?xml version='1.0'?>".as_ref();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,13 +54,13 @@ pub mod escape {
 }
 pub mod events;
 pub mod name;
-mod reader;
+pub mod reader;
 #[cfg(feature = "serialize")]
 pub mod se;
 /// Not an official API, public for integration tests
 #[doc(hidden)]
 pub mod utils;
-mod writer;
+pub mod writer;
 
 // reexports
 pub use crate::encoding::Decoder;

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -49,7 +49,7 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
     /// # tokio_test::block_on(async {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::Event;
-    /// use quick_xml::Reader;
+    /// use quick_xml::reader::Reader;
     ///
     /// // This explicitly uses `from_reader("...".as_bytes())` to use a buffered
     /// // reader instead of relying on the zero-copy optimizations for reading
@@ -106,7 +106,7 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
     /// # tokio_test::block_on(async {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::{BytesStart, Event};
-    /// use quick_xml::Reader;
+    /// use quick_xml::reader::Reader;
     ///
     /// let mut reader = Reader::from_reader(r#"
     ///     <outer>
@@ -185,7 +185,7 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::Event;
     /// use quick_xml::name::{Namespace, ResolveResult::*};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_reader(r#"
     ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
@@ -248,7 +248,7 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::name::{Namespace, ResolveResult};
     /// use quick_xml::events::{BytesStart, Event};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_reader(r#"
     ///     <outer xmlns="namespace 1">
@@ -320,7 +320,7 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::Event;
     /// use quick_xml::name::{Namespace, QName, ResolveResult::*};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_reader(r#"
     ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -159,8 +159,6 @@ macro_rules! impl_buffered_source {
             }
         }
 
-        /// Consume and discard all the whitespace until the next non-whitespace
-        /// character or EOF.
         $($async)? fn skip_whitespace(&mut self, position: &mut usize) -> Result<()> {
             loop {
                 break match self $(.$reader)? .fill_buf() $(.$await)? {
@@ -180,8 +178,6 @@ macro_rules! impl_buffered_source {
             }
         }
 
-        /// Consume and discard one character if it matches the given byte. Return
-        /// true if it matched.
         $($async)? fn skip_one(&mut self, byte: u8, position: &mut usize) -> Result<bool> {
             // search byte must be within the ascii range
             debug_assert!(byte.is_ascii());
@@ -196,8 +192,6 @@ macro_rules! impl_buffered_source {
             }
         }
 
-        /// Return one character without consuming it, so that future `read_*` calls
-        /// will still include it. On EOF, return None.
         $($async)? fn peek_one(&mut self) -> Result<Option<u8>> {
             loop {
                 break match self $(.$reader)? .fill_buf() $(.$await)? {

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -237,8 +237,8 @@ impl<R: BufRead> Reader<R> {
     /// # Examples
     ///
     /// ```
-    /// use quick_xml::Reader;
     /// use quick_xml::events::Event;
+    /// use quick_xml::reader::Reader;
     ///
     /// let xml = r#"<tag1 att1 = "test">
     ///                 <tag2><!--Test comment-->Test</tag2>
@@ -317,7 +317,7 @@ impl<R: BufRead> Reader<R> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::{BytesStart, Event};
-    /// use quick_xml::Reader;
+    /// use quick_xml::reader::Reader;
     ///
     /// let mut reader = Reader::from_str(r#"
     ///     <outer>

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1496,11 +1496,11 @@ mod test {
 
             mod issue_344 {
                 use crate::errors::Error;
+                use crate::reader::Reader;
 
                 #[$test]
                 $($async)? fn cdata() {
-                    let doc = "![]]>";
-                    let mut reader = crate::Reader::from_str(doc);
+                    let mut reader = Reader::from_str("![]]>");
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "CData" => {}
@@ -1514,8 +1514,7 @@ mod test {
 
                 #[$test]
                 $($async)? fn comment() {
-                    let doc = "!- -->";
-                    let mut reader = crate::Reader::from_str(doc);
+                    let mut reader = Reader::from_str("!- -->");
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
@@ -1529,8 +1528,7 @@ mod test {
 
                 #[$test]
                 $($async)? fn doctype_uppercase() {
-                    let doc = "!D>";
-                    let mut reader = crate::Reader::from_str(doc);
+                    let mut reader = Reader::from_str("!D>");
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
@@ -1544,8 +1542,7 @@ mod test {
 
                 #[$test]
                 $($async)? fn doctype_lowercase() {
-                    let doc = "!d>";
-                    let mut reader = crate::Reader::from_str(doc);
+                    let mut reader = Reader::from_str("!d>");
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1,4 +1,4 @@
-//! A module to handle `Reader`
+//! Contains high-level interface for a pull-based XML parser.
 
 #[cfg(feature = "encoding")]
 use encoding_rs::Encoding;
@@ -380,8 +380,8 @@ impl EncodingRef {
 /// # Examples
 ///
 /// ```
-/// use quick_xml::Reader;
 /// use quick_xml::events::Event;
+/// use quick_xml::reader::Reader;
 ///
 /// let xml = r#"<tag1 att1 = "test">
 ///                 <tag2><!--Test comment-->Test</tag2>
@@ -456,8 +456,8 @@ impl<R> Reader<R> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// use std::{str, io::Cursor};
-    /// use quick_xml::Reader;
     /// use quick_xml::events::Event;
+    /// use quick_xml::reader::Reader;
     ///
     /// let xml = r#"<tag1 att1 = "test">
     ///                 <tag2><!--Test comment-->Test</tag2>

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -305,7 +305,7 @@ enum ParseState {
     /// State after seeing the `<` symbol. Depending on the next symbol all other
     /// events (except `StartText`) could be generated.
     ///
-    /// After generating ane event the reader moves to the `ClosedTag` state.
+    /// After generating one event the reader moves to the `ClosedTag` state.
     OpenedTag,
     /// State in which reader searches the `<` symbol of a markup. All bytes before
     /// that symbol will be returned in the [`Event::Text`] event. After that

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -667,10 +667,22 @@ trait XmlSource<'r, B> {
     /// [events]: crate::events::Event
     fn read_element(&mut self, buf: B, position: &mut usize) -> Result<Option<&'r [u8]>>;
 
+    /// Consume and discard all the whitespace until the next non-whitespace
+    /// character or EOF.
+    ///
+    /// # Parameters
+    /// - `position`: Will be increased by amount of bytes consumed
     fn skip_whitespace(&mut self, position: &mut usize) -> Result<()>;
 
+    /// Consume and discard one character if it matches the given byte. Return
+    /// `true` if it matched.
+    ///
+    /// # Parameters
+    /// - `position`: Will be increased by 1 if byte is matched
     fn skip_one(&mut self, byte: u8, position: &mut usize) -> Result<bool>;
 
+    /// Return one character without consuming it, so that future `read_*` calls
+    /// will still include it. On EOF, return `None`.
     fn peek_one(&mut self) -> Result<Option<u8>>;
 }
 

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -205,7 +205,7 @@ impl<R> NsReader<R> {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::Event;
     /// use quick_xml::name::{Namespace, QName, ResolveResult::*};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str("<tag xmlns='root namespace'/>");
     ///
@@ -258,7 +258,7 @@ impl<R> NsReader<R> {
     /// use quick_xml::events::Event;
     /// use quick_xml::events::attributes::Attribute;
     /// use quick_xml::name::{Namespace, QName, ResolveResult::*};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str("
     ///     <tag one='1'
@@ -312,9 +312,9 @@ impl<R: BufRead> NsReader<R> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
-    /// use quick_xml::NsReader;
     /// use quick_xml::events::Event;
     /// use quick_xml::name::{Namespace, ResolveResult::*};
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str(r#"
     ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
@@ -370,9 +370,9 @@ impl<R: BufRead> NsReader<R> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
-    /// use quick_xml::NsReader;
     /// use quick_xml::events::Event;
     /// use quick_xml::name::{Namespace, QName, ResolveResult::*};
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str(r#"
     ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
@@ -467,7 +467,7 @@ impl<R: BufRead> NsReader<R> {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::name::{Namespace, ResolveResult};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str(r#"
     ///     <outer xmlns="namespace 1">
@@ -552,9 +552,9 @@ impl<'i> NsReader<&'i [u8]> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
-    /// use quick_xml::NsReader;
     /// use quick_xml::events::Event;
     /// use quick_xml::name::{Namespace, ResolveResult::*};
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str(r#"
     ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
@@ -613,9 +613,9 @@ impl<'i> NsReader<&'i [u8]> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
-    /// use quick_xml::NsReader;
     /// use quick_xml::events::Event;
     /// use quick_xml::name::{Namespace, QName, ResolveResult::*};
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str(r#"
     ///     <x:tag1 xmlns:x="www.xxxx" xmlns:y="www.yyyy" att1 = "test">
@@ -699,7 +699,7 @@ impl<'i> NsReader<&'i [u8]> {
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::name::{Namespace, ResolveResult};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str(r#"
     ///     <outer xmlns="namespace 1">
@@ -779,7 +779,7 @@ impl<'i> NsReader<&'i [u8]> {
     /// # use pretty_assertions::assert_eq;
     /// # use std::borrow::Cow;
     /// use quick_xml::events::{BytesStart, Event};
-    /// use quick_xml::NsReader;
+    /// use quick_xml::reader::NsReader;
     ///
     /// let mut reader = NsReader::from_str(r#"
     ///     <html>

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -45,7 +45,7 @@ impl<'a> Reader<&'a [u8]> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::Event;
-    /// use quick_xml::Reader;
+    /// use quick_xml::reader::Reader;
     ///
     /// let mut reader = Reader::from_str(r#"
     ///     <tag1 att1 = "test">
@@ -117,7 +117,7 @@ impl<'a> Reader<&'a [u8]> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::{BytesStart, Event};
-    /// use quick_xml::Reader;
+    /// use quick_xml::reader::Reader;
     ///
     /// let mut reader = Reader::from_str(r#"
     ///     <outer>
@@ -183,7 +183,7 @@ impl<'a> Reader<&'a [u8]> {
     /// # use pretty_assertions::assert_eq;
     /// # use std::borrow::Cow;
     /// use quick_xml::events::{BytesStart, Event};
-    /// use quick_xml::Reader;
+    /// use quick_xml::reader::Reader;
     ///
     /// let mut reader = Reader::from_str("
     ///     <html>

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -49,11 +49,11 @@ impl<'r, W: Write> Serializer<'r, W> {
     ///
     /// When serializing a primitive type, only its representation will be written:
     ///
-    /// ```edition2018
+    /// ```
     /// # use pretty_assertions::assert_eq;
     /// # use serde::Serialize;
-    /// use quick_xml::Writer;
     /// # use quick_xml::se::Serializer;
+    /// use quick_xml::writer::Writer;
     ///
     /// let mut buffer = Vec::new();
     /// let mut writer = Writer::new_with_indent(&mut buffer, b' ', 2);
@@ -66,11 +66,11 @@ impl<'r, W: Write> Serializer<'r, W> {
     /// When serializing a struct, newtype struct, unit struct or tuple `root_tag`
     /// is used as tag name of root(s) element(s):
     ///
-    /// ```edition2018
+    /// ```
     /// # use pretty_assertions::assert_eq;
     /// # use serde::Serialize;
-    /// use quick_xml::Writer;
     /// use quick_xml::se::Serializer;
+    /// use quick_xml::writer::Writer;
     ///
     /// #[derive(Debug, PartialEq, Serialize)]
     /// struct Struct {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,4 +1,4 @@
-//! A module to handle `Writer`
+//! Contains high-level interface for an events-based XML emitter.
 
 use crate::errors::{Error, Result};
 use crate::events::{attributes::Attribute, BytesCData, BytesStart, BytesText, Event};
@@ -13,7 +13,8 @@ use std::io::Write;
 /// ```
 /// # use pretty_assertions::assert_eq;
 /// use quick_xml::events::{Event, BytesEnd, BytesStart};
-/// use quick_xml::{Reader, Writer};
+/// use quick_xml::reader::Reader;
+/// use quick_xml::writer::Writer;
 /// use std::io::Cursor;
 ///
 /// let xml = r#"<this_tag k1="v1" k2="v2"><child>text</child></this_tag>"#;
@@ -179,8 +180,9 @@ impl<W: Write> Writer<W> {
     /// ```rust
     /// # use quick_xml::Result;
     /// # fn main() -> Result<()> {
-    /// use quick_xml::{Error, Writer};
     /// use quick_xml::events::{BytesStart, BytesText, Event};
+    /// use quick_xml::writer::Writer;
+    /// use quick_xml::Error;
     /// use std::io::Cursor;
     ///
     /// let mut writer = Writer::new(Cursor::new(Vec::new()));

--- a/tests/async-tokio.rs
+++ b/tests/async-tokio.rs
@@ -1,5 +1,5 @@
 use quick_xml::events::Event::*;
-use quick_xml::Reader;
+use quick_xml::reader::Reader;
 
 #[tokio::test]
 async fn test_sample() {

--- a/tests/namespaces.rs
+++ b/tests/namespaces.rs
@@ -3,7 +3,7 @@ use quick_xml::events::attributes::Attribute;
 use quick_xml::events::Event::*;
 use quick_xml::name::ResolveResult::*;
 use quick_xml::name::{Namespace, QName};
-use quick_xml::NsReader;
+use quick_xml::reader::NsReader;
 use std::borrow::Cow;
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,8 @@
+use quick_xml::events::attributes::Attribute;
+use quick_xml::events::Event::*;
 use quick_xml::name::QName;
-use quick_xml::{events::attributes::Attribute, events::Event::*, Error, Reader};
+use quick_xml::reader::Reader;
+use quick_xml::Error;
 use std::{borrow::Cow, io::Cursor};
 
 #[cfg(feature = "serialize")]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -6,7 +6,9 @@ use quick_xml::events::attributes::{AttrError, Attribute};
 use quick_xml::events::Event::*;
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText};
 use quick_xml::name::QName;
-use quick_xml::{Reader, Result, Writer};
+use quick_xml::reader::Reader;
+use quick_xml::writer::Writer;
+use quick_xml::Result;
 
 use pretty_assertions::assert_eq;
 

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -1,7 +1,8 @@
+use quick_xml::encoding::Decoder;
 use quick_xml::escape::unescape;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::{QName, ResolveResult};
-use quick_xml::{Decoder, NsReader};
+use quick_xml::reader::NsReader;
 use std::str::from_utf8;
 
 #[test]


### PR DESCRIPTION
In anticipation of release 0.24, some polishing, plus fix of a minor bug in `EndEventMismatch` error generation.

Also, make `reader` and `writer` modules public, because the content of those modules are tend to grow and reexport of everything under a crate root seems to me a bad idea. All examples was updated to use the new recommended way to consume `Reader`s and `Writer`s.

Other commits contains some polishing.

I not yet finished checking documentation, so probably there will be one more PR before release, the last, I hope.