### PR TITLE
Implement `write_serializable_content` on element writer

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,6 +39,8 @@ pub enum Error {
     EscapeError(EscapeError),
     /// Specified namespace prefix is unknown, cannot resolve namespace for it
     UnknownPrefix(Vec<u8>),
+    /// Serialization error
+    NonSerializable(String),
 }
 
 impl From<IoError> for Error {
@@ -112,6 +114,7 @@ impl fmt::Display for Error {
                 write_byte_string(f, prefix)?;
                 f.write_str("'")
             }
+            Error::NonSerializable(e) => write!(f, "error while serializing value: {e}"),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,8 +39,6 @@ pub enum Error {
     EscapeError(EscapeError),
     /// Specified namespace prefix is unknown, cannot resolve namespace for it
     UnknownPrefix(Vec<u8>),
-    /// Serialization error
-    NonSerializable(String),
 }
 
 impl From<IoError> for Error {
@@ -114,7 +112,6 @@ impl fmt::Display for Error {
                 write_byte_string(f, prefix)?;
                 f.write_str("'")
             }
-            Error::NonSerializable(e) => write!(f, "error while serializing value: {e}"),
         }
     }
 }

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -668,7 +668,7 @@ pub(super) mod tests {
                     let ser = ContentSerializer {
                         writer: String::new(),
                         level: QuoteLevel::Full,
-                        indent: Indent::Owned(Indentation::new(b' ', 2)),
+                        indent: Indent::Owned(Indentation::new(b' ', 2, 0)),
                         write_indent: false,
                     };
 
@@ -688,7 +688,7 @@ pub(super) mod tests {
                     let ser = ContentSerializer {
                         writer: &mut buffer,
                         level: QuoteLevel::Full,
-                        indent: Indent::Owned(Indentation::new(b' ', 2)),
+                        indent: Indent::Owned(Indentation::new(b' ', 2, 0)),
                         write_indent: false,
                     };
 

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -1486,7 +1486,7 @@ mod tests {
                         ser: ContentSerializer {
                             writer: String::new(),
                             level: QuoteLevel::Full,
-                            indent: Indent::Owned(Indentation::new(b' ', 2)),
+                            indent: Indent::Owned(Indentation::new(b' ', 2, 0)),
                             write_indent: false,
                         },
                         key: XmlName("root"),
@@ -1509,7 +1509,7 @@ mod tests {
                         ser: ContentSerializer {
                             writer: &mut buffer,
                             level: QuoteLevel::Full,
-                            indent: Indent::Owned(Indentation::new(b' ', 2)),
+                            indent: Indent::Owned(Indentation::new(b' ', 2, 0)),
                             write_indent: false,
                         },
                         key: XmlName("root"),

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -366,7 +366,17 @@ impl<'r, W: Write> Serializer<'r, W> {
 
     /// Configure indent for a serializer
     pub fn indent(&mut self, indent_char: char, indent_size: usize) -> &mut Self {
-        self.ser.indent = Indent::Owned(Indentation::new(indent_char as u8, indent_size));
+        self.indent_with_len(indent_char, indent_size, 0)
+    }
+
+    /// Set initial indent level for a serializer
+    pub fn indent_with_len(
+        &mut self,
+        indent_char: char,
+        indent_size: usize,
+        indents_len: usize,
+    ) -> &mut Self {
+        self.ser.indent = Indent::Owned(Indentation::new(indent_char as u8, indent_size, indents_len));
         self
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -661,22 +661,20 @@ mod indentation {
     }
 
     #[cfg(feature = "serialize")]
-    #[derive(Serialize)]
-    struct Foo {
-        bar: Bar,
-        val: String,
-    }
-
-    #[cfg(feature = "serialize")]
-    #[derive(Serialize)]
-    struct Bar {
-        baz: usize,
-        bat: usize,
-    }
-
-    #[cfg(feature = "serialize")]
     #[test]
     fn element_writer_serialize() {
+        #[derive(Serialize)]
+        struct Foo {
+            bar: Bar,
+            val: String,
+        }
+
+        #[derive(Serialize)]
+        struct Bar {
+            baz: usize,
+            bat: usize,
+        }
+
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
         let content = Foo {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -394,7 +394,7 @@ impl Indentation {
             indent_char,
             indent_size,
             indents: vec![indent_char; 128],
-            indents_len: indents_len,
+            indents_len,
         }
     }
 


### PR DESCRIPTION
Resolves #499 

This introduces a new `write_serializable_content` method in order to serialize arbitrary types through `serde` within manual manipulation of an XML writer.

I feel it's a bit rough, especially how indentation is handled, but I'm not sure how to improve this without a bigger overhaul of some of the deeper stuff.