### PR TITLE
Fix incorrect behaviour of `сheck_end_names` after disabling and enabling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,8 @@
   <B/>
   <C/>
   ```
+- [#514]: Fix wrong reporting `Error::EndEventMismatch` after disabling and enabling
+  `.check_end_names`
 
 ### Misc Changes
 
@@ -53,6 +55,7 @@
 
 [#490]: https://github.com/tafia/quick-xml/pull/490
 [#500]: https://github.com/tafia/quick-xml/issues/500
+[#514]: https://github.com/tafia/quick-xml/issues/514
 [XML name]: https://www.w3.org/TR/xml11/#NT-Name
 [documentation]: https://docs.rs/quick-xml/0.27.0/quick_xml/de/index.html#difference-between-text-and-value-special-names
 

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -339,7 +339,7 @@ impl<'k, W: Write> Struct<'k, W> {
     /// If `key` has a magic value [`TEXT_KEY`], then `value` serialized as a
     /// [simple type].
     ///
-    /// If `key` has a magic value [`CONTENT_KEY`], then `value` serialized as a
+    /// If `key` has a magic value [`VALUE_KEY`], then `value` serialized as a
     /// [content] without wrapping in tags, otherwise it is wrapped in
     /// `<${key}>...</${key}>`.
     ///

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,0 +1,69 @@
+//! Regression tests found in various issues
+//!
+//! Name each test as `issue<GH number>`
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::reader::Reader;
+use quick_xml::Error;
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/514
+mod issue514 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    /// Check that there is no unexpected error
+    #[test]
+    fn no_mismatch() {
+        let mut reader = Reader::from_str("<some-tag><html>...</html></some-tag>");
+
+        let outer_start = BytesStart::new("some-tag");
+        let outer_end = outer_start.to_end().into_owned();
+
+        let html_start = BytesStart::new("html");
+        let html_end = html_start.to_end().into_owned();
+
+        assert_eq!(reader.read_event().unwrap(), Event::Start(outer_start));
+        assert_eq!(reader.read_event().unwrap(), Event::Start(html_start));
+
+        reader.check_end_names(false);
+
+        assert_eq!(reader.read_text(html_end.name()).unwrap(), "...");
+
+        reader.check_end_names(true);
+
+        assert_eq!(reader.read_event().unwrap(), Event::End(outer_end));
+        assert_eq!(reader.read_event().unwrap(), Event::Eof);
+    }
+
+    /// Canary check that legitimate error is reported
+    #[test]
+    fn mismatch() {
+        let mut reader = Reader::from_str("<some-tag><html>...</html></other-tag>");
+
+        let outer_start = BytesStart::new("some-tag");
+
+        let html_start = BytesStart::new("html");
+        let html_end = html_start.to_end().into_owned();
+
+        assert_eq!(reader.read_event().unwrap(), Event::Start(outer_start));
+        assert_eq!(reader.read_event().unwrap(), Event::Start(html_start));
+
+        reader.check_end_names(false);
+
+        assert_eq!(reader.read_text(html_end.name()).unwrap(), "...");
+
+        reader.check_end_names(true);
+
+        match reader.read_event() {
+            Err(Error::EndEventMismatch { expected, found }) => {
+                assert_eq!(expected, "some-tag");
+                assert_eq!(found, "other-tag");
+            }
+            x => panic!(
+                r#"Expected `Err(EndEventMismatch("some-tag", "other-tag")))`, but found {:?}"#,
+                x
+            ),
+        }
+        assert_eq!(reader.read_event().unwrap(), Event::Eof);
+    }
+}


### PR DESCRIPTION
Since now are always track stack of names, regardless of `сheck_end_names` setting. This is also fixes an error when you start from disabled setting, read some open tag and then enable reporting. After this PR that error will be correctly reported if closed tag won't match opened.

Fixes #514