### PR TITLE
simple example with sub-tree reading in separate function

### DIFF
--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -14,17 +14,17 @@ const XML: &str = r#"
   </DefaultSettings>  
   <Localization>
     <Translation Tag="HELLO" Language="ja">
-        <Text>こんにちは</Text>
+      <Text>こんにちは</Text>
     </Translation>
     <Translation Tag="BYE" Language="ja">
-        <Text>さようなら</Text>
+      <Text>さようなら</Text>
     </Translation>
-     <Translation Tag="HELLO" Language="es">
-         <Text>Hola</Text>
-     </Translation>
-     <Translation Tag="BYE" Language="es">
-         <Text>Adiós</Text>
-     </Translation>
+    <Translation Tag="HELLO" Language="es">
+      <Text>Hola</Text>
+    </Translation>
+    <Translation Tag="BYE" Language="es">
+      <Text>Adiós</Text>
+    </Translation>
   </Localization>
 "#;
 
@@ -58,7 +58,7 @@ impl Translation {
         match event {
             Event::Text(ref e) => {
                 text = e.unescape()?;
-                println!("text node content: {}", text);
+                dbg!("text node content: {}", &text);
             }
             _ => (),
         }

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -45,7 +45,7 @@ impl Translation {
         let mut lang = Cow::Borrowed("");
         // let (tag, lang) =
         for attr_result in element.attributes() {
-            let a = attr_result.unwrap();
+            let a = attr_result?;
             match a.key.as_ref() {
                 b"Language" => lang = a.unescape_value()?,
                 b"Tag" => tag = a.unescape_value()?,

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -47,8 +47,8 @@ impl Translation {
         for attr_result in element.attributes() {
             let a = attr_result?;
             match a.key.as_ref() {
-                b"Language" => lang = a.unescape_value()?,
-                b"Tag" => tag = a.unescape_value()?,
+                b"Language" => lang = a.decode_and_unescape_value(reader)?,
+                b"Tag" => tag = a.decode_and_unescape_value(reader)?,
                 _ => (),
             }
         }
@@ -58,6 +58,7 @@ impl Translation {
         if let Event::Start(ref e) = event {
             let name = e.name();
             if name == QName(b"Text") {
+                // note: `read_text` does not support content as CDATA
                 let text_content = reader.read_text(e.name())?;
                 Ok(Translation {
                     tag: tag.into(),

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -1,0 +1,115 @@
+// example that separates logic for reading different top-level nodes of xml tree
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::reader::Reader;
+use std::collections::HashMap;
+use std::str;
+
+// Code doesn't work if DefaultSettings node is constructed like this:
+//   <DefaultSettings Language="es" Greeting="HELLO"/>
+
+const XML: &str = r#"
+<?xml version="1.0" encoding="utf-8"?>
+  <DefaultSettings Language="es" Greeting="HELLO">
+  </DefaultSettings>  
+  <Localization>
+    <Translation Tag="HELLO" Language="ja">
+        <Text>こんにちは</Text>
+    </Translation>
+    <Translation Tag="BYE" Language="ja">
+        <Text>さようなら</Text>
+    </Translation>
+     <Translation Tag="HELLO" Language="es">
+         <Text>Hola</Text>
+     </Translation>
+     <Translation Tag="BYE" Language="es">
+         <Text>Adiós</Text>
+     </Translation>
+  </Localization>
+"#;
+
+#[derive(Debug)]
+struct Translation {
+    tag: String,
+    lang: String,
+    text: String,
+}
+
+impl Translation {
+    fn new_from_element(
+        reader: &mut Reader<&[u8]>,
+        element: BytesStart,
+    ) -> Result<Translation, quick_xml::Error> {
+        use std::borrow::Cow;
+        let mut tag = Cow::Borrowed("");
+        let mut lang = Cow::Borrowed("");
+        // let (tag, lang) =
+        for attr_result in element.attributes() {
+            let a = attr_result.unwrap();
+            match a.key.as_ref() {
+                b"Language" => lang = a.unescape_value()?,
+                b"Tag" => tag = a.unescape_value()?,
+                _ => (),
+            }
+        }
+        let mut text = Cow::Borrowed("");
+        let mut element_buf = Vec::new();
+        let event = reader.read_event_into(&mut element_buf)?;
+        match event {
+            Event::Text(ref e) => {
+                text = str::from_utf8(e.as_ref())?.into();
+                println!("text node content: {}", text);
+            }
+            _ => (),
+        }
+
+        Ok(Translation {
+            tag: tag.into(),
+            lang: lang.into(),
+            text: text.into(),
+        })
+    }
+}
+
+fn main() -> Result<(), quick_xml::Error> {
+    // In a real-world use case, Settings would likely be a struct
+    // HashMap here is just to make the sample code short
+    let mut settings: HashMap<String, String>;
+    let mut translations: Vec<Translation> = Vec::new();
+
+    let mut reader = Reader::from_str(XML);
+    reader.trim_text(true);
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf)? {
+            Event::Start(element) => match element.name().as_ref() {
+                b"DefaultSettings" => {
+                    settings = element
+                        .attributes()
+                        .map(|attr_result| {
+                            let a = attr_result.unwrap();
+                            (
+                                str::from_utf8(a.key.as_ref()).unwrap().to_string(),
+                                a.unescape_value().unwrap().to_string(),
+                            )
+                        })
+                        .collect();
+                    println!("settings: {:?}", settings);
+                }
+                b"Translation" => {
+                    translations.push(Translation::new_from_element(&mut reader, element)?);
+                }
+                _ => (),
+            },
+
+            Event::Eof => break, // exits the loop when reaching end of file
+            _ => (),             // There are `Event` types not considered here
+        }
+    }
+    println!("translations...");
+    for item in translations {
+        println!("{} {} {}", item.lang, item.tag, item.text);
+    }
+    Ok(())
+}

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -1,4 +1,6 @@
 // example that separates logic for reading different top-level nodes of xml tree
+// Note: for this specific data set using serde feature would simplify
+//       this simple data is purely to make it easier to understand the code
 
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::QName;
@@ -41,7 +43,7 @@ impl Translation {
     ) -> Result<Translation, quick_xml::Error> {
         let mut tag = Cow::Borrowed("");
         let mut lang = Cow::Borrowed("");
-        // let (tag, lang) =
+
         for attr_result in element.attributes() {
             let a = attr_result?;
             match a.key.as_ref() {
@@ -123,7 +125,8 @@ fn main() -> Result<(), quick_xml::Error> {
                             }
                         })
                         .collect();
-                    println!("settings: {:?}", settings);
+                    assert_eq!(settings["Language"], "es");
+                    assert_eq!(settings["Greeting"], "HELLO");
                     reader.read_to_end(element.name())?;
                 }
                 b"Translation" => {
@@ -136,10 +139,11 @@ fn main() -> Result<(), quick_xml::Error> {
             _ => (),             // There are `Event` types not considered here
         }
     }
-    println!("translations...");
-    for item in translations {
-        // TODO: assert_eq so the reader can see the result without running the code
-        println!("{} {} {}", item.lang, item.tag, item.text);
-    }
+    dbg!("{:?}", &translations);
+    assert_eq!(translations.len(), 4);
+    assert_eq!(translations[2].tag, "HELLO");
+    assert_eq!(translations[2].text, "Hola");
+    assert_eq!(translations[2].lang, "es");
+
     Ok(())
 }

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -57,7 +57,7 @@ impl Translation {
         let event = reader.read_event_into(&mut element_buf)?;
         match event {
             Event::Text(ref e) => {
-                text = str::from_utf8(e.as_ref())?.into();
+                text = e.unescape()?;
                 println!("text node content: {}", text);
             }
             _ => (),


### PR DESCRIPTION
This is an attempt to create a simple example that mirrors my use case I think it is a common use case so could be useful to others once I get it to work

Questions:
- I thought there should be a way to read from a buffer in a function that takes the element (where the goal is for the function to process that sub-tree of the XML) -- I think I understand why the code is wrong, just not sure how to make it right!
- I found it unexpected that `<Element/>` syntax didn't work with code that works properly for `<Element></Element>`


Appreciate any and all feedback!  I'm relatively new to Rust, so please feel free to comment on whatever would make this more idiomatic or consistent with library goals of "almost zero-copy" and "easy on memory allocation"

Thank you!