### PR TITLE
Merge consequent text and CDATA events into one string 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,11 @@
   sequence type (for example, `Vec` or tuple)
 - [#540]: Fix a compilation error (probably a rustc bug) in some circumstances.
   `Serializer::new` and `Serializer::with_root` now accepts only references to `Write`r.
+- [#520]: Merge consequent (delimited only by comments and processing instructions)
+  texts and CDATA when deserialize using serde deserializer. `DeEvent::Text` and
+  `DeEvent::CData` events was replaced by `DeEvent::Text` with merged content.
+  The same behavior for the `Reader` does not implemented (yet?) and should be
+  implemented manually
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,8 +16,8 @@
   enums from textual content
 - [#556]: `to_writer` and `to_string` now accept `?Sized` types
 - [#556]: Add new `to_writer_with_root` and `to_string_with_root` helper functions
-- [#520]: Add method `BytesText::inplace_trim_start` to trim leading spaces from
-  text events
+- [#520]: Add methods `BytesText::inplace_trim_start` and `BytesText::inplace_trim_end`
+  to trim leading and trailing spaces from text events
 
 ### Bug Fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@
   enums from textual content
 - [#556]: `to_writer` and `to_string` now accept `?Sized` types
 - [#556]: Add new `to_writer_with_root` and `to_string_with_root` helper functions
+- [#520]: Add method `BytesText::inplace_trim_start` to trim leading spaces from
+  text events
 
 ### Bug Fixes
 
@@ -31,6 +33,7 @@
 [externally tagged]: https://serde.rs/enum-representations.html#externally-tagged
 [#490]: https://github.com/tafia/quick-xml/pull/490
 [#510]: https://github.com/tafia/quick-xml/issues/510
+[#520]: https://github.com/tafia/quick-xml/pull/520
 [#537]: https://github.com/tafia/quick-xml/issues/537
 [#540]: https://github.com/tafia/quick-xml/issues/540
 [#541]: https://github.com/tafia/quick-xml/pull/541

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -313,7 +313,7 @@ where
             ValueSource::Text => match self.de.next()? {
                 DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
                     // Comment to prevent auto-formatting
-                    e.decode(true)?,
+                    e.unescape()?,
                 )),
                 DeEvent::CData(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
                     // Comment to prevent auto-formatting
@@ -467,8 +467,8 @@ where
     /// [`Text`]: DeEvent::Text
     /// [`CData`]: DeEvent::CData
     #[inline]
-    fn read_string(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
-        self.map.de.read_string_impl(unescape, self.allow_start)
+    fn read_string(&mut self) -> Result<Cow<'de, str>, DeError> {
+        self.map.de.read_string_impl(self.allow_start)
     }
 }
 
@@ -728,8 +728,8 @@ where
     /// [`Text`]: DeEvent::Text
     /// [`CData`]: DeEvent::CData
     #[inline]
-    fn read_string(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
-        self.map.de.read_string_impl(unescape, true)
+    fn read_string(&mut self) -> Result<Cow<'de, str>, DeError> {
+        self.map.de.read_string_impl(true)
     }
 }
 
@@ -783,7 +783,7 @@ where
         match self.map.de.next()? {
             DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(
                 // Comment to prevent auto-formatting
-                e.decode(true)?,
+                e.unescape()?,
             )
             .deserialize_seq(visitor),
             DeEvent::CData(e) => SimpleTypeDeserializer::from_text_content(
@@ -798,7 +798,7 @@ where
                 let value = match self.map.de.next()? {
                     DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(
                         // Comment to prevent auto-formatting
-                        e.decode(true)?,
+                        e.unescape()?,
                     )
                     .deserialize_seq(visitor),
                     DeEvent::CData(e) => SimpleTypeDeserializer::from_text_content(

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2500,10 +2500,7 @@ impl<'de> Deserializer<'de, SliceReader<'de>> {
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &'de str) -> Self {
         let mut reader = Reader::from_str(s);
-        reader
-            .expand_empty_elements(true)
-            .check_end_names(true)
-            .trim_text(true);
+        reader.expand_empty_elements(true).check_end_names(true);
         Self::new(SliceReader {
             reader,
             start_trimmer: StartTrimmer::default(),
@@ -2521,10 +2518,7 @@ where
     /// is known to represent UTF-8, you can decode it first before using [`from_str`].
     pub fn from_reader(reader: R) -> Self {
         let mut reader = Reader::from_reader(reader);
-        reader
-            .expand_empty_elements(true)
-            .check_end_names(true)
-            .trim_text(true);
+        reader.expand_empty_elements(true).check_end_names(true);
 
         Self::new(IoReader {
             reader,
@@ -3420,7 +3414,6 @@ mod tests {
 
         reader
             .reader
-            .trim_text(true)
             .expand_empty_elements(true)
             .check_end_names(true);
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -77,11 +77,7 @@
 //! ```xml
 //! <...>text<![CDATA[cdata]]>text</...>
 //! ```
-//! <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
-//!
-//! Merging of the text / CDATA content is tracked in the issue [#474] and
-//! will be available in the next release.
-//! </div>
+//! Mixed text / CDATA content represents one logical string, `"textcdatatext"` in that case.
 //! </td>
 //! <td>
 //!
@@ -90,9 +86,7 @@
 //! - [`Cow<str>`]
 //! - [`u32`], [`f32`] and other numeric types
 //! - `enum`s, like
-//!   ```ignore
-//!   // FIXME: #474, merging mixed text / CDATA
-//!   // content does not work yet
+//!   ```
 //!   # use pretty_assertions::assert_eq;
 //!   # use serde::Deserialize;
 //!   # #[derive(Debug, PartialEq)]
@@ -149,11 +143,6 @@
 //!   ...
 //! ]]></...>
 //! ```
-//! <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
-//!
-//! Merging of the text / CDATA content is tracked in the issue [#474] and
-//! will be available in the next release.
-//! </div>
 //!
 //! [`xs:list`]: https://www.w3.org/TR/xmlschema11-2/#list-datatypes
 //! </td>
@@ -162,8 +151,6 @@
 //! Use any type that deserialized using [`deserialize_seq()`] call, for example:
 //!
 //! ```
-//! // FIXME: #474, merging mixed text / CDATA
-//! // content does not work yet
 //! type List = Vec<u32>;
 //! ```
 //!
@@ -520,8 +507,7 @@
 //! }
 //! # assert_eq!(AnyName::One { field1: () }, quick_xml::de::from_str(r#"<one field1="...">...</one>"#).unwrap());
 //! # assert_eq!(AnyName::Two { field2: () }, quick_xml::de::from_str(r#"<two><field2>...</field2></two>"#).unwrap());
-//! # assert_eq!(AnyName::Text("text".into()), quick_xml::de::from_str(r#"text"#).unwrap());
-//! # // TODO: After #474 parse mixed content
+//! # assert_eq!(AnyName::Text("text  cdata ".into()), quick_xml::de::from_str(r#"text <![CDATA[ cdata ]]>"#).unwrap());
 //! ```
 //! ```
 //! # use pretty_assertions::assert_eq;
@@ -544,8 +530,7 @@
 //! }
 //! # assert_eq!(AnyName::One,                     quick_xml::de::from_str(r#"<one field1="...">...</one>"#).unwrap());
 //! # assert_eq!(AnyName::Two(Two { field2: () }), quick_xml::de::from_str(r#"<two><field2>...</field2></two>"#).unwrap());
-//! # assert_eq!(AnyName::Text,                    quick_xml::de::from_str(r#"text"#).unwrap());
-//! # // TODO: After #474 parse mixed content
+//! # assert_eq!(AnyName::Text,                    quick_xml::de::from_str(r#"text <![CDATA[ cdata ]]>"#).unwrap());
 //! ```
 //! ```
 //! # use pretty_assertions::assert_eq;
@@ -561,8 +546,7 @@
 //! }
 //! # assert_eq!(AnyName::One,   quick_xml::de::from_str(r#"<one field1="...">...</one>"#).unwrap());
 //! # assert_eq!(AnyName::Other, quick_xml::de::from_str(r#"<two><field2>...</field2></two>"#).unwrap());
-//! # assert_eq!(AnyName::Other, quick_xml::de::from_str(r#"text"#).unwrap());
-//! # // TODO: After #474 parse mixed content
+//! # assert_eq!(AnyName::Other, quick_xml::de::from_str(r#"text <![CDATA[ cdata ]]>"#).unwrap());
 //! ```
 //! <div style="background:rgba(120,145,255,0.45);padding:0.75em;">
 //!
@@ -643,9 +627,8 @@
 //! #   quick_xml::de::from_str(r#"<any-tag field="..."><two>...</two></any-tag>"#).unwrap(),
 //! # );
 //! # assert_eq!(
-//! #   AnyName { field: (), any_name: Choice::Text("text".into()) },
-//! #   // TODO: After #474 parse mixed content
-//! #   quick_xml::de::from_str(r#"<any-tag field="...">text</any-tag>"#).unwrap(),
+//! #   AnyName { field: (), any_name: Choice::Text("text  cdata ".into()) },
+//! #   quick_xml::de::from_str(r#"<any-tag field="...">text <![CDATA[ cdata ]]></any-tag>"#).unwrap(),
 //! # );
 //! ```
 //! </td>
@@ -967,8 +950,7 @@
 //! from the full element (`<one>...</one>`), so they could use the element name
 //! to choose the right variant:
 //!
-//! ```ignore
-//! // FIXME: #474
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # type One = ();
@@ -985,9 +967,7 @@
 //! #   quick_xml::de::from_str(r#"<one>...</one>text <![CDATA[cdata]]><two>...</two><one>...</one>"#).unwrap(),
 //! # );
 //! ```
-//! ```ignore
-//! // FIXME: #474, Custom("unknown variant `two`,
-//! //                      expected `one`")
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # #[derive(Debug, PartialEq)]
@@ -1010,11 +990,6 @@
 //!
 //! NOTE: consequent text and CDATA nodes are merged into the one text node,
 //! so you cannot have two adjacent string types in your sequence.
-//! </div>
-//! <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
-//!
-//! Merging of the text / CDATA content is tracked in the issue [#474] and
-//! will be available in the next release.
 //! </div>
 //! </td>
 //! </tr>
@@ -1040,8 +1015,7 @@
 //! <td>
 //! A homogeneous sequence of elements with a fixed or dynamic size:
 //!
-//! ```ignore
-//! // FIXME: #474
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # #[derive(Debug, PartialEq)]
@@ -1059,8 +1033,7 @@
 //! #   quick_xml::de::from_str::<AnyName>(r#"<one>...</one>text <![CDATA[cdata]]><two>...</two><one>...</one>"#).unwrap(),
 //! # );
 //! ```
-//! ```ignore
-//! // FIXME: #474
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # #[derive(Debug, PartialEq)]
@@ -1088,11 +1061,6 @@
 //! NOTE: consequent text and CDATA nodes are merged into the one text node,
 //! so you cannot have two adjacent string types in your sequence.
 //! </div>
-//! <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
-//!
-//! Merging of the text / CDATA content is tracked in the issue [#474] and
-//! will be available in the next release.
-//! </div>
 //! </td>
 //! </tr>
 //! <!-- 16 ==================================================================================== -->
@@ -1119,8 +1087,7 @@
 //!
 //! You MUST specify `#[serde(rename = "$value")]` on that field:
 //!
-//! ```ignore
-//! // FIXME: #474, Custom("duplicate field `$value`")
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # type One = ();
@@ -1157,8 +1124,7 @@
 //! #   ).unwrap(),
 //! # );
 //! ```
-//! ```ignore
-//! // FIXME: #474, Custom("duplicate field `$value`")
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # type One = ();
@@ -1204,11 +1170,6 @@
 //! NOTE: consequent text and CDATA nodes are merged into the one text node,
 //! so you cannot have two adjacent string types in your sequence.
 //! </div>
-//! <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
-//!
-//! Merging of the text / CDATA content is tracked in the issue [#474] and
-//! will be available in the next release.
-//! </div>
 //! </td>
 //! </tr>
 //! <!-- 17 ==================================================================================== -->
@@ -1237,8 +1198,7 @@
 //!
 //! You MUST specify `#[serde(rename = "$value")]` on that field:
 //!
-//! ```ignore
-//! // FIXME: #474
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # #[derive(Debug, PartialEq)]
@@ -1282,8 +1242,7 @@
 //! #   ).unwrap(),
 //! # );
 //! ```
-//! ```ignore
-//! // FIXME: #474
+//! ```
 //! # use pretty_assertions::assert_eq;
 //! # use serde::Deserialize;
 //! # #[derive(Debug, PartialEq)]
@@ -1331,11 +1290,6 @@
 //!
 //! NOTE: consequent text and CDATA nodes are merged into the one text node,
 //! so you cannot have two adjacent string types in your sequence.
-//! </div>
-//! <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
-//!
-//! Merging of the text / CDATA content is tracked in the issue [#474] and
-//! will be available in the next release.
 //! </div>
 //! </td>
 //! </tr>
@@ -1720,7 +1674,6 @@
 //!
 //! [specification]: https://www.w3.org/TR/xmlschema11-1/#Simple_Type_Definition
 //! [`deserialize_with`]: https://serde.rs/field-attrs.html#deserialize_with
-//! [#474]: https://github.com/tafia/quick-xml/issues/474
 //! [#497]: https://github.com/tafia/quick-xml/issues/497
 
 // Macros should be defined before the modules that using them
@@ -2004,6 +1957,53 @@ impl<'i, R: XmlRead<'i>> XmlReader<'i, R> {
         )
     }
 
+    /// Read all consequent [`Text`] and [`CData`] events until non-text event
+    /// occurs. Content of all events would be appended to `result` and returned
+    /// as [`DeEvent::Text`].
+    ///
+    /// [`Text`]: PayloadEvent::Text
+    /// [`CData`]: PayloadEvent::CData
+    fn drain_text(&mut self, mut result: Cow<'i, str>) -> Result<DeEvent<'i>, DeError> {
+        loop {
+            match self.lookahead {
+                Ok(PayloadEvent::Text(_) | PayloadEvent::CData(_)) => {
+                    let text = self.next_text()?;
+
+                    let mut s = result.into_owned();
+                    s += &text;
+                    result = Cow::Owned(s);
+                }
+                _ => break,
+            }
+        }
+        Ok(DeEvent::Text(result))
+    }
+
+    /// Read one text event, panics if current event is not a text event
+    ///
+    /// |Event                  |XML                        |Handling
+    /// |-----------------------|---------------------------|----------------------------------------
+    /// |[`PayloadEvent::Start`]|`<tag>...</tag>`           |Possible panic (unreachable)
+    /// |[`PayloadEvent::End`]  |`</any-tag>`               |Possible panic (unreachable)
+    /// |[`PayloadEvent::Text`] |`text content`             |Unescapes `text content` and returns it
+    /// |[`PayloadEvent::CData`]|`<![CDATA[cdata content]]>`|Returns `cdata content` unchanged
+    /// |[`PayloadEvent::Eof`]  |                           |Possible panic (unreachable)
+    #[inline(always)]
+    fn next_text(&mut self) -> Result<Cow<'i, str>, DeError> {
+        match self.next_impl()? {
+            PayloadEvent::Text(mut e) => {
+                if self.need_trim_end() {
+                    e.inplace_trim_end();
+                }
+                Ok(e.unescape()?)
+            }
+            PayloadEvent::CData(e) => Ok(e.decode()?),
+
+            // SAFETY: this method is called only when we peeked Text or CData
+            _ => unreachable!("Only `Text` and `CData` events can come here"),
+        }
+    }
+
     /// Return an input-borrowing event.
     fn next(&mut self) -> Result<DeEvent<'i>, DeError> {
         loop {
@@ -2014,9 +2014,9 @@ impl<'i, R: XmlRead<'i>> XmlReader<'i, R> {
                     if self.need_trim_end() && e.inplace_trim_end() {
                         continue;
                     }
-                    Ok(DeEvent::Text(e.unescape()?))
+                    self.drain_text(e.unescape()?)
                 }
-                PayloadEvent::CData(e) => Ok(DeEvent::Text(e.decode()?)),
+                PayloadEvent::CData(e) => self.drain_text(e.decode()?),
                 PayloadEvent::Eof => Ok(DeEvent::Eof),
             };
         }
@@ -2386,11 +2386,12 @@ where
         self.read_string_impl(true)
     }
 
-    /// Consumes a one XML element or an XML tree, returns associated text or
+    /// Consumes consequent [`Text`] and [`CData`] (both a referred below as a _text_)
+    /// events, merge them into one string. If there are no such events, returns
     /// an empty string.
     ///
-    /// If `allow_start` is `false`, then only one event is consumed. If that
-    /// event is [`DeEvent::Start`], then [`DeError::UnexpectedStart`] is returned.
+    /// If `allow_start` is `false`, then only text events is consumed, for other
+    /// events an error is returned (see table below).
     ///
     /// If `allow_start` is `true`, then first [`DeEvent::Text`] event is returned
     /// and all other content is skipped until corresponding end tag will be consumed.
@@ -2415,6 +2416,9 @@ where
     /// |[`DeEvent::End`]  |`</any-tag>`               |Emits [`UnexpectedEnd("any-tag")`](DeError::UnexpectedEnd)
     /// |[`DeEvent::Text`] |`text content` or `<![CDATA[cdata content]]>` (probably mixed)|Returns event content unchanged, consumes events up to `</tag>`
     /// |[`DeEvent::Eof`]  |                           |Emits [`UnexpectedEof`](DeError::UnexpectedEof)
+    ///
+    /// [`Text`]: Event::Text
+    /// [`CData`]: Event::CData
     fn read_string_impl(&mut self, allow_start: bool) -> Result<Cow<'de, str>, DeError> {
         match self.next()? {
             DeEvent::Text(e) => Ok(e),
@@ -3003,7 +3007,7 @@ mod tests {
                 ]
             );
 
-            // Drop all events thet represents <target> tree. Now unconsumed XML looks like:
+            // Drop all events that represents <target> tree. Now unconsumed XML looks like:
             //
             //   <skip>
             //     text

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -504,14 +504,12 @@ impl<'de, 'a> Deref for CowRef<'de, 'a> {
 ///
 /// Used for deserialize values from:
 /// - attribute values (`<... ...="value" ...>`)
-/// - text content (`<...>text</...>`)
-/// - CDATA content (`<...><![CDATA[cdata]]></...>`)
+/// - mixed text / CDATA content (`<...>text<![CDATA[cdata]]></...>`)
 ///
 /// [simple types]: https://www.w3.org/TR/xmlschema11-1/#Simple_Type_Definition
 pub struct SimpleTypeDeserializer<'de, 'a> {
     /// - In case of attribute contains escaped attribute value
-    /// - In case of text contains escaped text value
-    /// - In case of CData contains unescaped cdata value
+    /// - In case of text contains unescaped text value
     content: CowRef<'de, 'a>,
     /// If `true`, `content` in escaped form and should be unescaped before use
     escaped: bool,

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -93,7 +93,7 @@ where
         if self.is_text {
             match self.de.next()? {
                 DeEvent::Text(e) => {
-                    seed.deserialize(SimpleTypeDeserializer::from_text_content(e.decode(true)?))
+                    seed.deserialize(SimpleTypeDeserializer::from_text_content(e.unescape()?))
                 }
                 DeEvent::CData(e) => {
                     seed.deserialize(SimpleTypeDeserializer::from_text_content(e.decode()?))
@@ -112,7 +112,7 @@ where
     {
         if self.is_text {
             match self.de.next()? {
-                DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(e.decode(true)?)
+                DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(e.unescape()?)
                     .deserialize_tuple(len, visitor),
                 DeEvent::CData(e) => SimpleTypeDeserializer::from_text_content(e.decode()?)
                     .deserialize_tuple(len, visitor),
@@ -134,7 +134,7 @@ where
     {
         if self.is_text {
             match self.de.next()? {
-                DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(e.decode(true)?)
+                DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(e.unescape()?)
                     .deserialize_struct("", fields, visitor),
                 DeEvent::CData(e) => SimpleTypeDeserializer::from_text_content(e.decode()?)
                     .deserialize_struct("", fields, visitor),

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -693,28 +693,6 @@ impl<'a> BytesText<'a> {
             Cow::Owned(s) => Ok(s.into()),
         }
     }
-
-    /// Gets content of this text buffer in the specified encoding and optionally
-    /// unescapes it.
-    #[cfg(feature = "serialize")]
-    pub(crate) fn decode(&self, unescape: bool) -> Result<Cow<'a, str>> {
-        let text = match &self.content {
-            Cow::Borrowed(bytes) => self.decoder.decode(bytes)?,
-            // Convert to owned, because otherwise Cow will be bound with wrong lifetime
-            Cow::Owned(bytes) => self.decoder.decode(bytes)?.into_owned().into(),
-        };
-        let text = if unescape {
-            //FIXME: need to take into account entities defined in the document
-            match unescape_with(&text, |_| None)? {
-                // Because result is borrowed, no replacements was done and we can use original string
-                Cow::Borrowed(_) => text,
-                Cow::Owned(s) => s.into(),
-            }
-        } else {
-            text
-        };
-        Ok(text)
-    }
 }
 
 impl<'a> Debug for BytesText<'a> {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -706,6 +706,14 @@ impl<'a> BytesText<'a> {
         );
         self.content.is_empty()
     }
+
+    /// Removes trailing XML whitespace bytes from text content.
+    ///
+    /// Returns `true` if content is empty after that
+    pub fn inplace_trim_end(&mut self) -> bool {
+        self.content = trim_cow(replace(&mut self.content, Cow::Borrowed(b"")), trim_xml_end);
+        self.content.is_empty()
+    }
 }
 
 impl<'a> Debug for BytesText<'a> {
@@ -962,6 +970,22 @@ const fn trim_xml_start(mut bytes: &[u8]) -> &[u8] {
     // making the function const.
     while let [first, rest @ ..] = bytes {
         if is_whitespace(*first) {
+            bytes = rest;
+        } else {
+            break;
+        }
+    }
+    bytes
+}
+
+/// Returns a byte slice with trailing XML whitespace bytes removed.
+///
+/// 'Whitespace' refers to the definition used by [`is_whitespace`].
+const fn trim_xml_end(mut bytes: &[u8]) -> &[u8] {
+    // Note: A pattern matching based approach (instead of indexing) allows
+    // making the function const.
+    while let [rest @ .., last] = bytes {
+        if is_whitespace(*last) {
             bytes = rest;
         } else {
             break;

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -42,10 +42,21 @@ macro_rules! configure_methods {
         ///
         /// Changing this option automatically changes the [`trim_text_end`] option.
         ///
-        /// (`false` by default)
+        /// (`false` by default).
+        ///
+        /// <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
+        ///
+        /// WARNING: With this option every text events will be trimmed which is
+        /// incorrect behavior when text events delimited by comments, processing
+        /// instructions or CDATA sections. To correctly trim data manually apply
+        /// [`BytesText::inplace_trim_start`] and [`BytesText::inplace_trim_end`]
+        /// only to necessary events.
+        /// </div>
         ///
         /// [`Text`]: Event::Text
         /// [`trim_text_end`]: Self::trim_text_end
+        /// [`BytesText::inplace_trim_start`]: crate::events::BytesText::inplace_trim_start
+        /// [`BytesText::inplace_trim_end`]: crate::events::BytesText::inplace_trim_end
         pub fn trim_text(&mut self, val: bool) -> &mut Self {
             self $(.$holder)? .parser.trim_text_start = val;
             self $(.$holder)? .parser.trim_text_end = val;
@@ -57,9 +68,20 @@ macro_rules! configure_methods {
         /// When set to `true`, trailing whitespace is trimmed in [`Text`] events.
         /// If after that the event is empty it will not be pushed.
         ///
-        /// (`false` by default)
+        /// (`false` by default).
+        ///
+        /// <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
+        ///
+        /// WARNING: With this option every text events will be trimmed which is
+        /// incorrect behavior when text events delimited by comments, processing
+        /// instructions or CDATA sections. To correctly trim data manually apply
+        /// [`BytesText::inplace_trim_start`] and [`BytesText::inplace_trim_end`]
+        /// only to necessary events.
+        /// </div>
         ///
         /// [`Text`]: Event::Text
+        /// [`BytesText::inplace_trim_start`]: crate::events::BytesText::inplace_trim_start
+        /// [`BytesText::inplace_trim_end`]: crate::events::BytesText::inplace_trim_end
         pub fn trim_text_end(&mut self, val: bool) -> &mut Self {
             self $(.$holder)? .parser.trim_text_end = val;
             self

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -848,7 +848,7 @@ impl ReadElementState {
 
 /// A function to check whether the byte is a whitespace (blank, new line, carriage return or tab)
 #[inline]
-pub(crate) fn is_whitespace(b: u8) -> bool {
+pub(crate) const fn is_whitespace(b: u8) -> bool {
     matches!(b, b' ' | b'\r' | b'\n' | b'\t')
 }
 

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -530,7 +530,8 @@ mod seq {
 
         #[test]
         fn mixed_content() {
-            from_str::<[(); 3]>(
+            // Text and CDATA represents a one logical text item
+            from_str::<[(); 2]>(
                 r#"
                 <element/>
                 text
@@ -547,7 +548,8 @@ mod seq {
                 "#,
             )
             .unwrap();
-            assert_eq!(data, vec![(), (), ()]);
+            // Text and CDATA represents a one logical text item
+            assert_eq!(data, vec![(), ()]);
         }
 
         /// This test ensures that composition of deserializer building blocks plays well
@@ -2432,8 +2434,9 @@ mod seq {
             fn mixed_content() {
                 #[derive(Debug, PartialEq, Deserialize)]
                 struct List {
+                    /// Text and CDATA represents a one logical text item
                     #[serde(rename = "$value")]
-                    item: [(); 3],
+                    item: [(); 2],
                 }
 
                 from_str::<List>(
@@ -3540,7 +3543,8 @@ mod seq {
                 assert_eq!(
                     data,
                     List {
-                        item: vec![(), (), ()],
+                        // Text and CDATA represents a one logical text item
+                        item: vec![(), ()],
                     }
                 );
             }


### PR DESCRIPTION
This PR fixes #474 and introduces a way to read current parser configuration, which was impossible before that.

I've changed the way how configuration is accessed and changed: instead of having functions to change configuration flags, readers now provides a reference to a `Config` object. Immutable and mutable references are provided. This new feature is used to temporary disable trimming while read text events in serde `Deserializer`.

After fixing #516, all configuration flags are safe to changed at any time, because their does not change the internal state of a reader in a user-visible way (for example, the `expand_empty_elements` changes an internal state of a reader, but that change is rolled back after next call to `read_event`, so user cannot see it consequences. It is safe to disable this setting just after read fake `Start` event and still get a fake `End` event after that).