### PR TITLE
Update versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ license = "MIT"
 document-features = { version = "0.2", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }
-tokio = { version = "1.20", optional = true, default-features = false, features = ["io-util"] }
+tokio = { version = "1.21", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.5"
 
 [dev-dependencies]
-criterion = "0.3"
-pretty_assertions = "1.2"
+criterion = "0.4"
+pretty_assertions = "1.3"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde-value = "0.7"
-tokio = { version = "1.20", default-features = false, features = ["macros", "rt"] }
+tokio = { version = "1.21", default-features = false, features = ["macros", "rt"] }
 tokio-test = "0.4"
 
 [lib]


### PR DESCRIPTION
- [tokio](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.21.0)
- [pretty_assertions](https://github.com/rust-pretty-assertions/rust-pretty-assertions/compare/v1.2.1...v1.3.0) -- removes dependency from unmaintained `ansi_term` crate
- [criterion](https://github.com/bheisler/criterion.rs/blob/master/CHANGELOG.md)