### PR TITLE
Implement Clone for error enums

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@1.46.0
+    - uses: dtolnay/rust-toolchain@1.52.0
     - run: cargo check
 
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tafia/quick-xml"
 keywords = ["xml", "serde", "parser", "writer", "html"]
 categories = ["asynchronous", "encoding", "parsing", "parser-implementations"]
 license = "MIT"
-rust-version = "1.46"
+rust-version = "1.52"
 include = ["src/*", "LICENSE-MIT.md", "README.md"]
 
 [dependencies]

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@
 
 ### New Features
 
+- [#521]: Implement `Clone` for all error types. This required changing `Error::Io` to contain
+  `Arc<std::io::Error>` instead of `std::io::Error` since `std::io::Error` does not implement
+  `Clone`.
+
 ### Bug Fixes
 
 - [#490]: Ensure that serialization of map keys always produces valid XML names.

--- a/Changelog.md
+++ b/Changelog.md
@@ -51,6 +51,7 @@
     that should be represented either by an `enum`, or by sequence of `enum`s
     (`Vec`, tuple, etc.), or by string. Use it when you want to map field to any
     content of the field, text or markup
+- [#521]: MSRV bumped to 1.52.
 
   Refer to [documentation] for details.
 
@@ -58,6 +59,7 @@
 [#500]: https://github.com/tafia/quick-xml/issues/500
 [#514]: https://github.com/tafia/quick-xml/issues/514
 [#517]: https://github.com/tafia/quick-xml/issues/517
+[#521]: https://github.com/tafia/quick-xml/pull/521
 [XML name]: https://www.w3.org/TR/xml11/#NT-Name
 [documentation]: https://docs.rs/quick-xml/0.27.0/quick_xml/de/index.html#difference-between-text-and-value-special-names
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,12 +7,15 @@ use std::fmt;
 use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
+use std::sync::Arc;
 
 /// The error type used by this crate.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Error {
-    /// IO error
-    Io(IoError),
+    /// IO error.
+    ///
+    /// `Arc<IoError>` instead of `IoError` since `IoError` is not `Clone`.
+    Io(Arc<IoError>),
     /// Input decoding error. If `encoding` feature is disabled, contains `None`,
     /// otherwise contains the UTF-8 decoding error
     NonDecodable(Option<Utf8Error>),
@@ -45,7 +48,7 @@ impl From<IoError> for Error {
     /// Creates a new `Error::Io` from the given error
     #[inline]
     fn from(error: IoError) -> Error {
-        Error::Io(error)
+        Error::Io(Arc::new(error))
     }
 }
 
@@ -140,7 +143,7 @@ pub mod serialize {
     use std::num::{ParseFloatError, ParseIntError};
 
     /// (De)serialization error
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     pub enum DeError {
         /// Serde custom error
         Custom(String),

--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use pretty_assertions::assert_eq;
 
 /// Error for XML escape / unescape.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum EscapeError {
     /// Entity with Null character
     EntityWithNull(Range<usize>),

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -241,7 +241,7 @@ impl<'a> FusedIterator for Attributes<'a> {}
 ///
 /// Recovery position in examples shows the position from which parsing of the
 /// next attribute will be attempted.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AttrError {
     /// Attribute key was not followed by `=`, position relative to the start of
     /// the owning tag is provided.

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -27,7 +27,7 @@ macro_rules! impl_buffered_source {
                         Ok(())
                     },
                     Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                    Err(e) => Err(Error::Io(e)),
+                    Err(e) => Err(Error::Io(e.into())),
                 };
             }
         }
@@ -43,7 +43,7 @@ macro_rules! impl_buffered_source {
                         Ok(None)
                     },
                     Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                    Err(e) => Err(Error::Io(e)),
+                    Err(e) => Err(Error::Io(e.into())),
                 };
             }
         }
@@ -69,7 +69,7 @@ macro_rules! impl_buffered_source {
                         Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
                         Err(e) => {
                             *position += read;
-                            return Err(Error::Io(e));
+                            return Err(Error::Io(e.into()));
                         }
                     };
 
@@ -136,7 +136,7 @@ macro_rules! impl_buffered_source {
                     Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
                     Err(e) => {
                         *position += read;
-                        return Err(Error::Io(e));
+                        return Err(Error::Io(e.into()));
                     }
                 }
             }
@@ -181,7 +181,7 @@ macro_rules! impl_buffered_source {
                     Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
                     Err(e) => {
                         *position += read;
-                        return Err(Error::Io(e));
+                        return Err(Error::Io(e.into()));
                     }
                 };
             }
@@ -207,7 +207,7 @@ macro_rules! impl_buffered_source {
                         }
                     }
                     Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                    Err(e) => Err(Error::Io(e)),
+                    Err(e) => Err(Error::Io(e.into())),
                 };
             }
         }
@@ -232,7 +232,7 @@ macro_rules! impl_buffered_source {
                     Ok(n) if n.is_empty() => Ok(None),
                     Ok(n) => Ok(Some(n[0])),
                     Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                    Err(e) => Err(Error::Io(e)),
+                    Err(e) => Err(Error::Io(e.into())),
                 };
             }
         }

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -398,7 +398,7 @@ impl<R: BufRead> Reader<R> {
 impl Reader<BufReader<File>> {
     /// Creates an XML reader from a file path.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = File::open(path).map_err(Error::Io)?;
+        let file = File::open(path)?;
         let reader = BufReader::new(file);
         Ok(Self::from_reader(reader))
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 
 use crate::encoding::UTF8_BOM;
-use crate::errors::{Error, Result};
+use crate::errors::Result;
 use crate::events::{attributes::Attribute, BytesCData, BytesStart, BytesText, Event};
 
 /// XML writer. Writes XML [`Event`]s to a [`std::io::Write`] implementor.
@@ -163,7 +163,7 @@ impl<W: Write> Writer<W> {
     /// Writes bytes
     #[inline]
     pub(crate) fn write(&mut self, value: &[u8]) -> Result<()> {
-        self.writer.write_all(value).map_err(Error::Io)
+        self.writer.write_all(value).map_err(Into::into)
     }
 
     #[inline]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -170,8 +170,8 @@ impl<W: Write> Writer<W> {
     fn write_wrapped(&mut self, before: &[u8], value: &[u8], after: &[u8]) -> Result<()> {
         if let Some(ref i) = self.indent {
             if i.should_line_break {
-                self.writer.write_all(b"\n").map_err(Error::Io)?;
-                self.writer.write_all(i.current()).map_err(Error::Io)?;
+                self.writer.write_all(b"\n")?;
+                self.writer.write_all(i.current())?;
             }
         }
         self.write(before)?;
@@ -193,8 +193,8 @@ impl<W: Write> Writer<W> {
     /// [`new_with_indent`]: Self::new_with_indent
     pub fn write_indent(&mut self) -> Result<()> {
         if let Some(ref i) = self.indent {
-            self.writer.write_all(b"\n").map_err(Error::Io)?;
-            self.writer.write_all(i.current()).map_err(Error::Io)?;
+            self.writer.write_all(b"\n")?;
+            self.writer.write_all(i.current())?;
         }
         Ok(())
     }


### PR DESCRIPTION
This would allow using crates to embed errors from this crate into their error types that implement Clone.

Unfortunately `std::io::Error` [does not implement `Clone`](https://github.com/rust-lang/rust/issues/24135) so we've to loose some of its state during cloning. The most importat bit (error kind) is preserved though.