### PR TITLE
Truly check that result is borrowed when it should

### DIFF
--- a/src/escapei.rs
+++ b/src/escapei.rs
@@ -1741,7 +1741,13 @@ fn parse_decimal(bytes: &str) -> Result<u32, EscapeError> {
 
 #[test]
 fn test_unescape() {
-    assert_eq!(unescape("test").unwrap(), Cow::Borrowed("test"));
+    let unchanged = unescape("test").unwrap();
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Cow::Borrowed("test"));
+    assert!(matches!(unchanged, Cow::Borrowed(_)));
+
     assert_eq!(unescape("&lt;test&gt;").unwrap(), "<test>");
     assert_eq!(unescape("&#x30;").unwrap(), "0");
     assert_eq!(unescape("&#48;").unwrap(), "0");
@@ -1755,10 +1761,13 @@ fn test_unescape_with() {
         _ => None,
     };
 
-    assert_eq!(
-        unescape_with("test", custom_entities).unwrap(),
-        Cow::Borrowed("test")
-    );
+    let unchanged = unescape_with("test", custom_entities).unwrap();
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Cow::Borrowed("test"));
+    assert!(matches!(unchanged, Cow::Borrowed(_)));
+
     assert_eq!(
         unescape_with("&lt;test&gt;", custom_entities).unwrap(),
         "<test>"
@@ -1771,7 +1780,13 @@ fn test_unescape_with() {
 
 #[test]
 fn test_escape() {
-    assert_eq!(escape("test"), Cow::Borrowed("test"));
+    let unchanged = escape("test");
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Cow::Borrowed("test"));
+    assert!(matches!(unchanged, Cow::Borrowed(_)));
+
     assert_eq!(escape("<test>"), "&lt;test&gt;");
     assert_eq!(escape("\"a\"bc"), "&quot;a&quot;bc");
     assert_eq!(escape("\"a\"b&c"), "&quot;a&quot;b&amp;c");
@@ -1783,7 +1798,13 @@ fn test_escape() {
 
 #[test]
 fn test_partial_escape() {
-    assert_eq!(partial_escape("test"), Cow::Borrowed("test"));
+    let unchanged = partial_escape("test");
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Cow::Borrowed("test"));
+    assert!(matches!(unchanged, Cow::Borrowed(_)));
+
     assert_eq!(partial_escape("<test>"), "&lt;test&gt;");
     assert_eq!(partial_escape("\"a\"bc"), "\"a\"bc");
     assert_eq!(partial_escape("\"a\"b&c"), "\"a\"b&amp;c");

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -360,35 +360,28 @@ impl<'a> BytesDecl<'a> {
     /// # Examples
     ///
     /// ```
-    /// use std::borrow::Cow;
     /// use quick_xml::Error;
     /// use quick_xml::events::{BytesDecl, BytesStart};
     ///
     /// // <?xml version='1.1'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" version='1.1'", 0));
-    /// assert_eq!(
-    ///     decl.version().unwrap(),
-    ///     Cow::Borrowed(b"1.1".as_ref())
-    /// );
+    /// assert_eq!(decl.version().unwrap(), b"1.1".as_ref());
     ///
     /// // <?xml version='1.0' version='1.1'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" version='1.0' version='1.1'", 0));
-    /// assert_eq!(
-    ///     decl.version().unwrap(),
-    ///     Cow::Borrowed(b"1.0".as_ref())
-    /// );
+    /// assert_eq!(decl.version().unwrap(), b"1.0".as_ref());
     ///
     /// // <?xml encoding='utf-8'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" encoding='utf-8'", 0));
     /// match decl.version() {
-    ///     Err(Error::XmlDeclWithoutVersion(Some(key))) => assert_eq!(key, "encoding".to_string()),
+    ///     Err(Error::XmlDeclWithoutVersion(Some(key))) => assert_eq!(key, "encoding"),
     ///     _ => assert!(false),
     /// }
     ///
     /// // <?xml encoding='utf-8' version='1.1'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" encoding='utf-8' version='1.1'", 0));
     /// match decl.version() {
-    ///     Err(Error::XmlDeclWithoutVersion(Some(key))) => assert_eq!(key, "encoding".to_string()),
+    ///     Err(Error::XmlDeclWithoutVersion(Some(key))) => assert_eq!(key, "encoding"),
     ///     _ => assert!(false),
     /// }
     ///

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -212,6 +212,7 @@ impl<'a> Reader<&'a [u8]> {
     ///         <p>Usual XML rules does not apply inside it
     ///         <p>For example, elements not needed to be &quot;closed&quot;
     ///     "#));
+    /// assert!(matches!(text, Cow::Borrowed(_)));
     ///
     /// // Now we can enable checks again
     /// reader.check_end_names(true);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn write_byte_string0() {
         let bytes = ByteBuf(vec![10, 32, 32, 32, 32, 32, 32, 32, 32]);
-        assert_eq!(format!("{:?}", bytes), "\"0xA        \"".to_owned());
+        assert_eq!(format!("{:?}", bytes), "\"0xA        \"");
     }
 
     #[test]
@@ -160,7 +160,7 @@ mod tests {
         ]);
         assert_eq!(
             format!("{:?}", bytes),
-            r##""http://www.w3.org/2002/07/owl#""##.to_owned()
+            r##""http://www.w3.org/2002/07/owl#""##
         );
     }
 
@@ -169,6 +169,6 @@ mod tests {
         let bytes = ByteBuf(vec![
             67, 108, 97, 115, 115, 32, 73, 82, 73, 61, 34, 35, 66, 34,
         ]);
-        assert_eq!(format!("{:?}", bytes), r##""Class IRI=\"#B\"""##.to_owned());
+        assert_eq!(format!("{:?}", bytes), r##""Class IRI=\"#B\"""##);
     }
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -332,7 +332,7 @@ fn test_new_xml_decl_full() {
     let result = writer.into_inner();
     assert_eq!(
         String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\" encoding=\"utf-X\" standalone=\"yo\"?>".to_owned(),
+        "<?xml version=\"1.2\" encoding=\"utf-X\" standalone=\"yo\"?>",
         "writer output (LHS)"
     );
 }
@@ -347,7 +347,7 @@ fn test_new_xml_decl_standalone() {
     let result = writer.into_inner();
     assert_eq!(
         String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\" standalone=\"yo\"?>".to_owned(),
+        "<?xml version=\"1.2\" standalone=\"yo\"?>",
         "writer output (LHS)"
     );
 }
@@ -362,7 +362,7 @@ fn test_new_xml_decl_encoding() {
     let result = writer.into_inner();
     assert_eq!(
         String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\" encoding=\"utf-X\"?>".to_owned(),
+        "<?xml version=\"1.2\" encoding=\"utf-X\"?>",
         "writer output (LHS)"
     );
 }
@@ -377,7 +377,7 @@ fn test_new_xml_decl_version() {
     let result = writer.into_inner();
     assert_eq!(
         String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"1.2\"?>".to_owned(),
+        "<?xml version=\"1.2\"?>",
         "writer output (LHS)"
     );
 }
@@ -395,7 +395,7 @@ fn test_new_xml_decl_empty() {
     let result = writer.into_inner();
     assert_eq!(
         String::from_utf8(result).expect("utf-8 output"),
-        "<?xml version=\"\" encoding=\"\" standalone=\"\"?>".to_owned(),
+        "<?xml version=\"\" encoding=\"\" standalone=\"\"?>",
         "writer output (LHS)"
     );
 }
@@ -533,7 +533,7 @@ fn test_read_write_roundtrip_results_in_identity() -> Result<()> {
     }
 
     let result = writer.into_inner().into_inner();
-    assert_eq!(result, input.as_bytes());
+    assert_eq!(String::from_utf8(result).unwrap(), input);
     Ok(())
 }
 
@@ -559,7 +559,7 @@ fn test_read_write_roundtrip() -> Result<()> {
     }
 
     let result = writer.into_inner().into_inner();
-    assert_eq!(String::from_utf8(result).unwrap(), input.to_string());
+    assert_eq!(String::from_utf8(result).unwrap(), input);
     Ok(())
 }
 
@@ -589,7 +589,7 @@ fn test_read_write_roundtrip_escape_text() -> Result<()> {
     }
 
     let result = writer.into_inner().into_inner();
-    assert_eq!(String::from_utf8(result).unwrap(), input.to_string());
+    assert_eq!(String::from_utf8(result).unwrap(), input);
     Ok(())
 }
 


### PR DESCRIPTION
As reported [here](https://github.com/tafia/quick-xml/pull/423#issuecomment-1407425485), some checks does not do what they are supposed to do, so fix that in the first commit and made a small cleanup in the second.