### PR TITLE
Fix #473: add explicit serde feature that is independent from dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,8 +164,21 @@ escape-html = []
 ## [`Deserializer`]: crate::de::Deserializer
 overlapped-lists = []
 
-## Enables support for [`serde`] serialization and deserialization
-serialize = ["serde"]
+## Enables serialization of some types using [`serde`]. Probably your rarely will
+## need this feature enabled.
+##
+## This feature does NOT provide XML serializer or deserializer. You should use
+## the `serialize` feature for that instead.
+# Cannot name "serde" to avoid clash with dependency.
+# "dep:" prefix only avalible from Rust 1.60
+serde-types = ["serde/derive"]
+
+## Enables support for [`serde`] serialization and deserialization. When this
+## feature is enabled, quick-xml provides serializer and deserializer for XML.
+##
+## This feature does NOT enables serializaton of the types inside quick-xml.
+## If you need that, use the `serde-types` feature.
+serialize = ["serde"] # "dep:" prefix only avalible from Rust 1.60
 
 [package.metadata.docs.rs]
 # document all features

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@
   ```
 - [#523]: Fix incorrect handling of `xs:list`s with encoded spaces: they still
   act as delimiters, which is confirmed also by mature XmlBeans Java library
+- [#473]: Fix a hidden requirement to enable serde's `derive` feature to get
+  quick-xml's `serialize` feature for `edition = 2021` or `resolver = 2` crates
 
 ### Misc Changes
 
@@ -65,7 +67,9 @@
 
   Refer to [documentation] for details.
 - [#521]: MSRV bumped to 1.52.
+- [#473]: `serde` feature that used to make some types serializable, renamed to `serde-types`
 
+[#473]: https://github.com/tafia/quick-xml/issues/473
 [#490]: https://github.com/tafia/quick-xml/pull/490
 [#500]: https://github.com/tafia/quick-xml/issues/500
 [#514]: https://github.com/tafia/quick-xml/issues/514

--- a/src/name.rs
+++ b/src/name.rs
@@ -16,7 +16,7 @@ use std::fmt::{self, Debug, Formatter};
 ///
 /// [qualified name]: https://www.w3.org/TR/xml-names11/#dt-qualname
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde-types", derive(serde::Deserialize, serde::Serialize))]
 pub struct QName<'a>(pub &'a [u8]);
 impl<'a> QName<'a> {
     /// Converts this name to an internal slice representation.
@@ -133,7 +133,7 @@ impl<'a> AsRef<[u8]> for QName<'a> {
 ///
 /// [local (unqualified) name]: https://www.w3.org/TR/xml-names11/#dt-localname
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde-types", derive(serde::Deserialize, serde::Serialize))]
 pub struct LocalName<'a>(&'a [u8]);
 impl<'a> LocalName<'a> {
     /// Converts this name to an internal slice representation.
@@ -183,7 +183,7 @@ impl<'a> From<QName<'a>> for LocalName<'a> {
 ///
 /// [namespace prefix]: https://www.w3.org/TR/xml-names11/#dt-prefix
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde-types", derive(serde::Deserialize, serde::Serialize))]
 pub struct Prefix<'a>(&'a [u8]);
 impl<'a> Prefix<'a> {
     /// Extracts internal slice
@@ -225,7 +225,7 @@ pub enum PrefixDeclaration<'a> {
 ///
 /// [namespace name]: https://www.w3.org/TR/xml-names11/#dt-NSName
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde-types", derive(serde::Deserialize, serde::Serialize))]
 pub struct Namespace<'a>(pub &'a [u8]);
 impl<'a> Namespace<'a> {
     /// Converts this namespace to an internal slice representation.


### PR DESCRIPTION
This should fix #473. @loyd, @xkr47, can you check?

Checked by 
```console
cargo init
cargo add quick-xml --features serialize --path path/to/local/copy/of/quick-xml
cargo check
```
(failed without `--path` with the fix)