### PR TITLE
Fix bugs when parsing sequences in `overlapped-lists` mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@
 
 - [#530]: Fix an infinite loop leading to unbounded memory consumption that occurs when
   skipping events on malformed XML with the `overlapped-lists` feature active.
+- [#530]: Fix an error in the `Deserializer::read_to_end` when `overlapped-lists`
+  feature is active and malformed XML is parsed
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,12 @@
 
 ### Bug Fixes
 
+- [#530]: Fix an infinite loop leading to unbounded memory consumption that occurs when
+  skipping events on malformed XML with the `overlapped-lists` feature active.
+
 ### Misc Changes
+
+[#530]: https://github.com/tafia/quick-xml/pull/530
 
 ## 0.27.0 -- 2022-12-25
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3155,11 +3155,11 @@ mod tests {
 
     #[test]
     fn borrowing_reader_parity() {
-        let s = r##"
+        let s = r#"
             <item name="hello" source="world.rs">Some text</item>
             <item2/>
             <item3 value="world" />
-    	"##;
+        "#;
 
         let mut reader1 = IoReader {
             reader: Reader::from_reader(s.as_bytes()),
@@ -3183,12 +3183,12 @@ mod tests {
 
     #[test]
     fn borrowing_reader_events() {
-        let s = r##"
+        let s = r#"
             <item name="hello" source="world.rs">Some text</item>
             <item2></item2>
             <item3/>
             <item4 value="world" />
-        "##;
+        "#;
 
         let mut reader = SliceReader {
             reader: Reader::from_str(s),
@@ -3229,27 +3229,6 @@ mod tests {
                 End(BytesEnd::new("item4")),
             ]
         )
-    }
-
-    #[test]
-    fn borrowing_read_to_end() {
-        let s = " <item /> ";
-        let mut reader = SliceReader {
-            reader: Reader::from_str(s),
-        };
-
-        reader
-            .reader
-            .trim_text(true)
-            .expand_empty_elements(true)
-            .check_end_names(true);
-
-        assert_eq!(
-            reader.next().unwrap(),
-            DeEvent::Start(BytesStart::from_content("item ", 4))
-        );
-        reader.read_to_end(QName(b"item")).unwrap();
-        assert_eq!(reader.next().unwrap(), DeEvent::Eof);
     }
 
     /// Ensures, that [`Deserializer::read_string()`] never can get an `End` event,


### PR DESCRIPTION
This fixes two bugs, that I've found:
- `Deserializer::skip()` could enter to an infinity loop when parse malformed XML (some tags does not closed)
- `Deserializer::read_to_end()` could return success when parse malformed XML (some tags does not closed)

I think both bugs are important enough to release 0.27.1