### PR TITLE
Exclude files from Cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,12 @@ bench = false
 [[bench]]
 name = "microbenches"
 harness = false
+path = "benches/microbenches.rs"
 
 [[bench]]
 name = "macrobenches"
 harness = false
+path = "benches/macrobenches.rs"
 
 [features]
 default = []
@@ -175,27 +177,34 @@ rustdoc-args = ["--cfg", "docs_rs"]
 [[test]]
 name = "encodings"
 required-features = ["encoding"]
+path = "tests/encodings.rs"
 
 [[test]]
 name = "serde_attrs"
 required-features = ["serialize"]
+path = "tests/serde_attrs.rs"
 
 [[test]]
 name = "serde_roundtrip"
 required-features = ["serialize"]
+path = "tests/serde_roundtrip.rs"
 
 [[test]]
 name = "serde-de"
 required-features = ["serialize"]
+path = "tests/serde-de.rs"
 
 [[test]]
 name = "serde-se"
 required-features = ["serialize"]
+path = "tests/serde-se.rs"
 
 [[test]]
 name = "serde-migrated"
 required-features = ["serialize"]
+path = "tests/serde-migrated.rs"
 
 [[test]]
 name = "async-tokio"
 required-features = ["async-tokio"]
+path = "tests/async-tokio.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["xml", "serde", "parser", "writer", "html"]
 categories = ["asynchronous", "encoding", "parsing", "parser-implementations"]
 license = "MIT"
 rust-version = "1.46"
+include = ["src/*", "LICENSE-MIT.md", "README.md"]
 
 [dependencies]
 document-features = { version = "0.2", optional = true }


### PR DESCRIPTION
Closes #488 

This excludes unnecessary files from the package that is published to crates.io. This reduces the size of the package to less than half of what it was before by excluding some of the larger files, especially the ones in the `tests` folder.

The files that are being included in the package as a result of this PR are:
- `src/*`
- `LICENSE-MIT.md`
- `README.md`

Some other files I considered but did not include are:
- `examples/*` (these can be found online, and `rustdoc` is still available offline)
- `Changelog.md` (this file is rather large and may be better suited as an online resource)

To ensure that `cargo publish` is unaffected by the exclusion of unit tests and benchmarks, paths have been added explicitly to those items in the `Cargo.toml` file. [See this thread for more information.](https://users.rust-lang.org/t/cargo-publish-with-excluded-benchmark-fails-validation/53444)