### PR TITLE
Add regression tests for fixed issues

### DIFF
--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -3,8 +3,22 @@
 //! Name each module / test as `issue<GH number>` and keep sorted by issue number
 
 use quick_xml::events::{BytesStart, Event};
+use quick_xml::name::QName;
 use quick_xml::reader::Reader;
 use quick_xml::Error;
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/115
+#[test]
+fn issue115() {
+    let mut r = Reader::from_str("<tag1 attr1='line 1\nline 2'></tag1>");
+    match r.read_event() {
+        Ok(Event::Start(e)) if e.name() == QName(b"tag1") => {
+            let v = e.attributes().map(|a| a.unwrap().value).collect::<Vec<_>>();
+            assert_eq!(v[0].clone().into_owned(), b"line 1\nline 2");
+        }
+        _ => (),
+    }
+}
 
 /// Regression test for https://github.com/tafia/quick-xml/issues/514
 mod issue514 {

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -142,6 +142,43 @@ fn issue349() {
     );
 }
 
+/// Regression test for https://github.com/tafia/quick-xml/issues/429.
+#[test]
+fn issue429() {
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    enum State {
+        A,
+        B,
+        C,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct StateOuter {
+        #[serde(rename = "$text")]
+        state: State,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    pub struct Root {
+        state: StateOuter,
+    }
+
+    assert_eq!(
+        from_str::<Root>("<root><state>B</state></root>").unwrap(),
+        Root {
+            state: StateOuter { state: State::B }
+        }
+    );
+
+    assert_eq!(
+        to_string(&Root {
+            state: StateOuter { state: State::B }
+        })
+        .unwrap(),
+        "<Root><state>B</state></Root>"
+    );
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/537.
 ///
 /// This test checks that special `xmlns:xxx` attributes uses full name of

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -179,6 +179,68 @@ fn issue429() {
     );
 }
 
+/// Regression test for https://github.com/tafia/quick-xml/issues/500.
+#[test]
+fn issue500() {
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct TagOne {}
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct TagTwo {}
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    enum Tag {
+        TagOne(TagOne),
+        TagTwo(TagTwo),
+    }
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Root {
+        #[serde(rename = "$value", default)]
+        data: Vec<Tag>,
+    }
+
+    let data: Root = from_str(
+        "\
+        <root>\
+            <TagOne></TagOne>\
+            <TagTwo></TagTwo>\
+            <TagOne></TagOne>\
+        </root>\
+    ",
+    )
+    .unwrap();
+
+    assert_eq!(
+        data,
+        Root {
+            data: vec![
+                Tag::TagOne(TagOne {}),
+                Tag::TagTwo(TagTwo {}),
+                Tag::TagOne(TagOne {}),
+            ],
+        }
+    );
+
+    let data: Vec<Tag> = from_str(
+        "\
+        <TagOne></TagOne>\
+        <TagTwo></TagTwo>\
+        <TagOne></TagOne>\
+    ",
+    )
+    .unwrap();
+
+    assert_eq!(
+        data,
+        vec![
+            Tag::TagOne(TagOne {}),
+            Tag::TagTwo(TagTwo {}),
+            Tag::TagOne(TagOne {}),
+        ]
+    );
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/537.
 ///
 /// This test checks that special `xmlns:xxx` attributes uses full name of

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -2,9 +2,11 @@
 //!
 //! Name each module / test as `issue<GH number>` and keep sorted by issue number
 
+use pretty_assertions::assert_eq;
 use quick_xml::de::from_str;
 use quick_xml::se::to_string;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Regression tests for https://github.com/tafia/quick-xml/issues/252.
 mod issue252 {
@@ -76,6 +78,39 @@ mod issue252 {
             r#"<OptionalElements><a>a</a><b>b</b></OptionalElements>"#
         );
     }
+}
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/343.
+#[test]
+fn issue343() {
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Users {
+        users: HashMap<String, User>,
+    }
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Max(u16);
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct User {
+        max: Max,
+    }
+
+    let xml = "<Users>\
+                        <users>\
+                            <roger>\
+                                <max>10</max>\
+                            </roger>\
+                        </users>\
+                    </Users>";
+    let users: Users = from_str(xml).unwrap();
+
+    assert_eq!(
+        users,
+        Users {
+            users: HashMap::from([("roger".to_string(), User { max: Max(10) })]),
+        }
+    );
+    assert_eq!(to_string(&users).unwrap(), xml);
 }
 
 /// Regression test for https://github.com/tafia/quick-xml/issues/537.

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -6,6 +6,78 @@ use quick_xml::de::from_str;
 use quick_xml::se::to_string;
 use serde::{Deserialize, Serialize};
 
+/// Regression tests for https://github.com/tafia/quick-xml/issues/252.
+mod issue252 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn attributes() {
+        #[derive(Serialize, Debug, PartialEq)]
+        struct OptionalAttributes {
+            #[serde(rename = "@a")]
+            a: Option<&'static str>,
+
+            #[serde(rename = "@b")]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            b: Option<&'static str>,
+        }
+
+        assert_eq!(
+            to_string(&OptionalAttributes { a: None, b: None }).unwrap(),
+            r#"<OptionalAttributes a=""/>"#
+        );
+        assert_eq!(
+            to_string(&OptionalAttributes {
+                a: Some(""),
+                b: Some("")
+            })
+            .unwrap(),
+            r#"<OptionalAttributes a="" b=""/>"#
+        );
+        assert_eq!(
+            to_string(&OptionalAttributes {
+                a: Some("a"),
+                b: Some("b")
+            })
+            .unwrap(),
+            r#"<OptionalAttributes a="a" b="b"/>"#
+        );
+    }
+
+    #[test]
+    fn elements() {
+        #[derive(Serialize, Debug, PartialEq)]
+        struct OptionalElements {
+            a: Option<&'static str>,
+
+            #[serde(skip_serializing_if = "Option::is_none")]
+            b: Option<&'static str>,
+        }
+
+        assert_eq!(
+            to_string(&OptionalElements { a: None, b: None }).unwrap(),
+            r#"<OptionalElements><a/></OptionalElements>"#
+        );
+        assert_eq!(
+            to_string(&OptionalElements {
+                a: Some(""),
+                b: Some("")
+            })
+            .unwrap(),
+            r#"<OptionalElements><a/><b/></OptionalElements>"#
+        );
+        assert_eq!(
+            to_string(&OptionalElements {
+                a: Some("a"),
+                b: Some("b")
+            })
+            .unwrap(),
+            r#"<OptionalElements><a>a</a><b>b</b></OptionalElements>"#
+        );
+    }
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/537.
 ///
 /// This test checks that special `xmlns:xxx` attributes uses full name of

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -113,6 +113,35 @@ fn issue343() {
     assert_eq!(to_string(&users).unwrap(), xml);
 }
 
+/// Regression test for https://github.com/tafia/quick-xml/issues/349.
+#[test]
+fn issue349() {
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Entity {
+        id: Id,
+    }
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Id {
+        #[serde(rename = "$value")]
+        content: Enum,
+    }
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(rename_all = "kebab-case")]
+    enum Enum {
+        A(String),
+        B(String),
+    }
+
+    assert_eq!(
+        from_str::<Entity>("<entity><id><a>Id</a></id></entity>").unwrap(),
+        Entity {
+            id: Id {
+                content: Enum::A("Id".to_string()),
+            }
+        }
+    );
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/537.
 ///
 /// This test checks that special `xmlns:xxx` attributes uses full name of


### PR DESCRIPTION
A set of tests copied directly from issues (with minimal changes) just to be sure, that reported problems solved. Although each problem already has its own set of tests testing it, these tests make sure that we do not have any hidden interaction effects.

Included tests for:
- #115 
- #252 
- #343 
- #349 
- #360 
- #429 
- #500