### PR TITLE
Fix couple of bugs in serde deserializer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,8 @@
   ```xml
   unwanted text<struct>...</struct>
   ```
+- [#523]: Fix incorrect handling of `xs:list`s with encoded spaces: they still
+  act as delimiters, which is confirmed also by mature XmlBeans Java library
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,11 @@
 - [#514]: Fix wrong reporting `Error::EndEventMismatch` after disabling and enabling
   `.check_end_names`
 - [#517]: Fix swapped codes for `\r` and `\n` characters when escaping them
+- [#523]: Fix incorrect skipping text and CDATA content before any map-like structures
+  in serde deserializer, like
+  ```xml
+  unwanted text<struct>...</struct>
+  ```
 
 ### Misc Changes
 
@@ -64,6 +69,7 @@
 [#514]: https://github.com/tafia/quick-xml/issues/514
 [#517]: https://github.com/tafia/quick-xml/issues/517
 [#521]: https://github.com/tafia/quick-xml/pull/521
+[#523]: https://github.com/tafia/quick-xml/pull/523
 [XML name]: https://www.w3.org/TR/xml11/#NT-Name
 [documentation]: https://docs.rs/quick-xml/0.27.0/quick_xml/de/index.html#difference-between-text-and-value-special-names
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -311,15 +311,13 @@ where
             // of that events)
             // This case are checked by "xml_schema_lists::element" tests in tests/serde-de.rs
             ValueSource::Text => match self.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_cow(
-                    e.into_inner(),
-                    true,
-                    self.de.reader.decoder(),
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
+                    // Comment to prevent auto-formatting
+                    e.decode(true)?,
                 )),
-                DeEvent::CData(e) => seed.deserialize(SimpleTypeDeserializer::from_cow(
-                    e.into_inner(),
-                    false,
-                    self.de.reader.decoder(),
+                DeEvent::CData(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
+                    // Comment to prevent auto-formatting
+                    e.decode()?,
                 )),
                 // SAFETY: We set `Text` only when we seen `Text` or `CData`
                 _ => unreachable!(),
@@ -777,17 +775,14 @@ where
         V: Visitor<'de>,
     {
         match self.map.de.next()? {
-            DeEvent::Text(e) => SimpleTypeDeserializer::from_cow(
-                // Comment to prevent auto-formatting and keep Text and Cdata similar
-                e.into_inner(),
-                true,
-                self.map.de.reader.decoder(),
+            DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(
+                // Comment to prevent auto-formatting
+                e.decode(true)?,
             )
             .deserialize_seq(visitor),
-            DeEvent::CData(e) => SimpleTypeDeserializer::from_cow(
-                e.into_inner(),
-                false,
-                self.map.de.reader.decoder(),
+            DeEvent::CData(e) => SimpleTypeDeserializer::from_text_content(
+                // Comment to prevent auto-formatting
+                e.decode()?,
             )
             .deserialize_seq(visitor),
             // This is a sequence element. We cannot treat it as another flatten
@@ -795,16 +790,14 @@ where
             // it to `xs:simpleType` implementation
             DeEvent::Start(e) => {
                 let value = match self.map.de.next()? {
-                    DeEvent::Text(e) => SimpleTypeDeserializer::from_cow(
-                        e.into_inner(),
-                        true,
-                        self.map.de.reader.decoder(),
+                    DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(
+                        // Comment to prevent auto-formatting
+                        e.decode(true)?,
                     )
                     .deserialize_seq(visitor),
-                    DeEvent::CData(e) => SimpleTypeDeserializer::from_cow(
-                        e.into_inner(),
-                        false,
-                        self.map.de.reader.decoder(),
+                    DeEvent::CData(e) => SimpleTypeDeserializer::from_text_content(
+                        // Comment to prevent auto-formatting
+                        e.decode()?,
                     )
                     .deserialize_seq(visitor),
                     e => Err(DeError::Unsupported(

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -381,7 +381,7 @@ where
     /// Access to the map that created this deserializer. Gives access to the
     /// context, such as list of fields, that current map known about.
     map: &'m mut MapAccess<'de, 'a, R>,
-    /// Determines, should [`Deserializer::next_text_impl()`] expand the second
+    /// Determines, should [`Deserializer::read_string_impl()`] expand the second
     /// level of tags or not.
     ///
     /// If this field is `true`, we process the following XML shape:
@@ -463,10 +463,14 @@ impl<'de, 'a, 'm, R> MapValueDeserializer<'de, 'a, 'm, R>
 where
     R: XmlRead<'de>,
 {
-    /// Returns a text event, used inside [`deserialize_primitives!()`]
+    /// Returns a next string as concatenated content of consequent [`Text`] and
+    /// [`CData`] events, used inside [`deserialize_primitives!()`].
+    ///
+    /// [`Text`]: DeEvent::Text
+    /// [`CData`]: DeEvent::CData
     #[inline]
-    fn next_text(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
-        self.map.de.next_text_impl(unescape, self.allow_start)
+    fn read_string(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
+        self.map.de.read_string_impl(unescape, self.allow_start)
     }
 }
 
@@ -709,10 +713,14 @@ impl<'de, 'a, 'm, R> SeqValueDeserializer<'de, 'a, 'm, R>
 where
     R: XmlRead<'de>,
 {
-    /// Returns a text event, used inside [`deserialize_primitives!()`]
+    /// Returns a next string as concatenated content of consequent [`Text`] and
+    /// [`CData`] events, used inside [`deserialize_primitives!()`].
+    ///
+    /// [`Text`]: DeEvent::Text
+    /// [`CData`]: DeEvent::CData
     #[inline]
-    fn next_text(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
-        self.map.de.next_text_impl(unescape, true)
+    fn read_string(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
+        self.map.de.read_string_impl(unescape, true)
     }
 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -239,7 +239,7 @@ macro_rules! deserialize_type {
             V: Visitor<'de>,
         {
             // No need to unescape because valid integer representations cannot be escaped
-            let text = self.next_text(false)?;
+            let text = self.read_string(false)?;
             visitor.$visit(text.parse()?)
         }
     };
@@ -272,7 +272,7 @@ macro_rules! deserialize_primitives {
             V: Visitor<'de>,
         {
             // No need to unescape because valid boolean representations cannot be escaped
-            let text = self.next_text(false)?;
+            let text = self.read_string(false)?;
 
             str2bool(&text, visitor)
         }
@@ -297,7 +297,7 @@ macro_rules! deserialize_primitives {
         where
             V: Visitor<'de>,
         {
-            let text = self.next_text(true)?;
+            let text = self.read_string(true)?;
             match text {
                 Cow::Borrowed(string) => visitor.visit_borrowed_str(string),
                 Cow::Owned(string) => visitor.visit_string(string),
@@ -685,8 +685,8 @@ where
     }
 
     #[inline]
-    fn next_text(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
-        self.next_text_impl(unescape, true)
+    fn read_string(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
+        self.read_string_impl(unescape, true)
     }
 
     /// Consumes a one XML element or an XML tree, returns associated text or
@@ -721,7 +721,7 @@ where
     /// |[`DeEvent::Text`] |`text content`             |Unescapes `text content` and returns it, consumes events up to `</tag>`
     /// |[`DeEvent::CData`]|`<![CDATA[cdata content]]>`|Returns `cdata content` unchanged, consumes events up to `</tag>`
     /// |[`DeEvent::Eof`]  |                           |Emits [`UnexpectedEof`](DeError::UnexpectedEof)
-    fn next_text_impl(
+    fn read_string_impl(
         &mut self,
         unescape: bool,
         allow_start: bool,
@@ -1732,10 +1732,10 @@ mod tests {
         assert_eq!(reader.next().unwrap(), DeEvent::Eof);
     }
 
-    /// Ensures, that [`Deserializer::next_text()`] never can get an `End` event,
+    /// Ensures, that [`Deserializer::read_string()`] never can get an `End` event,
     /// because parser reports error early
     #[test]
-    fn next_text() {
+    fn read_string() {
         match from_str::<String>(r#"</root>"#) {
             Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
                 assert_eq!(expected, "");

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -522,12 +522,12 @@ pub struct SimpleTypeDeserializer<'de, 'a> {
 
 impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
     /// Creates a deserializer from a value, that possible borrowed from input
-    pub fn from_cow(value: Cow<'de, [u8]>, escaped: bool, decoder: Decoder) -> Self {
+    pub fn from_text_content(value: Cow<'de, str>) -> Self {
         let content = match value {
-            Cow::Borrowed(slice) => CowRef::Input(slice),
-            Cow::Owned(content) => CowRef::Owned(content),
+            Cow::Borrowed(slice) => CowRef::Input(slice.as_bytes()),
+            Cow::Owned(content) => CowRef::Owned(content.into_bytes()),
         };
-        Self::new(content, escaped, decoder)
+        Self::new(content, false, Decoder::utf8())
     }
 
     /// Creates a deserializer from a part of value at specified range

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -6060,10 +6060,13 @@ mod xml_schema_lists {
             list!(bool_: bool = "<root>true false  true</root>" => vec![true, false, true]);
             list!(char_: char = "<root>4 2  j</root>" => vec!['4', '2', 'j']);
 
+            // Expanding of entity references happens before list parsing
+            // This is confirmed by XmlBeans (mature Java library) as well
             list!(string: String = "<root>first second  third&#x20;3</root>" => vec![
                 "first".to_string(),
                 "second".to_string(),
-                "third 3".to_string(),
+                "third".to_string(),
+                "3".to_string(),
             ]);
             err!(byte_buf: ByteBuf = "<root>first second  third&#x20;3</root>"
                 => Unsupported("byte arrays are not supported as `xs:list` items"));


### PR DESCRIPTION
This PR fixes two bugs in serde deserializer that I found during work on #521:
- text of CDATA content before the element was silently skipped when attempting to deserialize `struct`s. This should not happen
- unescaping of escaped entities is performed before applying rules to split elements in `xs:list`. That means, that you cannot encode spaces in `xs:list` elements using entity references `&#32;` and `&#x20;` -- that escape sequences should be threated as list delimiters. The Java's mature XmlBeans library confirm that.