### PR TITLE
Fix #257 and allow $text to work with tags in the text

### DIFF
--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -150,7 +150,7 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
         // We should name that lifetime due to https://github.com/rust-lang/rust/issues/63033`
         end: QName<'n>,
         buf: &mut Vec<u8>,
-    ) -> Result<Span> {
+    ) -> Result<(Span,BytesEnd<'n>)> {
         Ok(read_to_end!(self, end, buf, read_event_into_async, { buf.clear(); }, await))
     }
 

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use memchr;
 
 use crate::errors::{Error, Result};
-use crate::events::Event;
+use crate::events::{Event, BytesText, BytesEnd};
 use crate::name::QName;
 use crate::reader::{is_whitespace, BangType, ReadElementState, Reader, Span, XmlSource};
 
@@ -391,7 +391,13 @@ impl<R: BufRead> Reader<R> {
     pub fn read_to_end_into(&mut self, end: QName, buf: &mut Vec<u8>) -> Result<Span> {
         Ok(read_to_end!(self, end, buf, read_event_impl, {
             buf.clear();
-        }))
+        }).0)
+    }
+
+    /// TODO: Document
+    pub fn read_text_into<'a>(&mut self, end: QName, buf: &'a mut Vec<u8>) -> Result<(BytesText<'a>, BytesEnd<'a>)> {
+        let (span, end_bytes) = read_to_end!(self, end, buf, read_event_impl, { });            
+        Ok((self.parser.read_text(&buf[0..span.len()])?, end_bytes))
     }
 }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -198,7 +198,7 @@ macro_rules! read_until_open {
             .read_bytes_until(b'<', $buf, &mut $self.parser.offset)
             $(.$await)?
         {
-            Ok(Some(bytes)) => $self.parser.read_text(bytes),
+            Ok(Some(bytes)) => Ok(Event::Text($self.parser.read_text(bytes)?)),
             Ok(None) => Ok(Event::Eof),
             Err(e) => Err(e),
         }
@@ -276,7 +276,7 @@ macro_rules! read_to_end {
                 Ok(Event::Start(e)) if e.name() == $end => depth += 1,
                 Ok(Event::End(e)) if e.name() == $end => {
                     if depth == 0 {
-                        break start..end;
+                        break (start..end, e.into_owned());
                     }
                     depth -= 1;
                 }

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 use std::path::Path;
 
 use crate::errors::Result;
-use crate::events::Event;
+use crate::events::{Event, BytesText};
 use crate::name::{LocalName, NamespaceResolver, QName, ResolveResult};
 use crate::reader::{Reader, Span, XmlSource};
 
@@ -759,7 +759,7 @@ impl<'i> NsReader<&'i [u8]> {
     pub fn read_to_end(&mut self, end: QName) -> Result<Span> {
         // According to the https://www.w3.org/TR/xml11/#dt-etag, end name should
         // match literally the start name. See `Self::check_end_names` documentation
-        self.reader.read_to_end(end)
+        Ok(self.reader.read_to_end(end)?.0)
     }
 
     /// Reads content between start and end tags, including any markup. This
@@ -828,8 +828,8 @@ impl<'i> NsReader<&'i [u8]> {
     /// [`Start`]: Event::Start
     /// [`decoder()`]: Reader::decoder()
     #[inline]
-    pub fn read_text(&mut self, end: QName) -> Result<Cow<'i, str>> {
-        self.reader.read_text(end)
+    pub fn read_text(&mut self, end: QName) -> Result<BytesText<'i>> {
+        Ok(self.reader.read_text(end)?.0)
     }
 }
 

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -65,7 +65,7 @@ impl Parser {
     /// - `bytes`: data from the start of stream to the first `<` or from `>` to `<`
     ///
     /// [`Text`]: Event::Text
-    pub fn read_text<'b>(&mut self, bytes: &'b [u8]) -> Result<Event<'b>> {
+    pub fn read_text<'b>(&mut self, bytes: &'b [u8]) -> Result<BytesText<'b>> {
         let mut content = bytes;
 
         if self.trim_text_end {
@@ -77,7 +77,7 @@ impl Parser {
             content = &bytes[..len];
         }
 
-        Ok(Event::Text(BytesText::wrap(content, self.decoder())))
+        Ok(BytesText::wrap(content, self.decoder()))
     }
 
     /// reads `BytesElement` starting with a `!`,

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -283,6 +283,8 @@ mod trivial {
 
             in_struct!(string: String = "<root>escaped&#x20;string</root>", "escaped string".into());
 
+            in_struct!(string_with_style_tags: String = "<root>style tags <em>in this document</em></root>", "style tags <em>in this document</em>".into());
+
             /// XML does not able to store binary data
             #[test]
             fn byte_buf() {


### PR DESCRIPTION
This is a very early attempt at solving #257 (awful, but functional, code below). Unfortunately, I ran into a design issue so I'd like to open the discussion now and get your feedback on what to do.

Suppose we have the following struct to deserialize (from the test case attached in serde-de.rs below)

```rust
#[derive(Debug, Deserialize, PartialEq)]
struct Trivial<T> {
    #[serde(rename = "$text")]
    value: T,
}
```
The test case has the following xml
```xml
<root>style tags <em>in this document</em></root>
```
deserialize into
```rust
Trivial {
    value: "style tags <em>in this document</em>".to_string(),
}
```

The test case also assumes the xml
```xml
<outer><root>style tags <em>in this document</em></root></outer>
``` 
**should not** deserialize (missing field `$text`)

However, if we change the design for how $text works to include embedded tags, this would now be deserializable where 'outer' is the root tag and everything between <outer></outer> can now be fed into a text field because root can be part of the string now. 

Outside of the above being newly expected behavior we could make the user describe which tags can be deserialized into text fields instead of read:
```rust
#[derive(Debug, Deserialize, PartialEq)]
struct Trivial<T> {
    #[serde(rename = "$text$<EM>$<B>")] // only <EM>...</EM>s and <B>...</B>s are allowed to be part of the string
    value: T,
}
```

Let me know if you have any other ideas on what would be best to do here.