### PR TITLE
Fix: the `serialize` feature should also enable `serde/derive`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ escape-html = []
 overlapped-lists = []
 
 ## Enables support for [`serde`] serialization and deserialization
-serialize = ["serde"]
+serialize = ["serde/derive"]
 
 [package.metadata.docs.rs]
 # document all features


### PR DESCRIPTION
In master/last release `serialize` feature implicitly depends on `serde/derive`.

Just add `resolve = "2"` to `Cargo.toml` to see the following:
```
error[E0433]: failed to resolve: could not find `Deserialize` in `serde`
  --> src/name.rs:19:45
   |
19 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
   |                                             ^^^^^^^^^^^ could not find `Deserialize` in `serde`

error[E0433]: failed to resolve: could not find `Serialize` in `serde`
  --> src/name.rs:19:65
   |
19 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
   |                                                                 ^^^^^^^^^ could not find `Serialize` in `serde`

error[E0433]: failed to resolve: could not find `Deserialize` in `serde`
   --> src/name.rs:136:45
    |
136 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
    |                                             ^^^^^^^^^^^ could not find `Deserialize` in `serde`

error[E0433]: failed to resolve: could not find `Serialize` in `serde`
   --> src/name.rs:136:65
    |
136 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
    |                                                                 ^^^^^^^^^ could not find `Serialize` in `serde`

error[E0433]: failed to resolve: could not find `Deserialize` in `serde`
   --> src/name.rs:186:45
    |
186 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
    |                                             ^^^^^^^^^^^ could not find `Deserialize` in `serde`

error[E0433]: failed to resolve: could not find `Serialize` in `serde`
   --> src/name.rs:186:65
    |
186 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
    |                                                                 ^^^^^^^^^ could not find `Serialize` in `serde`

error[E0433]: failed to resolve: could not find `Deserialize` in `serde`
   --> src/name.rs:228:45
    |
228 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
    |                                             ^^^^^^^^^^^ could not find `Deserialize` in `serde`

error[E0433]: failed to resolve: could not find `Serialize` in `serde`
   --> src/name.rs:228:65
    |
228 | #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
    |                                                                 ^^^^^^^^^ could not find `Serialize` in `serde`
```