### PR TITLE
Strip BOM from the event data, add an encoding configuration option on the writer for writing the BOM

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -182,7 +182,8 @@
 - [#456]: Reader and writer stuff grouped under `reader` and `writer` modules.
   You still can use re-exported definitions from a crate root
 
-- [#458]: Made the `Writer::write()` method non-public as writing random bytes to a document is not generally useful.
+- [#458]: Made the `Writer::write()` method non-public as writing random bytes to a document is not generally useful or desirable.
+- [#458]: BOM bytes are no longer emitted as `Event::Text`. To write a BOM, use the configuration options present on `Writer`.
 
 ### New Tests
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -42,7 +42,9 @@
 - [#450]: Added support of asynchronous [tokio](https://tokio.rs/) readers
 - [#455]: Change return type of all `read_to_end*` methods to return a span between tags
 - [#455]: Added `Reader::read_text` method to return a raw content (including markup) between tags
-
+- [#458]: Added an `EncodingScheme` configuration option to `Writer` to allow writing documents
+  with a BOM. Currently UTF-8 is the only supported encoding however it could be extended to cover
+  others in the future.
 
 ### Bug Fixes
 
@@ -186,10 +188,12 @@
 - [#440]: Removed `Deserializer::from_slice` and `quick_xml::de::from_slice` methods because deserializing from a byte
   array cannot guarantee borrowing due to possible copying while decoding.
 
-- [#455]: Removed `Reader::read_text_into` which is only not a better wrapper over match on `Event::Text`
+- [#455]: Removed `Reader::read_text_into` which is just a thin wrapper around match on `Event::Text`
 
 - [#456]: Reader and writer stuff grouped under `reader` and `writer` modules.
   You still can use re-exported definitions from a crate root
+
+- [#458]: Made the `Writer::write()` method non-public as writing random bytes to a document is not generally useful.
 
 ### New Tests
 
@@ -234,7 +238,7 @@
 [#450]: https://github.com/tafia/quick-xml/pull/450
 [#455]: https://github.com/tafia/quick-xml/pull/455
 [#456]: https://github.com/tafia/quick-xml/pull/456
-
+[#458]: https://github.com/tafia/quick-xml/pull/458
 
 ## 0.23.0 -- 2022-05-08
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,8 +20,6 @@
 - [#180]: Make `Decoder` struct public. You already had access to it via the
   `Reader::decoder()` method, but could not name it in the code. Now the preferred
   way to access decoding functionality is via this struct
-- [#191]: New event variant `StartText` emitted for bytes before the XML declaration
-  or a start comment or a tag. For streams with BOM this event will contain a BOM
 - [#395]: Add support for XML Schema `xs:list`
 - [#324]: `Reader::from_str` / `Deserializer::from_str` / `from_str` now ignore
   the XML declared encoding and always use UTF-8
@@ -102,15 +100,6 @@
   `Decoder::decode()` and `Decoder::decode_with_bom_removal()`.
   Use `reader.decoder().decode_*(...)` instead of `reader.decode_*(...)` for now.
   `Reader::encoding()` is replaced by `Decoder::encoding()` as well
-- [#191]: Remove poorly designed `BytesText::unescape_and_decode_without_bom()` and
-  `BytesText::unescape_and_decode_without_bom_with_custom_entities()`. Although these methods worked
-  as expected, this was only due to good luck. They was replaced by the
-  `BytesStartText::decode_with_bom_removal()`:
-  - conceptually, you should decode BOM only for the first `Text` event from the
-    reader (since now `StartText` event is emitted instead for this)
-  - text before the first tag is not an XML content at all, so it is meaningless
-    to try to unescape something in it
-
 - [#180]: Eliminated the differences in the decoding API when feature `encoding` enabled and when it is
   disabled. Signatures of functions are now the same regardless of whether or not the feature is
   enabled, and an error will be returned instead of performing replacements for invalid characters

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -118,20 +118,6 @@ fn read_resolved_event_into(c: &mut Criterion) {
 /// Benchmarks, how fast individual event parsed
 fn one_event(c: &mut Criterion) {
     let mut group = c.benchmark_group("One event");
-    group.bench_function("StartText", |b| {
-        let src = "Hello world!".repeat(512 / 12);
-        b.iter(|| {
-            let mut r = Reader::from_str(&src);
-            let mut nbtxt = criterion::black_box(0);
-            r.check_end_names(false).check_comments(false);
-            match r.read_event() {
-                Ok(Event::StartText(e)) => nbtxt += e.len(),
-                something_else => panic!("Did not expect {:?}", something_else),
-            };
-
-            assert_eq!(nbtxt, 504);
-        })
-    });
 
     group.bench_function("Start", |b| {
         let src = format!(r#"<hello target="{}">"#, "world".repeat(512 / 5));

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -929,10 +929,6 @@ impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
         let event = loop {
             let e = self.reader.read_event_into(&mut self.buf)?;
             match e {
-                //TODO: Probably not the best idea treat StartText as usual text
-                // Usually this event will represent a BOM
-                // Changing this requires review of the serde-de::top_level::one_element test
-                Event::StartText(e) => break Ok(DeEvent::Text(e.into_owned().into())),
                 Event::Start(e) => break Ok(DeEvent::Start(e.into_owned())),
                 Event::End(e) => break Ok(DeEvent::End(e.into_owned())),
                 Event::Text(e) => break Ok(DeEvent::Text(e.into_owned())),
@@ -974,10 +970,6 @@ impl<'de> XmlRead<'de> for SliceReader<'de> {
         loop {
             let e = self.reader.read_event()?;
             match e {
-                //TODO: Probably not the best idea treat StartText as usual text
-                // Usually this event will represent a BOM
-                // Changing this requires review of the serde-de::top_level::one_element test
-                Event::StartText(e) => break Ok(DeEvent::Text(e.into())),
                 Event::Start(e) => break Ok(DeEvent::Start(e)),
                 Event::End(e) => break Ok(DeEvent::End(e)),
                 Event::Text(e) => break Ok(DeEvent::Text(e)),

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -152,7 +152,7 @@ fn split_at_bom<'b>(bytes: &'b [u8], encoding: &'static Encoding) -> (&'b [u8], 
 }
 
 #[cfg(feature = "encoding")]
-fn remove_bom<'b>(bytes: &'b [u8], encoding: &'static Encoding) -> &'b [u8] {
+pub(crate) fn remove_bom<'b>(bytes: &'b [u8], encoding: &'static Encoding) -> &'b [u8] {
     let (_, bytes) = split_at_bom(bytes, encoding);
     bytes
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -286,7 +286,7 @@ pub type Span = Range<usize>;
 ///   subgraph _
 ///     direction LR
 ///
-///     Init      -- "(no event)"\nStartText                              --> OpenedTag
+///     Init      -- "(no event)"\n                                       --> OpenedTag
 ///     OpenedTag -- Decl, DocType, PI\nComment, CData\nStart, Empty, End --> ClosedTag
 ///     ClosedTag -- "#lt;false#gt;\n(no event)"\nText                    --> OpenedTag
 ///   end
@@ -297,13 +297,13 @@ pub type Span = Range<usize>;
 #[derive(Clone)]
 enum ParseState {
     /// Initial state in which reader stay after creation. Transition from that
-    /// state could produce a `StartText`, `Decl`, `Comment` or `Start` event.
-    /// The next state is always `OpenedTag`. The reader will never return to this
-    /// state. The event emitted during transition to `OpenedTag` is a `StartEvent`
-    /// if the first symbol not `<`, otherwise no event are emitted.
+    /// state could produce a `Text`, `Decl`, `Comment` or `Start` event. The next
+    /// state is always `OpenedTag`. The reader will never return to this state. The
+    /// event emitted during transition to `OpenedTag` is a `StartEvent` if the
+    /// first symbol not `<`, otherwise no event are emitted.
     Init,
     /// State after seeing the `<` symbol. Depending on the next symbol all other
-    /// events (except `StartText`) could be generated.
+    /// events could be generated.
     ///
     /// After generating one event the reader moves to the `ClosedTag` state.
     OpenedTag,
@@ -553,8 +553,6 @@ impl<R> Reader<R> {
     }
 
     /// Read until '<' is found and moves reader to an `OpenedTag` state.
-    ///
-    /// Return a `StartText` event if `first` is `true` and a `Text` event otherwise
     fn read_until_open<'i, B>(&mut self, buf: B, first: bool) -> Result<Event<'i>>
     where
         R: XmlSource<'i, B>,
@@ -1572,16 +1570,6 @@ mod test {
                 use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
                 use crate::reader::Reader;
                 use pretty_assertions::assert_eq;
-
-                #[$test]
-                $($async)? fn start_text() {
-                    let mut reader = Reader::from_str("bom");
-
-                    assert_eq!(
-                        reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::StartText(BytesText::from_escaped("bom").into())
-                    );
-                }
 
                 #[$test]
                 $($async)? fn declaration() {

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -61,17 +61,11 @@ pub(super) struct Parser {
 }
 
 impl Parser {
-    /// Trims whitespaces from `bytes`, if required, and returns a [`StartText`]
-    /// or a [`Text`] event. When [`StartText`] is returned, the method can change
-    /// the encoding of the reader, detecting it from the beginning of the stream.
+    /// Trims whitespaces from `bytes`, if required, and returns a [`Text`] event.
     ///
     /// # Parameters
     /// - `bytes`: data from the start of stream to the first `<` or from `>` to `<`
-    /// - `first`: if `true`, then this is the first call of that function,
-    ///   i. e. data from the start of stream and [`StartText`] will be returned,
-    ///   otherwise [`Text`] will be returned
     ///
-    /// [`StartText`]: Event::StartText
     /// [`Text`]: Event::Text
     pub fn read_text<'b>(&mut self, bytes: &'b [u8], first: bool) -> Result<Event<'b>> {
         #[cfg(feature = "encoding")]
@@ -91,12 +85,7 @@ impl Parser {
         } else {
             bytes
         };
-
-        Ok(if first {
-            Event::StartText(BytesText::wrap(content, self.decoder()).into())
-        } else {
-            Event::Text(BytesText::wrap(content, self.decoder()))
-        })
+        Ok(Event::Text(BytesText::wrap(content, self.decoder())))
     }
 
     /// reads `BytesElement` starting with a `!`,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -133,7 +133,6 @@ impl<W: Write> Writer<W> {
     pub fn write_event<'a, E: AsRef<Event<'a>>>(&mut self, event: E) -> Result<()> {
         let mut next_should_line_break = true;
         let result = match *event.as_ref() {
-            Event::StartText(ref e) => self.write(&e),
             Event::Start(ref e) => {
                 let result = self.write_wrapped(b"<", e, b">");
                 if let Some(i) = self.indent.as_mut() {

--- a/tests/encodings.rs
+++ b/tests/encodings.rs
@@ -1,4 +1,6 @@
+#[allow(dead_code)]
 use quick_xml::events::Event;
+#[allow(dead_code)]
 use quick_xml::Reader;
 
 #[cfg(feature = "encoding")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -111,7 +111,7 @@ fn test_issue94() {
 fn test_no_trim() {
     let mut reader = Reader::from_str(" <tag> text </tag> ");
 
-    assert!(matches!(reader.read_event().unwrap(), StartText(_)));
+    assert!(matches!(reader.read_event().unwrap(), Text(_)));
     assert!(matches!(reader.read_event().unwrap(), Start(_)));
     assert!(matches!(reader.read_event().unwrap(), Text(_)));
     assert!(matches!(reader.read_event().unwrap(), End(_)));
@@ -123,7 +123,7 @@ fn test_trim_end() {
     let mut reader = Reader::from_str(" <tag> text </tag> ");
     reader.trim_text_end(true);
 
-    assert!(matches!(reader.read_event().unwrap(), StartText(_)));
+    assert!(matches!(reader.read_event().unwrap(), Text(_)));
     assert!(matches!(reader.read_event().unwrap(), Start(_)));
     assert!(matches!(reader.read_event().unwrap(), Text(_)));
     assert!(matches!(reader.read_event().unwrap(), End(_)));

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -374,11 +374,6 @@ fn test_bytes(input: &[u8], output: &[u8], trim: bool) {
     let mut decoder = reader.decoder();
     loop {
         let line = match reader.read_resolved_event() {
-            Ok((_, Event::StartText(_))) => {
-                // BOM could change decoder
-                decoder = reader.decoder();
-                "StartText".to_string()
-            }
             Ok((_, Event::Decl(e))) => {
                 // Declaration could change decoder
                 decoder = reader.decoder();


### PR DESCRIPTION
We need to allow users to write a BOM, but encoding it in the event stream creates other issues.  Instead lets delegate it to an option on the `Writer`.