### PR TITLE
 Fix using incorrect deserializer when deserialize `Option` values in maps and structs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,11 +19,14 @@
 
 - [#537]: Restore ability to deserialize attributes that represents XML namespace
   mappings (`xmlns:xxx`) that was broken since [#490]
+- [#510]: Fix an error of deserialization of `Option<T>` fields where `T` is some
+  sequence type (for example, `Vec` or tuple)
 
 ### Misc Changes
 
 [externally tagged]: https://serde.rs/enum-representations.html#externally-tagged
 [#490]: https://github.com/tafia/quick-xml/pull/490
+[#510]: https://github.com/tafia/quick-xml/issues/510
 [#537]: https://github.com/tafia/quick-xml/issues/537
 [#541]: https://github.com/tafia/quick-xml/pull/541
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -481,8 +481,6 @@ where
     deserialize_primitives!(mut);
 
     forward!(deserialize_unit);
-    forward!(deserialize_unit_struct(name: &'static str));
-    forward!(deserialize_newtype_struct(name: &'static str));
 
     forward!(deserialize_map);
     forward!(deserialize_struct(
@@ -503,27 +501,6 @@ where
         V: Visitor<'de>,
     {
         deserialize_option!(self.map.de, self, visitor)
-    }
-
-    /// Tuple representation is the same as [sequences](#method.deserialize_seq).
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    /// Named tuple representation is the same as [unnamed tuples](#method.deserialize_tuple).
-    fn deserialize_tuple_struct<V>(
-        self,
-        _name: &'static str,
-        len: usize,
-        visitor: V,
-    ) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_tuple(len, visitor)
     }
 
     /// Deserializes each `<tag>` in
@@ -765,8 +742,6 @@ where
     deserialize_primitives!(mut);
 
     forward!(deserialize_unit);
-    forward!(deserialize_unit_struct(name: &'static str));
-    forward!(deserialize_newtype_struct(name: &'static str));
 
     forward!(deserialize_map);
     forward!(deserialize_struct(
@@ -787,27 +762,6 @@ where
         V: Visitor<'de>,
     {
         deserialize_option!(self.map.de, self, visitor)
-    }
-
-    /// Representation of tuples the same as [sequences](#method.deserialize_seq).
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    /// Representation of named tuples the same as [unnamed tuples](#method.deserialize_tuple).
-    fn deserialize_tuple_struct<V>(
-        self,
-        _name: &'static str,
-        len: usize,
-        visitor: V,
-    ) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_tuple(len, visitor)
     }
 
     /// This method deserializes a sequence inside of element that itself is a

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -480,7 +480,6 @@ where
 
     deserialize_primitives!(mut);
 
-    forward!(deserialize_option);
     forward!(deserialize_unit);
     forward!(deserialize_unit_struct(name: &'static str));
     forward!(deserialize_newtype_struct(name: &'static str));
@@ -498,6 +497,13 @@ where
 
     forward!(deserialize_any);
     forward!(deserialize_ignored_any);
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        deserialize_option!(self.map.de, self, visitor)
+    }
 
     /// Tuple representation is the same as [sequences](#method.deserialize_seq).
     fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
@@ -758,7 +764,6 @@ where
 
     deserialize_primitives!(mut);
 
-    forward!(deserialize_option);
     forward!(deserialize_unit);
     forward!(deserialize_unit_struct(name: &'static str));
     forward!(deserialize_newtype_struct(name: &'static str));
@@ -776,6 +781,13 @@ where
 
     forward!(deserialize_any);
     forward!(deserialize_ignored_any);
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        deserialize_option!(self.map.de, self, visitor)
+    }
 
     /// Representation of tuples the same as [sequences](#method.deserialize_seq).
     fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1815,6 +1815,50 @@ macro_rules! deserialize_primitives {
             self.deserialize_bytes(visitor)
         }
 
+        /// Representation of the named units the same as [unnamed units](#method.deserialize_unit)
+        fn deserialize_unit_struct<V>(
+            self,
+            _name: &'static str,
+            visitor: V,
+        ) -> Result<V::Value, DeError>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_unit(visitor)
+        }
+
+        fn deserialize_newtype_struct<V>(
+            self,
+            _name: &'static str,
+            visitor: V,
+        ) -> Result<V::Value, DeError>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_tuple(1, visitor)
+        }
+
+        /// Representation of tuples the same as [sequences](#method.deserialize_seq).
+        fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_seq(visitor)
+        }
+
+        /// Representation of named tuples the same as [unnamed tuples](#method.deserialize_tuple).
+        fn deserialize_tuple_struct<V>(
+            self,
+            _name: &'static str,
+            len: usize,
+            visitor: V,
+        ) -> Result<V::Value, DeError>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_tuple(len, visitor)
+        }
+
         /// Identifiers represented as [strings](#method.deserialize_str).
         fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
@@ -2422,50 +2466,6 @@ where
             DeEvent::End(e) => Err(DeError::UnexpectedEnd(e.name().as_ref().to_owned())),
             DeEvent::Eof => Err(DeError::UnexpectedEof),
         }
-    }
-
-    /// Representation of the names units the same as [unnamed units](#method.deserialize_unit)
-    fn deserialize_unit_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_unit(visitor)
-    }
-
-    fn deserialize_newtype_struct<V>(
-        self,
-        _name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_tuple(1, visitor)
-    }
-
-    /// Representation of tuples the same as [sequences](#method.deserialize_seq).
-    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_seq(visitor)
-    }
-
-    /// Representation of named tuples the same as [unnamed tuples](#method.deserialize_tuple).
-    fn deserialize_tuple_struct<V>(
-        self,
-        _name: &'static str,
-        len: usize,
-        visitor: V,
-    ) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_tuple(len, visitor)
     }
 
     fn deserialize_enum<V>(

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -241,6 +241,48 @@ fn issue500() {
     );
 }
 
+/// Regression test for https://github.com/tafia/quick-xml/issues/510.
+#[test]
+fn issue510() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(rename = "ENTRY")]
+    struct Entry {
+        #[serde(rename = "CUE_V2")]
+        cues: Option<Vec<Cue>>,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    // #[serde_with::serde_as]
+    struct Cue {
+        #[serde(rename = "@NAME")]
+        name: String,
+    }
+
+    let data: Entry = from_str(
+        "\
+        <ENTRY>\
+            <CUE_V2 NAME='foo'></CUE_V2>\
+            <CUE_V2 NAME='bar'></CUE_V2>\
+        </ENTRY>\
+    ",
+    )
+    .unwrap();
+
+    assert_eq!(
+        data,
+        Entry {
+            cues: Some(vec![
+                Cue {
+                    name: "foo".to_string(),
+                },
+                Cue {
+                    name: "bar".to_string(),
+                },
+            ]),
+        }
+    );
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/537.
 ///
 /// This test checks that special `xmlns:xxx` attributes uses full name of


### PR DESCRIPTION
Fixes #510. The reason for the error is that an incorrect deserializer was used after forwarding. The fix changes all methods that can forward actual deserialization to another deserializer, like that:
```rust
    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
    where
        V: Visitor<'de>,
    {
        match self.peek()? {
            DeEvent::Text(t) if t.is_empty() => visitor.visit_none(),
            DeEvent::CData(t) if t.is_empty() => visitor.visit_none(),
            DeEvent::Eof => visitor.visit_none(),
            _ => visitor.visit_some(self), // <<< Forwarding deserialization to another deserializer
        }
    }
```