### PR TITLE
Implement read_to_end_to_string() to return the text content between two tags as a string

### DIFF
--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -248,6 +248,55 @@ impl<'b, R: BufRead> XmlSource<'b, &'b mut Vec<u8>> for R {
     impl_buffered_source!();
 }
 
+use std::io::{Read};
+struct StoredReader<R> {
+    inner: R,
+    initial_offset: usize,
+    stored: Vec<u8>
+}
+
+impl<R: Read> Read for StoredReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let result = self.inner.read(buf);
+        if let Ok(size) = &result {
+            self.stored.extend_from_slice(&buf[0..*size]);
+        }
+        result
+    }
+}
+impl<R> StoredReader<R> {
+    fn new(inner: R, initial_offset: usize) -> Self {
+        Self {
+            inner, initial_offset, stored: Vec::new()
+        }
+    }
+    fn get_stored_value(mut self, start: usize, end: usize) -> Vec<u8> {
+        // Pray that the start is 0 so we don't have to allocate
+        let start = start - self.initial_offset;
+        let end = end - self.initial_offset;
+
+        if start == 0 {
+            self.stored.truncate(end);
+            self.stored
+        } else {
+            unimplemented!()
+        }
+    }
+}
+impl<R: BufRead> BufRead for StoredReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        let result = self.inner.fill_buf();
+        if let Ok(x) = result {
+            self.stored.extend_from_slice(x);
+        };
+        result
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt)
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// This is an implementation for reading from a [`BufRead`] as underlying byte stream.
@@ -392,6 +441,21 @@ impl<R: BufRead> Reader<R> {
         Ok(read_to_end!(self, end, buf, read_event_impl, {
             buf.clear();
         }))
+    }
+
+    /// sample
+    pub fn read_text_to_string(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Vec<u8>> {
+        // Initialize a new XMLParser
+        let bp = self.buffer_position();
+        let reader = StoredReader ::new(
+        &mut self.reader, bp
+        );
+        let mut temp_reader: Reader<StoredReader<&mut R>> = Reader {
+            reader, parser: self.parser.clone()
+        };
+
+        let range = temp_reader.read_to_end_into(end, buf)?;
+        Ok(temp_reader.into_inner().get_stored_value(range.start, range.end))
     }
 }
 

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -398,7 +398,7 @@ impl<R: BufRead> Reader<R> {
     }
 
     /// Same as `read_to_end_into` but returns all the bytes read instead of the indices.
-    pub fn read_text_to_string(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Vec<u8>> {
+    pub fn read_to_end_to_string(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Vec<u8>> {
         read_to_string_impl(self.buffer_position(), &mut self.reader, self.parser.clone(), end, buf)
     }
 }

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -528,10 +528,17 @@ impl<R: BufRead> NsReader<R> {
     }
 
     /// Same as `read_to_end_into` but returns all the bytes read instead of the indices.
-    pub fn read_to_end_to_string(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Vec<u8>> {
-        let parser = self.parser.clone();
+    pub fn read_to_end_to_string<'b>(
+        &mut self,
+        end: QName,
+        buf: &mut Vec<u8>,
+        output_buf: &'b mut Vec<u8>,
+    ) -> Result<&'b str> {
+        let parser = std::mem::take(&mut self.reader.parser);
         let bp = self.buffer_position();
-        read_to_string_impl(bp,  self.reader.get_mut(), parser, end, buf)
+        let (result, parser) = read_to_string_impl(bp, self.reader.get_mut(), parser, end, buf, output_buf);
+        self.reader.parser = parser;
+        result
     }
 }
 

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -528,7 +528,7 @@ impl<R: BufRead> NsReader<R> {
     }
 
     /// Same as `read_to_end_into` but returns all the bytes read instead of the indices.
-    pub fn read_text_to_string(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Vec<u8>> {
+    pub fn read_to_end_to_string(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Vec<u8>> {
         let parser = self.parser.clone();
         let bp = self.buffer_position();
         read_to_string_impl(bp,  self.reader.get_mut(), parser, end, buf)

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use crate::errors::Result;
 use crate::events::Event;
 use crate::name::{LocalName, NamespaceResolver, QName, ResolveResult};
-use crate::reader::{Reader, Span, XmlSource};
+use crate::reader::{read_to_string_impl, Reader, Span, XmlSource};
 
 /// A low level encoding-agnostic XML event reader that performs namespace resolution.
 ///
@@ -525,6 +525,13 @@ impl<R: BufRead> NsReader<R> {
         // According to the https://www.w3.org/TR/xml11/#dt-etag, end name should
         // match literally the start name. See `Self::check_end_names` documentation
         self.reader.read_to_end_into(end, buf)
+    }
+
+    /// Same as `read_to_end_into` but returns all the bytes read instead of the indices.
+    pub fn read_text_to_string(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Vec<u8>> {
+        let parser = self.parser.clone();
+        let bp = self.buffer_position();
+        read_to_string_impl(bp,  self.reader.get_mut(), parser, end, buf)
     }
 }
 

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -536,7 +536,8 @@ impl<R: BufRead> NsReader<R> {
     ) -> Result<&'b str> {
         let parser = std::mem::take(&mut self.reader.parser);
         let bp = self.buffer_position();
-        let (result, parser) = read_to_string_impl(bp, self.reader.get_mut(), parser, end, buf, output_buf);
+        let (result, parser) =
+            read_to_string_impl(bp, self.reader.get_mut(), parser, end, buf, output_buf);
         self.reader.parser = parser;
         result
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -36,7 +36,7 @@ fn test_read_to_string() {
         let mut buf = Vec::new();
         match reader.read_event_into(&mut buf).unwrap() {
             Start(x) if x.local_name().as_ref() == b"sheetData" => {
-                assert_eq!(reader.read_text_to_string(x.name(), &mut Vec::new()).unwrap().as_slice(), b"<row><v>5</v></row><row><v>3</v></row>");
+                assert_eq!(reader.read_to_end_to_string(x.name(), &mut Vec::new()).unwrap().as_slice(), b"<row><v>5</v></row><row><v>3</v></row>");
                 return;
             }
             _ => {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -28,15 +28,21 @@ fn test_sample() {
     println!("{}", count);
 }
 
-
 #[test]
 fn test_read_to_string() {
-    let mut reader = Reader::from_str("<sheetData><row><v>5</v></row><row><v>3</v></row></sheetData>");
+    let mut reader =
+        Reader::from_str("<sheetData><row><v>5</v></row><row><v>3</v></row></sheetData>");
     loop {
         let mut buf = Vec::new();
         match reader.read_event_into(&mut buf).unwrap() {
             Start(x) if x.local_name().as_ref() == b"sheetData" => {
-                assert_eq!(reader.read_to_end_to_string(x.name(), &mut Vec::new()).unwrap().as_slice(), b"<row><v>5</v></row><row><v>3</v></row>");
+                let mut buf = Vec::new();
+                assert_eq!(
+                    reader
+                        .read_text_into(x.name(), &mut Vec::new(), &mut buf)
+                        .unwrap(),
+                    "<row><v>5</v></row><row><v>3</v></row>"
+                );
                 return;
             }
             _ => {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,6 +4,8 @@ use quick_xml::name::QName;
 use quick_xml::reader::Reader;
 use quick_xml::Error;
 use std::borrow::Cow;
+use std::fs::File;
+use std::io::BufReader;
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
@@ -26,6 +28,21 @@ fn test_sample() {
     println!("{}", count);
 }
 
+
+#[test]
+fn test_read_to_string() {
+    let mut reader = Reader::from_str("<sheetData><row><v>5</v></row><row><v>3</v></row></sheetData>");
+    loop {
+        let mut buf = Vec::new();
+        match reader.read_event_into(&mut buf).unwrap() {
+            Start(x) if x.local_name().as_ref() == b"sheetData" => {
+                assert_eq!(reader.read_text_to_string(x.name(), &mut Vec::new()).unwrap().as_slice(), b"<row><v>5</v></row><row><v>3</v></row>");
+                return;
+            }
+            _ => {}
+        }
+    }
+}
 #[test]
 fn test_attributes_empty() {
     let src = "<a att1='a' att2='b'/>";


### PR DESCRIPTION
Implements the feature request from #483 . 