### PR TITLE
Fix clippy issues

### DIFF
--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -40,8 +40,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     );
                 }
             }
-            Ok(Event::Start(ref e)) => match e.name().as_ref() {
-                b"test" => {
+            Ok(Event::Start(ref e)) => {
+                if let b"test" = e.name().as_ref() {
                     let attributes = e
                         .attributes()
                         .map(|a| {
@@ -55,8 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .collect::<Vec<_>>();
                     println!("attributes values: {:?}", attributes);
                 }
-                _ => (),
-            },
+            }
             Ok(Event::Text(ref e)) => {
                 println!(
                     "text value: {}",

--- a/examples/nested_readers.rs
+++ b/examples/nested_readers.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), quick_xml::Error> {
     let mut found_tables = Vec::new();
     loop {
         match reader.read_event_into(&mut buf)? {
-            Event::Start(element) => match element.name().as_ref() {
-                b"w:tbl" => {
+            Event::Start(element) => {
+                if let b"w:tbl" = element.name().as_ref() {
                     count += 1;
                     let mut stats = TableStat {
                         index: count,
@@ -57,8 +57,7 @@ fn main() -> Result<(), quick_xml::Error> {
                         }
                     }
                 }
-                _ => {}
-            },
+            }
             Event::Eof => break,
             _ => {}
         }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2372,6 +2372,7 @@ where
 
 impl<'de> Deserializer<'de, SliceReader<'de>> {
     /// Create new deserializer that will borrow data from the specified string
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &'de str) -> Self {
         let mut reader = Reader::from_str(s);
         reader

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -531,6 +531,7 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
     }
 
     /// Creates a deserializer from a part of value at specified range
+    #[allow(clippy::ptr_arg)]
     pub fn from_part(
         value: &'a Cow<'de, [u8]>,
         range: Range<usize>,

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -181,8 +181,7 @@ where
 
                 // search for character correctness
                 let pat = &raw[start + 1..end];
-                if pat.starts_with('#') {
-                    let entity = &pat[1..]; // starts after the #
+                if let Some(entity) = pat.strip_prefix('#') {
                     let codepoint = parse_number(entity, start..end)?;
                     unescaped.push_str(codepoint.encode_utf8(&mut [0u8; 4]));
                 } else if let Some(value) = named_entity(pat) {
@@ -1691,8 +1690,8 @@ fn named_entity(name: &str) -> Option<&str> {
 }
 
 fn parse_number(bytes: &str, range: Range<usize>) -> Result<char, EscapeError> {
-    let code = if bytes.starts_with('x') {
-        parse_hexadecimal(&bytes[1..])
+    let code = if let Some(hex_digits) = bytes.strip_prefix('x') {
+        parse_hexadecimal(hex_digits)
     } else {
         parse_decimal(bytes)
     }?;

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -19,7 +19,7 @@ use std::{borrow::Cow, ops::Range};
 ///
 /// [`unescape_value`]: Self::unescape_value
 /// [`decode_and_unescape_value`]: Self::decode_and_unescape_value
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Attribute<'a> {
     /// The key to uniquely define the attribute.
     ///
@@ -537,6 +537,7 @@ impl IterState {
 
     /// Skip all characters up to first space symbol or end-of-input
     #[inline]
+    #[allow(clippy::manual_map)]
     fn skip_value(&self, slice: &[u8], offset: usize) -> Option<usize> {
         let mut iter = (offset..).zip(slice[offset..].iter());
 
@@ -776,7 +777,7 @@ impl IterState {
             None => {
                 // Because we reach end-of-input, stop iteration on next call
                 self.state = State::Done;
-                return Some(Err(AttrError::ExpectedQuote(slice.len(), quote)));
+                Some(Err(AttrError::ExpectedQuote(slice.len(), quote)))
             }
         }
     }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -119,7 +119,7 @@ impl<'a> BytesStart<'a> {
     /// Converts the event into an owned event without taking ownership of Event
     pub fn to_owned(&self) -> BytesStart<'static> {
         BytesStart {
-            buf: Cow::Owned(self.buf.to_owned().into()),
+            buf: Cow::Owned(self.buf.clone().into_owned()),
             name_len: self.name_len,
         }
     }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -802,7 +802,7 @@ impl BangType {
         None
     }
     #[inline]
-    fn to_err(self) -> Error {
+    fn to_err(&self) -> Error {
         let bang_str = match self {
             Self::CData => "CData",
             Self::Comment => "Comment",
@@ -849,10 +849,7 @@ impl ReadElementState {
 /// A function to check whether the byte is a whitespace (blank, new line, carriage return or tab)
 #[inline]
 pub(crate) fn is_whitespace(b: u8) -> bool {
-    match b {
-        b' ' | b'\r' | b'\n' | b'\t' => true,
-        _ => false,
-    }
+    matches!(b, b' ' | b'\r' | b'\n' | b'\t')
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -538,6 +538,7 @@ impl NsReader<BufReader<File>> {
 impl<'i> NsReader<&'i [u8]> {
     /// Creates an XML reader from a string slice.
     #[inline]
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &'i str) -> Self {
         Self::new(Reader::from_str(s))
     }

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -21,6 +21,7 @@ use memchr;
 /// itself can be used to borrow from.
 impl<'a> Reader<&'a [u8]> {
     /// Creates an XML reader from a string slice.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &'a str) -> Self {
         // Rust strings are guaranteed to be UTF-8, so lock the encoding
         #[cfg(feature = "encoding")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,11 +6,12 @@ use serde::de::{Deserialize, Deserializer, Error, Visitor};
 #[cfg(feature = "serialize")]
 use serde::ser::{Serialize, Serializer};
 
+#[allow(clippy::ptr_arg)]
 pub fn write_cow_string(f: &mut Formatter, cow_string: &Cow<[u8]>) -> fmt::Result {
     match cow_string {
         Cow::Owned(s) => {
             write!(f, "Owned(")?;
-            write_byte_string(f, &s)?;
+            write_byte_string(f, s)?;
         }
         Cow::Borrowed(s) => {
             write!(f, "Borrowed(")?;

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -433,7 +433,7 @@ fn test_bytes(input: &[u8], output: &[u8], trim: bool) {
                 Ok(c) => format!("Characters({})", &c),
                 Err(err) => format!("FailedUnescape({:?}; {})", e.as_ref(), err),
             },
-            Ok((_, Event::Eof)) => format!("EndDocument"),
+            Ok((_, Event::Eof)) => "EndDocument".to_string(),
             Err(e) => format!("Error: {}", e),
         };
         if let Some((n, spec)) = spec_lines.next() {


### PR DESCRIPTION
This PR fixes a few issues identified via `cargo clippy --all-features`. I interspersed a few `#[allow(clippy::...)]` bits where it seemed like readability was more important than the changes Clippy was suggesting or where performance might be affected (notably cases where `&Cow<>` is taken as a parameter instead of `Cow<>`, seemingly intentionally).

Might hold off on this one until the [serialization PR (#490)](https://github.com/tafia/quick-xml/pull/490) lands; I can fix the conflicts that will result afterward.