### PR TITLE
Restore ability to deserialize attributes that represents XML namespace mappings (`xmlns:xxx`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,11 @@ required-features = ["serialize"]
 path = "tests/serde-migrated.rs"
 
 [[test]]
+name = "serde-issues"
+required-features = ["serialize"]
+path = "tests/serde-issues.rs"
+
+[[test]]
 name = "async-tokio"
 required-features = ["async-tokio"]
 path = "tests/async-tokio.rs"

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,13 @@
 
 ### Bug Fixes
 
+- [#537]: Restore ability to deserialize attributes that represents XML namespace
+  mappings (`xmlns:xxx`) that was broken since [#490]
+
 ### Misc Changes
+
+[#490]: https://github.com/tafia/quick-xml/pull/490
+[#537]: https://github.com/tafia/quick-xml/issues/537
 
 ## 0.27.1 -- 2022-12-28
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,6 +1,6 @@
-//! Regression tests found in various issues
+//! Regression tests found in various issues.
 //!
-//! Name each test as `issue<GH number>`
+//! Name each module / test as `issue<GH number>` and keep sorted by issue number
 
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::reader::Reader;

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -1,0 +1,60 @@
+//! Regression tests found in various issues with serde integration.
+//!
+//! Name each module / test as `issue<GH number>` and keep sorted by issue number
+
+use quick_xml::de::from_str;
+use quick_xml::se::to_string;
+use serde::{Deserialize, Serialize};
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/537.
+///
+/// This test checks that special `xmlns:xxx` attributes uses full name of
+/// an attribute (xmlns:xxx) as a field name instead of just local name of
+/// an attribute (xxx)
+mod issue537 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct Bindings<'a> {
+        /// Default namespace binding
+        #[serde(rename = "@xmlns")]
+        xmlns: &'a str,
+
+        /// Named namespace binding
+        #[serde(rename = "@xmlns:named")]
+        xmlns_named: &'a str,
+
+        /// Usual attribute
+        #[serde(rename = "@attribute")]
+        attribute: &'a str,
+    }
+
+    #[test]
+    fn de() {
+        assert_eq!(
+            from_str::<Bindings>(
+                r#"<Bindings xmlns="default" xmlns:named="named" attribute="attribute"/>"#
+            )
+            .unwrap(),
+            Bindings {
+                xmlns: "default",
+                xmlns_named: "named",
+                attribute: "attribute",
+            }
+        );
+    }
+
+    #[test]
+    fn se() {
+        assert_eq!(
+            to_string(&Bindings {
+                xmlns: "default",
+                xmlns_named: "named",
+                attribute: "attribute",
+            })
+            .unwrap(),
+            r#"<Bindings xmlns="default" xmlns:named="named" attribute="attribute"/>"#
+        );
+    }
+}


### PR DESCRIPTION
Fixes #537.

Change in behavior was made in 8b50c64de3f309d670d3393f894b6cfe4b2aeca2 of #490 
https://github.com/tafia/quick-xml/blob/4a09041c023918541acbdaf28c825e8ca9798350/src/de/key.rs#L73-L80

Here only local part of an attribute name is mapped to the field name. Because `xmlns:...` attributes is a special names, I make a special handling for that names -- use the full name of an attribute.

Note, that usually `xmlns` should not be considered as a data that could be accessed via serde interface. This is metadata of an XML serialization format. When (if) #218 would be implemented, that attributes most likely wouldn't be accessible at all.