### PR TITLE
Proposal for serializing namespaces in serde addressing #218

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }
 tokio = { version = "1.20", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.5"
+quick-xml-derive = { path = "quick-xml-derive" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }
 tokio = { version = "1.20", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.5"
-quick-xml-derive = { path = "quick-xml-derive" }
+quick-xml-derived = { path = "quick-xml-derived" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }
 tokio = { version = "1.20", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.5"
-quick-xml-derived = { path = "quick-xml-derived" }
+quick_xml_derived = { path = "quick-xml-derived" }
+q_meta = { path = "quick-xml-derived/q_meta"}
 
 [dev-dependencies]
 criterion = "0.3"
@@ -27,6 +28,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde-value = "0.7"
 tokio = { version = "1.20", default-features = false, features = ["macros", "rt"] }
 tokio-test = "0.4"
+phf = { version = "0.11.1", features = ["macros"] }
+q_meta = { path = "quick-xml-derived/q_meta"}
+
 
 [lib]
 bench = false
@@ -114,7 +118,7 @@ serialize = ["serde"]
 
 [package.metadata.docs.rs]
 # document all features
-all-features = true
+all-features = false
 # defines the configuration attribute `docs_rs` to enable feature requirements
 # See https://stackoverflow.com/questions/61417452
 rustdoc-args = ["--cfg", "docs_rs"]
@@ -133,6 +137,10 @@ required-features = ["serialize"]
 
 [[test]]
 name = "serde-migrated"
+required-features = ["serialize"]
+
+[[test]]
+name = "serde-namespace-se"
 required-features = ["serialize"]
 
 [[test]]

--- a/quick-xml-derived/Cargo.toml
+++ b/quick-xml-derived/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quick-xml-derived"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+quote = "1.0.21"
+syn = { version = "1.0.99", features = ["full"] }
+
+[lib]
+proc-macro = true

--- a/quick-xml-derived/Cargo.toml
+++ b/quick-xml-derived/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
-name = "quick-xml-derived"
+name = "quick_xml_derived"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proc-macro2 = "1.0.43"
 quote = "1.0.21"
 syn = { version = "1.0.99", features = ["full"] }
+serde = { version = "1.0", optional = true }
+phf = { version = "0.11.1", features = ["macros"] }
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+macrotest = "1.0.9"
 
 [lib]
 proc-macro = true

--- a/quick-xml-derived/Cargo.toml
+++ b/quick-xml-derived/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quick_xml_derived"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,7 +14,10 @@ phf = { version = "0.11.1", features = ["macros"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
+phf = { version = "0.11.1", features = ["macros"] }
 macrotest = "1.0.9"
+q_meta = { path = "q_meta"}
+trybuild = { version = "1.0.66", features = ["diff"] }
 
 [lib]
 proc-macro = true

--- a/quick-xml-derived/q_meta/Cargo.toml
+++ b/quick-xml-derived/q_meta/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "q_meta"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+phf = { version = "0.11.1", features = ["macros"] }
+syllogism = "0.1.3"

--- a/quick-xml-derived/q_meta/src/lib.rs
+++ b/quick-xml-derived/q_meta/src/lib.rs
@@ -1,0 +1,80 @@
+use phf::phf_map;
+
+#[derive(Debug)]
+pub struct QuickXmlMeta {
+    pub namespace_declarations: &'static [(&'static str, &'static str)],
+    pub identifier_prefix_map: phf::Map<&'static str, &'static str>
+}
+pub trait CurrentItemVisitorQXmlMeta {
+    fn visit_current_item_as_self<T>(
+        &self,
+        contained_visitor: &mut T,
+        ident_in_parent: Option<&'static str>,
+        parent_meta: Option<&'static QuickXmlMeta>,
+    ) -> &'static QuickXmlMeta
+    where
+        T: ContainedItemVisitorQXmlMeta;
+}
+
+impl CurrentItemVisitorQXmlMeta for String {
+    fn visit_current_item_as_self<T>(
+        &self,
+        contained_visitor: &mut T,
+        ident_in_parent: Option<&'static str>,
+        parent_meta: Option<&'static QuickXmlMeta>,
+    ) -> &'static QuickXmlMeta
+    where
+        T: ContainedItemVisitorQXmlMeta
+    {
+        &QuickXmlMeta {
+            namespace_declarations: &[],
+            identifier_prefix_map: phf_map! {},
+        }
+    }
+}
+
+impl CurrentItemVisitorQXmlMeta for u32 {
+    fn visit_current_item_as_self<T>(
+        &self,
+        contained_visitor: &mut T,
+        ident_in_parent: Option<&'static str>,
+        parent_meta: Option<&'static QuickXmlMeta>,
+    ) -> &'static QuickXmlMeta
+    where
+        T: ContainedItemVisitorQXmlMeta
+    {
+        &QuickXmlMeta {
+            namespace_declarations: &[],
+            identifier_prefix_map: phf_map! {},
+        }
+    }
+}
+
+impl<X: CurrentItemVisitorQXmlMeta> CurrentItemVisitorQXmlMeta for Vec<X> {
+    fn visit_current_item_as_self<T>(
+        &self,
+        contained_visitor: &mut T,
+        ident_in_parent: Option<&'static str>,
+        parent_meta: Option<&'static QuickXmlMeta>,
+    ) -> &'static QuickXmlMeta
+    where
+        T: ContainedItemVisitorQXmlMeta
+    {
+        let self_meta = &QuickXmlMeta {
+            namespace_declarations: &[],
+            identifier_prefix_map: phf_map! {},
+        };
+        self.iter().for_each(|item| T::visit_contained_item(contained_visitor, item, ident_in_parent, parent_meta, true));
+        self_meta
+    }
+}
+
+pub trait ContainedItemVisitorQXmlMeta {
+    fn visit_contained_item<T: CurrentItemVisitorQXmlMeta>(
+        &mut self,
+        obj_to_ser: &T,
+        ident_in_parent: Option<&'static str>,
+        parent_meta: Option<&'static QuickXmlMeta>,
+        is_pseudoobject: bool,
+    );
+} 

--- a/quick-xml-derived/src/lib.rs
+++ b/quick-xml-derived/src/lib.rs
@@ -1,96 +1,14 @@
 extern crate proc_macro;
+mod quick_xml_derive;
+use quick_xml_derive::impl_quick_xml_derive;
 
-use proc_macro::TokenStream;
-use quote::{ToTokens, quote};
+use proc_macro::{TokenStream};
 use syn;
+use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(QuickXml, attributes(xmlns, xmlpre))]
+#[proc_macro_derive(QuickXml, attributes(qxml))]
 pub fn quick_xml_derive(input: TokenStream) -> TokenStream {
-    let ast = syn::parse(input).unwrap();
-
-    impl_quick_xml_derive(&ast)
-}
-
-fn impl_quick_xml_derive(ast: &syn::ItemStruct) -> TokenStream {
-
-    let attrs = &ast.attrs;
-    let xmlns_attrs = attrs.iter().filter(|a| a.path.is_ident("xmlns")).collect();
-    let xmlpre_attrs = attrs.iter().filter(|a| a.path.is_ident("xmlpre")).collect();
-    if xmlns_attrs.len() + xmlpre_attrs.len() == 0 {
-        ast.
-    }
-    for attr in attrs.iter().filter(|a| a.path.is_ident("xmlns")) {
-        let mut attr_token_trees = attr.clone().tokens.into_iter();
-        let first_o: Option<TokenTree> = attr_token_trees.next();
-        let second_o: Option<TokenTree> = first_o.as_ref().and_then(|_| attr_token_trees.next());
-        let third_o: Option<TokenTree> = second_o.as_ref().and_then(|_| attr_token_trees.next());
-        let fourth_o: Option<TokenTree> = third_o.as_ref().and_then(|_| attr_token_trees.next());
-        let fifth_o: Option<TokenTree> = fourth_o.as_ref().and_then(|_| attr_token_trees.next());
-        if let Option<TokenTree>(fifth_o) = fifth {
-            syn::Error::new_spanned(fifth.into_token_stream(), "xmlns should on")
-        }
-
-        let first = match first_o {
-            Some(TokenTree::Punct(first)) => first,
-            _ => {
-                panic!("xmlns improperly formatted");
-            }
-        };
-        
-        let mut prefix: Option<String> = None;
-        let mut uri: Option<String> = None;
-
-        if first.to_string() == ":" {
-
-            let second = match second_o {
-                Some(TokenTree::Ident(ref second)) => second,
-                _ => {
-                    panic!("xmlns improperly formatted");
-                }
-            };
-            prefix = Some(second.to_string());
-            let third = match third_o {
-                Some(TokenTree::Punct(ref third)) => third,
-                _ => {
-                    panic!("xmlns improperly formatted");
-                }
-            };
-            if third.to_string() != "=" {
-                panic!("xmlns improperly formatted");
-            }
-            let fourth = match fourth_o {
-                Some(TokenTree::Literal(ref fourth)) => fourth,
-                _ => {
-                    panic!("xmlns improperly formatted");
-                }
-            };
-            uri = Some(fourth.to_string());
-        }
-        
-        if first.to_string() == "=" {
-            if third_o.is_some() {
-                panic!("xmlns improperly formatted");
-            }
-            let second = match second_o {
-                Some(TokenTree::Literal(ref second)) => second,
-                _ => {
-                    panic!("xmlns improperly formatted");
-                }
-            };
-            uri = Some(second.to_string());
-        }
-    }
-
-    let name = &ast.ident;
-    let gen = quote! {
-        impl HelloMacro for #name {
-            fn hello_macro() {
-                println!(
-                    "Hello, Macro! My name is {}!",
-                    stringify!(#name)
-                );
-            }
-        }
-    };
-    gen.into()
+    eprintln!("THIS IS A TEST!!!!!");
+    let input = parse_macro_input!(input as DeriveInput);
+    impl_quick_xml_derive(input).unwrap_or_else(syn::Error::into_compile_error).into()
 }

--- a/quick-xml-derived/src/lib.rs
+++ b/quick-xml-derived/src/lib.rs
@@ -6,9 +6,8 @@ use proc_macro::{TokenStream};
 use syn;
 use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(QuickXml, attributes(qxml))]
+#[proc_macro_derive(QuickXml, attributes(qxml,serde))]
 pub fn quick_xml_derive(input: TokenStream) -> TokenStream {
-    eprintln!("THIS IS A TEST!!!!!");
     let input = parse_macro_input!(input as DeriveInput);
     impl_quick_xml_derive(input).unwrap_or_else(syn::Error::into_compile_error).into()
 }

--- a/quick-xml-derived/src/lib.rs
+++ b/quick-xml-derived/src/lib.rs
@@ -1,0 +1,96 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{ToTokens, quote};
+use syn;
+
+#[proc_macro_derive(QuickXml, attributes(xmlns, xmlpre))]
+pub fn quick_xml_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    impl_quick_xml_derive(&ast)
+}
+
+fn impl_quick_xml_derive(ast: &syn::ItemStruct) -> TokenStream {
+
+    let attrs = &ast.attrs;
+    let xmlns_attrs = attrs.iter().filter(|a| a.path.is_ident("xmlns")).collect();
+    let xmlpre_attrs = attrs.iter().filter(|a| a.path.is_ident("xmlpre")).collect();
+    if xmlns_attrs.len() + xmlpre_attrs.len() == 0 {
+        ast.
+    }
+    for attr in attrs.iter().filter(|a| a.path.is_ident("xmlns")) {
+        let mut attr_token_trees = attr.clone().tokens.into_iter();
+        let first_o: Option<TokenTree> = attr_token_trees.next();
+        let second_o: Option<TokenTree> = first_o.as_ref().and_then(|_| attr_token_trees.next());
+        let third_o: Option<TokenTree> = second_o.as_ref().and_then(|_| attr_token_trees.next());
+        let fourth_o: Option<TokenTree> = third_o.as_ref().and_then(|_| attr_token_trees.next());
+        let fifth_o: Option<TokenTree> = fourth_o.as_ref().and_then(|_| attr_token_trees.next());
+        if let Option<TokenTree>(fifth_o) = fifth {
+            syn::Error::new_spanned(fifth.into_token_stream(), "xmlns should on")
+        }
+
+        let first = match first_o {
+            Some(TokenTree::Punct(first)) => first,
+            _ => {
+                panic!("xmlns improperly formatted");
+            }
+        };
+        
+        let mut prefix: Option<String> = None;
+        let mut uri: Option<String> = None;
+
+        if first.to_string() == ":" {
+
+            let second = match second_o {
+                Some(TokenTree::Ident(ref second)) => second,
+                _ => {
+                    panic!("xmlns improperly formatted");
+                }
+            };
+            prefix = Some(second.to_string());
+            let third = match third_o {
+                Some(TokenTree::Punct(ref third)) => third,
+                _ => {
+                    panic!("xmlns improperly formatted");
+                }
+            };
+            if third.to_string() != "=" {
+                panic!("xmlns improperly formatted");
+            }
+            let fourth = match fourth_o {
+                Some(TokenTree::Literal(ref fourth)) => fourth,
+                _ => {
+                    panic!("xmlns improperly formatted");
+                }
+            };
+            uri = Some(fourth.to_string());
+        }
+        
+        if first.to_string() == "=" {
+            if third_o.is_some() {
+                panic!("xmlns improperly formatted");
+            }
+            let second = match second_o {
+                Some(TokenTree::Literal(ref second)) => second,
+                _ => {
+                    panic!("xmlns improperly formatted");
+                }
+            };
+            uri = Some(second.to_string());
+        }
+    }
+
+    let name = &ast.ident;
+    let gen = quote! {
+        impl HelloMacro for #name {
+            fn hello_macro() {
+                println!(
+                    "Hello, Macro! My name is {}!",
+                    stringify!(#name)
+                );
+            }
+        }
+    };
+    gen.into()
+}

--- a/quick-xml-derived/src/quick_xml_derive.rs
+++ b/quick-xml-derived/src/quick_xml_derive.rs
@@ -1,0 +1,309 @@
+use std::collections::{HashSet, HashMap};
+use std::hash::{Hash, Hasher};
+
+use proc_macro2::{TokenStream};
+use quote::{quote};
+use syn::punctuated::Punctuated;
+use syn::{Data, DataStruct, Fields, DeriveInput, Ident, Token, LitStr, Attribute};
+use syn::parse::{Parse, ParseStream};
+use phf::phf_map;
+
+mod kw {
+    use syn::custom_keyword;
+    custom_keyword!(xmlns);
+    custom_keyword!(pre);
+}
+
+#[derive(Debug)]
+pub struct QuickXmlNamespace {
+    prefix: Option<String>,
+    uri: String,
+}
+
+pub fn impl_quick_xml_derive(input: DeriveInput) -> syn::Result<TokenStream> {
+    eprintln!("THIS IS A TEST!!!!!");
+    // Same as before
+    let fields = match input.data {
+        Data::Struct(DataStruct { fields: Fields::Named(fields), .. }) => fields.named,
+        _ => panic!("this derive macro only works on structs with named fields"),
+    };
+
+    //input.attrs.iter().filter(|attr| attr.path.is_ident("qxml")).collect::<Vec<_>>();
+    let declaration_attrs = input.attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("qxml"))
+        .collect::<Vec<_>>();
+    let mut declaration_meta = QXmlDeclarationMeta::default();
+    for attr in declaration_attrs {
+        let to_merge = attr.parse_args_with(QXmlDeclarationMeta::parse)?;
+        declaration_meta.merge(to_merge)?;
+    }
+        // .try_fold(QXmlDeclarationMeta::default(), |meta, attr| {
+        //     let to_merge = attr.parse_args_with(QXmlDeclarationMeta::parse)?;
+        //     meta.merge(&to_merge)?;
+        //     Ok(meta)
+        // })?;
+    
+    let field_metas = fields
+        .into_iter()
+        .map(|f| {
+            let field_attrs = f
+                .attrs
+                .iter()
+                .filter(|attr| attr.path.is_ident("qxml"))
+                .collect::<Vec<_>>();
+            let mut field_meta = QXmlFieldMeta::default();
+            for attr in field_attrs {
+                let to_merge = attr.parse_args_with(QXmlFieldMeta::parse)?;
+                field_meta.merge(to_merge)?;
+            }
+            
+                // .try_fold(QXmlFieldMeta::default(), |meta, attr| {
+                //     let to_merge = attr.parse_args_with(QXmlFieldMeta::parse)?;
+                //     meta.merge(to_merge)
+                // })?;
+            field_meta.identifier = f.ident;
+            Ok(field_meta)
+            })
+        .collect::<syn::Result<Vec<QXmlFieldMeta>>>()?;
+
+    let mut block_meta = QXmlInsideBlockMeta::default();
+    for field_meta in field_metas {
+        let field_ident = match field_meta.identifier {
+            Some(ident) => ident,
+            None => continue
+        };
+        let elem_prefix = match field_meta.element_prefix {
+            Some(elem) => elem,
+            None => continue
+        };
+        block_meta.field_prefix_collection.push((field_ident, elem_prefix.prefix));
+    }
+            
+        //     let visibility = meta.vis.unwrap_or_else(|| parse_quote! { pub });
+        //     let method_name = meta.name.unwrap_or_else(|| f.ident.clone().expect("a named field"));
+        //     let field_name = f.ident;
+        //     let field_ty = f.ty;
+
+        //     Ok(quote! {
+        //         #visibility fn #method_name(&self) -> &#field_ty {
+        //             &self.#field_name
+        //         }
+        //     })
+        // })
+        // .collect::<syn::Result<TokenStream>>()?;
+
+    let st_name = input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics #st_name #ty_generics #where_clause {
+            fn namespace_declarations() -> &'static [(&'static str, &'static str)] {
+                &[("C", "http://asdfasdf"), ("B", "asdf"), ("", "")]
+            }
+
+            fn identifier_prefix_map() -> phf::Map<&'static str, &'static str> {
+                phf_map! {
+                    "foo" => "C", 
+                    "bar" => "B",
+                    "jax" => "B"
+                }
+            }
+        }
+    })
+    // fn identifier_prefix_map -> HashMap<String, String> {
+    //     HashMap::from([("foo", "C"), ("bar", "B"), ("jax", "B")])
+    // }
+}
+
+fn namespace_declarations() -> &'static [(&'static str, &'static str)] {
+    &[("C", "http://asdfasdf"), ("B", "asdf"), ("", "")]
+    //vec![("C", "http://asdfasdf"), ("B", "asdf"), ("", "")]
+}
+
+fn identifier_prefix_map() -> phf::Map<&'static str, &'static str> {
+    phf_map! {
+        "foo" => "C", 
+        "bar" => "B",
+        "jax" => "B"
+    }
+}
+
+fn get_quick_xml_meta() -> &'static QuickXmlItemMeta {
+    &QuickXmlItemMeta {
+        namespace_declarations: &[("C", "http://asdfasdf"), ("B", "asdf"), ("", "")],
+        identifier_prefix_map: phf_map! {
+            "foo" => "C", 
+            "bar" => "B",
+            "jax" => "B"
+        },
+    }
+}
+
+struct QuickXmlItemMeta {
+    namespace_declarations: &'static [(&'static str, &'static str)],
+    identifier_prefix_map: phf::Map<&'static str, &'static str>
+}
+struct ByUnconsumedKeyword {}
+
+impl ByUnconsumedKeyword {
+    fn new() -> Self {
+        ByUnconsumedKeyword {
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Namespace {
+    xmlns_token: kw::xmlns,
+    prefix: Option<Ident>,
+    uri: LitStr
+}
+
+impl Hash for Namespace {
+    fn hash<H>(&self, state: &mut H) where H: Hasher {
+        self.prefix.hash(state);
+    }
+}
+
+impl PartialEq for Namespace {
+    fn eq(&self, other: &Self) -> bool {
+        self.prefix == other.prefix
+    }
+}
+
+impl Eq for Namespace {}
+
+impl Namespace {
+    fn is_default_namespace(&self) -> bool {
+        self.prefix.is_none()
+    }
+}
+
+impl Parse for Namespace {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut prefix: Option<Ident> = None;
+        let xmlns_token: kw::xmlns = input.parse()?;
+        let lookahead = input.lookahead1();
+        if lookahead.peek(Token![:]) {
+            let _: Token![:] = input.parse()?;
+            prefix = Some(input.parse::<Ident>()?);
+        } 
+        let _: Token![=] = input.parse()?;
+        let uri = input.parse()?;
+        Ok(Self {xmlns_token, prefix, uri})
+    }
+}
+#[derive(Default)]
+struct QXmlDeclarationMeta {
+    declared_namespaces_set: HashSet<Namespace>,
+    declared_namespaces: Vec<Namespace>
+}
+
+impl QXmlDeclarationMeta {
+    fn merge(&mut self, other: QXmlDeclarationMeta) -> syn::Result<&mut Self> {
+        for other_namespace in other.declared_namespaces {
+            if let Some(this_namespace) = self.declared_namespaces_set.get(&other_namespace) {
+                if other_namespace.is_default_namespace() {
+                    let mut error = syn::Error::new_spanned(other_namespace.xmlns_token, "duplicate default namespace declaration, first here");
+                    error.combine(syn::Error::new_spanned(this_namespace.xmlns_token, "second here"));
+                    return Err(error);
+                } else {
+                    let mut error = syn::Error::new_spanned(other_namespace.prefix.as_ref().unwrap(), "duplicate namespace declaration, first one here");
+                    error.combine(syn::Error::new_spanned(this_namespace.prefix.as_ref().unwrap(), "second here"));
+                    return Err(error);
+                }
+            }
+            self.declared_namespaces.push(other_namespace.clone());
+            self.declared_namespaces_set.insert(other_namespace.clone());
+        }
+        Ok(self)
+    }
+}
+
+impl Parse for QXmlDeclarationMeta {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut meta = Self::default();
+        loop {
+            if input.is_empty() {
+                return Ok(meta);
+            }
+            let lookahead = input.lookahead1();
+            if lookahead.peek(kw::xmlns) { 
+                
+                let namespace: Namespace = input.parse()?;
+                let declared_namespaces = Vec::from([namespace.clone()]);
+                let declared_namespaces_set = HashSet::from([namespace]);
+                let to_merge = Self { declared_namespaces, declared_namespaces_set };
+                meta.merge(to_merge)?;
+            } else {
+                return Err(lookahead.error());
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ElementPrefix {
+    prefix_token: kw::pre,
+    prefix: Ident,
+}
+
+impl Parse for ElementPrefix {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let prefix_token: kw::pre = input.parse()?;
+        let _: Token![:] = input.parse()?;
+        let prefix: Ident = input.parse()?;
+        Ok(Self { prefix_token, prefix})
+    }
+}
+
+#[derive(Default)]
+struct QXmlFieldMeta {
+    element_prefix: Option<ElementPrefix>,
+    identifier: Option<Ident>
+}
+
+impl QXmlFieldMeta {
+    fn merge(&mut self, other: QXmlFieldMeta) -> syn::Result<&mut Self> {
+        match (self.element_prefix.as_ref(), other.element_prefix) {
+            (None, None) => Ok(self),
+            (Some(_), None) => Ok(self),
+            (None, Some(elem)) => {
+                self.element_prefix = Some(elem);
+                Ok(self)
+            }
+            (Some(this_elem), Some(other_elem)) => {
+                let mut error = syn::Error::new_spanned(this_elem.prefix_token, "redundant prefix argument");
+                error.combine(syn::Error::new_spanned(other_elem.prefix_token, "note: first one here"));
+                Err(error)
+            }
+        }
+    }
+}
+
+impl Parse for QXmlFieldMeta {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut meta = Self::default();
+        loop {
+            if input.is_empty() {
+                return Ok(meta);
+            }
+            let lookahead = input.lookahead1();
+            if lookahead.peek(kw::pre) { 
+                let element_prefix_unopt: ElementPrefix = input.parse()?;
+                let element_prefix = Some(element_prefix_unopt);
+                let to_merge = Self {identifier: None, element_prefix };
+                meta.merge(to_merge)?;
+            } else {
+                return Err(lookahead.error());
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct QXmlInsideBlockMeta {
+    field_prefix_collection: Vec<(Ident, Ident)>
+}

--- a/quick-xml-derived/tests/expand/namespaced_struct.expanded.rs
+++ b/quick-xml-derived/tests/expand/namespaced_struct.expanded.rs
@@ -1,8 +1,38 @@
 extern crate quick_xml_derived;
+use quick_xml_derived::QuickXml;
+use q_meta::QuickXmlMeta;
 #[qxml{xmlns:F = "foorun"
 xmlns:B = "barurn"
 xmlns = "http://this-is-a-default-namespace"}]
 struct Foo {
     #[qxml{pre:B}]
     id: String,
+}
+#[doc(hidden)]
+#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+const _: () = {
+    use phf::phf_map;
+    #[automatically_derived]
+    impl Foo {
+        fn get_quick_xml_meta() -> &'static QuickXmlItemMeta {
+            &QuickXmlItemMeta {
+                namespace_declarations: &[
+                    ("C", "http://asdfasdf"),
+                    ("B", "asdf"),
+                    ("", ""),
+                ],
+                identifier_prefix_map: phf::Map {
+                    key: 12913932095322966823u64,
+                    disps: &[(0u32, 0u32)],
+                    entries: &[("jax", "B"), ("foo", "C"), ("bar", "B")],
+                },
+            }
+        }
+    }
+};
+fn check_foo_has_qxml_meta() {
+    foo = Foo { id: "asdf".to_string() };
+}
+fn has_qxml_meta<T: QuickXmlMeta>(t: T) {
+    t.get_quick_xml_meta();
 }

--- a/quick-xml-derived/tests/expand/namespaced_struct.expanded.rs
+++ b/quick-xml-derived/tests/expand/namespaced_struct.expanded.rs
@@ -1,0 +1,8 @@
+extern crate quick_xml_derived;
+#[qxml{xmlns:F = "foorun"
+xmlns:B = "barurn"
+xmlns = "http://this-is-a-default-namespace"}]
+struct Foo {
+    #[qxml{pre:B}]
+    id: String,
+}

--- a/quick-xml-derived/tests/expand/namespaced_struct.rs
+++ b/quick-xml-derived/tests/expand/namespaced_struct.rs
@@ -1,4 +1,6 @@
 extern crate quick_xml_derived;
+use quick_xml_derived::QuickXml;
+use q_meta::QuickXmlMeta;
 #[derive(QuickXml)]
 #[qxml{
     xmlns:F="foorun"
@@ -8,5 +10,13 @@ extern crate quick_xml_derived;
 struct Foo {
     #[qxml{ pre:B }]
     id: String
+}
+
+fn check_foo_has_qxml_meta() {
+    foo = Foo { id: "asdf".to_string()};
+}
+
+fn has_qxml_meta<T: QuickXmlMeta>(t: T) {
+    t.get_quick_xml_meta();
 }
 

--- a/quick-xml-derived/tests/expand/namespaced_struct.rs
+++ b/quick-xml-derived/tests/expand/namespaced_struct.rs
@@ -1,0 +1,12 @@
+extern crate quick_xml_derived;
+#[derive(QuickXml)]
+#[qxml{
+    xmlns:F="foorun"
+    xmlns:B="barurn"
+    xmlns="http://this-is-a-default-namespace"
+}]
+struct Foo {
+    #[qxml{ pre:B }]
+    id: String
+}
+

--- a/quick-xml-derived/tests/tests.rs
+++ b/quick-xml-derived/tests/tests.rs
@@ -1,6 +1,11 @@
 use macrotest;
-
 #[test]
 pub fn pass() {
     macrotest::expand("tests/expand/*.rs");
+}
+
+#[test]
+fn try_build_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/try_build_tests/example.rs");
 }

--- a/quick-xml-derived/tests/tests.rs
+++ b/quick-xml-derived/tests/tests.rs
@@ -1,0 +1,6 @@
+use macrotest;
+
+#[test]
+pub fn pass() {
+    macrotest::expand("tests/expand/*.rs");
+}

--- a/quick-xml-derived/tests/try_build_tests/example.rs
+++ b/quick-xml-derived/tests/try_build_tests/example.rs
@@ -1,0 +1,20 @@
+use quick_xml_derived::QuickXml;
+use q_meta::QuickXmlItemMeta;
+
+#[derive(QuickXml)]
+#[qxml{
+    xmlns:F="foorun"
+    xmlns:B="barurn"
+    xmlns="http://this-is-a-default-namespace"
+}]
+struct Foo {
+    #[qxml{ pre:B }]
+    id: String
+}
+
+fn main() {
+    let foo = Foo{
+        id: "asdf".to_string()
+    };
+    println!("{:?}", Foo::get_quick_xml_meta());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
     cfg_attr(doc, doc = ::document_features::document_features!())
 )]
 #![forbid(unsafe_code)]
-#![deny(missing_docs)]
+#![allow(missing_docs)]
 #![recursion_limit = "1024"]
 // Enable feature requirements in the docs from 1.57
 // See https://stackoverflow.com/questions/61417452

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -2,6 +2,7 @@
 
 mod var;
 
+
 use self::var::{Map, Seq, Struct, Tuple};
 use crate::{
     de::PRIMITIVE_PREFIX,

--- a/src/se/var.rs
+++ b/src/se/var.rs
@@ -4,11 +4,15 @@ use crate::{
     events::{BytesEnd, BytesStart, Event},
     se::Serializer,
     writer::Writer,
+    se::QuickXmlMetaNode,
 };
 use serde::ser::{self, Serialize};
 use serde::Serializer as _;
 use std::io::Write;
-
+use q_meta::{QuickXmlMeta};
+use std::any::Any;
+use std::string::String;
+use std::collections::HashMap;
 /// An implementation of `SerializeMap` for serializing to XML.
 pub struct Map<'r, 'w, W>
 where
@@ -99,13 +103,24 @@ where
     W: 'w + Write,
 {
     /// Create a new `Struct`
-    pub fn new(parent: &'w mut Serializer<'r, W>, name: &'r str) -> Self {
-        Struct {
+    pub fn new(parent: &'w mut Serializer<'r, W>, name: &'r str, namespace_declarations: Option<&'static [(&'static str, &'static str)]>) -> Self {
+        let mut to_return = Struct {
             parent,
             attrs: BytesStart::new(name),
             children: Vec::new(),
             buffer: Vec::new(),
+        };
+        if let Some(decls) = namespace_declarations {
+            for declaration in decls {
+                let namespace_with_colon_or_default= match declaration.0 {
+                    "" => "".to_string(),
+                    ns => format!(":{}", ns.to_string())
+                };
+                let fmt_decl = format!("xmlns{}", namespace_with_colon_or_default);
+                to_return.attrs.push_attribute((&fmt_decl[..], declaration.1));
+            }
         }
+        to_return
     }
 }
 
@@ -123,14 +138,34 @@ where
     ) -> Result<(), DeError> {
         // TODO: Inherit indentation state from self.parent.writer
         let writer = Writer::new(&mut self.buffer);
+        let pointer = value;
+        let address_as_str = format!("{pointer:p}");
+        eprintln!("POP {address_as_str} {key}");
+        let qxml_meta_map: &mut HashMap<String, Vec<QuickXmlMetaNode>> = self.parent.obj_to_ser_pointer_vs_meta_map;
+        let node = qxml_meta_map
+            .get_mut(&address_as_str)
+            .ok_or(DeError::Custom("TODO1".to_string()))?
+            .pop()
+            .ok_or(DeError::Custom("TODO2".to_string()))?;
+        let opt_chain = || -> Option<String> {
+            let prefix = node
+            .parent_meta?
+            .identifier_prefix_map.get(node.ident_in_parent?)?;
+            Some(format!("{}:", prefix))
+        };
+        eprintln!("PEEK {:?}", node);
+        let prefix_with_colon = opt_chain();
+        //eprintln!("PREFIX {:?}", prefix_with_colon);
+
         if key.starts_with(UNFLATTEN_PREFIX) {
             let key = &key[UNFLATTEN_PREFIX.len()..];
-            let mut serializer = Serializer::with_root(writer, Some(key));
+            let mut serializer = Serializer::with_root(writer, Some(key), qxml_meta_map, self.parent.root_obj_addr, Some(node.meta.namespace_declarations));
             serializer.serialize_newtype_struct(key, value)?;
             self.children.append(&mut self.buffer);
         } else {
-            let mut serializer = Serializer::with_root(writer, Some(key));
+            let mut serializer = Serializer::with_root(writer, Some(key), qxml_meta_map, self.parent.root_obj_addr, Some(node.meta.namespace_declarations));
             value.serialize(&mut serializer)?;
+            let q_name = format!("{}{}", prefix_with_colon.unwrap_or_else(|| "".to_string()), key);
 
             if !self.buffer.is_empty() {
                 if self.buffer[0] == b'<' || key == INNER_VALUE {
@@ -138,7 +173,7 @@ where
                     self.children.append(&mut self.buffer);
                 } else {
                     self.attrs
-                        .push_attribute((key.as_bytes(), self.buffer.as_ref()));
+                        .push_attribute((q_name.as_bytes(), self.buffer.as_ref()));
                     self.buffer.clear();
                 }
             }

--- a/tests/serde-namespace-se.rs
+++ b/tests/serde-namespace-se.rs
@@ -1,0 +1,78 @@
+use quick_xml::se::to_string;
+use quick_xml_derived::QuickXml;
+use regex::Regex;
+use serde::Serialize;
+use std::borrow::Cow;
+
+use pretty_assertions::assert_eq;
+
+#[derive(QuickXml, Serialize)]
+#[serde(rename = "classroom")]
+#[qxml{
+    xmlns:B="hello"
+    xmlns:C="asdfasdfasdf"
+    xmlns="http://google.com"
+}]
+struct Classroom {
+    #[qxml{ pre:B }]
+    pub students: Students,
+    #[qxml{ pre:B }]
+    pub number: String,
+    pub adviser: Person,
+}
+
+#[derive(QuickXml, Serialize)]
+#[qxml{
+    xmlns="http://reddit.com"
+}]
+struct Students {
+    //#[serde(rename = "person")]
+    #[qxml{ pre:B }]
+    pub persons: Vec<Person>,
+}
+
+#[derive(QuickXml, Serialize)]
+struct Person {
+    #[qxml{ pre:B }]
+    pub name: String,
+    pub age: u32,
+}
+
+#[test]
+fn struct_test() {
+    let s1 = Person {
+        name: "sherlock".to_string(),
+        age: 20,
+    };
+    let s2 = Person {
+        name: "harry".to_string(),
+        age: 19,
+    };
+    let t = Person {
+        name: "albus".to_string(),
+        age: 88,
+    };
+    let doc = Classroom {
+        students: Students {
+            persons: vec![s1, s2],
+        },
+        number: "3-1".to_string(),
+        adviser: t,
+    };
+    let xml = quick_xml::se::to_string_with_qxml_meta(&doc).unwrap();
+    let str = r#"<classroom xmlns:B="hello" xmlns:C="asdfasdfasdf" xmlns="http://google.com" B:number="3-1">
+                   <students xmlns="http://reddit.com">
+                      <persons B:name="sherlock" age="20"/>
+                      <persons B:name="harry" age="19"/>
+                   </students>
+                   <adviser B:name="albus" age="88"/>
+                 </classroom>"#;
+    assert_eq!(xml, inline(str));
+
+}
+
+fn inline(str: &str) -> Cow<str> {
+    let regex = Regex::new(r">\s+<").unwrap();
+    regex.replace_all(str, "><")
+}
+


### PR DESCRIPTION
I'm interested in forwarding the design / implementing a solution to the problem of serializing namespaces in Serde.

## Proposal from issue #218
The current proposal is to implement a 'namespace' attribute macro where the first argument is the prefix and the second argument is the namespace. Additionally, the proposal indicates that any child field will automatically take the defined prefix unless the field is shadowed by an additional namespace macro + serde flatten helper attribute.

Input: 
```rust
#[derive(Serialize, Deserialize)]
#[namespace(F,foourn)]
struct Foo {
  id: String,
  #[serde(flatten)]
  #[namespace(B,barurn)]
  bar: Bar
}

#[derive(Serialize, Deserialize)]
struct Bar {
  name: String,
  desc: String
}
```

output: 
```xml
<F:foo xmlns:B="foourn" xmlns:F="barurn">
      <F:id>123</F:id>
      <B:name>asdf</B:name>
      <B:desc>foobar </B:desc>
</F:foo>
```

### Potential downside
One downside I see with #218 is that the second xmlns statement will have to be 'hoisted' up into the foo tag. Additionally, multiple namespaces will **always** have to be used with the serde-flatten macro. The downside of using the flatten-macro is that quick-xml doesn't allow attributes to be directly defined (as currently implemented) in the parent container. As seen in the example above, the "id" field gets serialized into `<id>123</id>` and not `id="123"`. Thus, it doesn't look like it would be possible for id to be an xml attribute, which could be limiting for serializing xml documents.

## Alternative idea
Despite the proposal above, I want to explore a little bit on some other design ideas and get feedback on it. Playing around a little bit with attribute macros, I was able to get the following to process using `syn::parse2`. I haven't gotten it to fully serialize into xml quite yet, but I can indicate the expected xml.

### The proposal
Create a new derive macro called `QuickXml` with two helper attributes `xmlns` and `xmlpre`. What Serde does is that the `Serialize` and `Deserialize` macros are derive macros, but they list `serde` as a helper attribute. Thus, anytime you see `#[serde(...)]`, it isn't actually a separate macro which expands. Instead, the `Serialize` and `Deserialize` macros will be fed the location and parameters to the `#[serde(...)]` statements and use that for their expansion.

In a similar vein, we could have `QuickXml` be the derive macro which runs, but is fed `xmlns` and `xmlpre` helper attributes to expand-out namespace and prefix information for the struct. In contrast to the above proposal, there won't be a need for 'hoisting up' additional namespaces into the containing tag. Additionally, without being forced to use `serde(flatten)`, it's possible to both have multiple namespaces for a single tag, and, define attributes and elements at the same time for the tag. This would give a good amount of flexibility to the programmer for representing xml files as serde structs.

Another point is that `xmlns` and `xlmpre` would be one-to-one with the xml document in contrast to the above proposal. That is, as the programmer is reading through an example xml output which they would like to represent in rust using quick-xml and serde, everytime they see an 'xmlns:prefix=" and "prefix:attr-or-element-name" statement in the xml document, they would put an `#[xmlns:prefix="..."]` and `#[xmlpre:prefix]attr_or_element_name: type` into the rust serde struct. The downside is of course typing 'xmlpre' for each field in the struct and struct name which has a prefix on it. However, one-to-oneness makes it easier to visually verify the correctness between an example xml document and the rust serde struct the programmer is trying to make.

Finally, the format `xmlns:prefix="namespace"` or `xmlns="default-namespace"` used inside the attribute helper might be somewhat non-standard. However, this format allows the programmer to directly copy-and-paste xmlns statements from an example xml document, which provides a usability advantage.

### Example
Input: 
```rust
#[derive(Serialize, Deserialize, QuickXml)]
#[xmlns:F="foourn"]
#[xmlns:B="barurn"]
#[xmlns="http://this-is-a-default-namespace"]
#[xmlpre:B]
#[serde(rename = foo)]
struct Foo {

    // attributes

    #[xmlpre:F]
    id: String,

    mar: String

    // elements

    #[xmlpre:F]
    #[serde(rename = "$unflatten=element")]
    element: String,

    #[xmlpre:B]
    bar: Bar,
}

#[derive(Serialize, Deserialize, QuickXml)]
#[xmlns="http://this-is-another-default-namespace-shadowing-the-previous"]
#[serde(rename = "bar")]
struct Bar {

    // attributes

    #[xmlpre:F]
    name: String,

    #[xmlpre:F]
    desc: String,

    #[serde(rename = "default-namespace-field"]
    default_namespace_field: String

    // elements

    #[serde(rename = "$value")]
    pub body: String,
}
```
Intended output:
```xml
<B:foo xmlns:F="foourn" xmlns:B="barurn" xmlns="http://this-is-a-default-namespace" F:id="123" mar="asdf">
    <element>this is an element</element>
    <B:bar xmlns="http://this-is-another-default-namespace-shadowing-the-previous" F:name="a name" F:desc="asdf" default-namespace-field="another filled field">this is a value</B:bar>
</B:foo>
```

### Remaining questions
1. One possible issue from this proposal is multiply-defined prefixes for fields. That is, if a parent struct Parent has a field `#[xmlpre:A]child: Child`, but, Child is defined by `#[xmlpre:B] struct Child`, what should the outcome be?