### PR TITLE
Parser position tracking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,10 @@ jobs:
       env:
         LLVM_PROFILE_FILE: coverage/serialize-escape-html-%p-%m.profraw
       run: cargo test --features serialize,escape-html
+    - name: Run tests (serialize+span)
+      env:
+        LLVM_PROFILE_FILE: coverage/serialize-span-%p-%m.profraw
+      run: cargo test --features serialize,span
     - name: Run tests (all features)
       env:
         LLVM_PROFILE_FILE: coverage/all-features-%p-%m.profraw

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,10 @@ serde-types = ["serde/derive"]
 ## If you need that, use the `serde-types` feature.
 serialize = ["serde"] # "dep:" prefix only avalible from Rust 1.60
 
+## Enables gathering spans in events, which can slowdown parser a bit and increase
+## memory consumption for events
+span = []
+
 [package.metadata.docs.rs]
 # document all features
 all-features = true

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -53,13 +53,13 @@ use crate::reader::Span;
 use crate::utils::write_cow_string;
 use attributes::{Attribute, Attributes};
 
-/// A trait for get a span information
+/// A trait for acquiring the start and end locations of a parsing event in an input
 #[cfg(feature = "span")]
 pub trait Spanned {
-    /// Returns a span that type is occupied in the input
+    /// Returns a span over the location of a parsing event
     fn span(&self) -> Span;
 
-    /// Sets the span of this holder to a given value
+    /// Sets the span of this parsing event to a given value
     fn with_span(self, span: Span) -> Self;
 }
 

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -111,6 +111,8 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
     /// ```
     /// # tokio_test::block_on(async {
     /// # use pretty_assertions::assert_eq;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::reader::Reader;
     ///
@@ -129,6 +131,9 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
     ///
     /// let start = BytesStart::new("outer");
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..12);
     ///
     /// // First, we read a start event...
     /// assert_eq!(reader.read_event_into_async(&mut buf).await.unwrap(), Event::Start(start));
@@ -246,6 +251,8 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     /// ```
     /// # tokio_test::block_on(async {
     /// # use pretty_assertions::assert_eq;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::name::{Namespace, ResolveResult};
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::reader::NsReader;
@@ -270,6 +277,9 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     /// let ns = Namespace(b"namespace 1");
     /// let start = BytesStart::from_content(r#"outer xmlns="namespace 1""#, 5);
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..32);
     ///
     /// // First, we read a start event...
     /// assert_eq!(

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -350,6 +350,8 @@ impl<R: BufRead> Reader<R> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::reader::Reader;
     ///
@@ -368,6 +370,9 @@ impl<R: BufRead> Reader<R> {
     ///
     /// let start = BytesStart::new("outer");
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..12);
     ///
     /// // First, we read a start event...
     /// assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Start(start));

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -165,7 +165,7 @@ macro_rules! read_event_impl {
             },
             ParseState::ClosedTag => $self.$read_until_open($buf) $(.$await)?,
             ParseState::OpenedTag => $self.$read_until_close($buf) $(.$await)?,
-            ParseState::Empty => $self.parser.close_expanded_empty(),
+            ParseState::Empty(start) => $self.parser.close_expanded_empty(start),
             ParseState::Exit => return Ok(Event::Eof),
         };
         match event {
@@ -194,11 +194,14 @@ macro_rules! read_until_open {
             return $self.$read_event($buf) $(.$await)?;
         }
 
+        // Position just after `>`
+        let start = $self.parser.offset;
+
         match $reader
             .read_bytes_until(b'<', $buf, &mut $self.parser.offset)
             $(.$await)?
         {
-            Ok(Some(bytes)) => $self.parser.read_text(bytes),
+            Ok(Some(bytes)) => $self.parser.read_text(start, bytes),
             Ok(None) => Ok(Event::Eof),
             Err(e) => Err(e),
         }
@@ -213,6 +216,8 @@ macro_rules! read_until_close {
     ) => {{
         $self.parser.state = ParseState::ClosedTag;
 
+        // Cannot substract -1 here because in case of malformed documents `offset` is zero
+        let start = $self.parser.offset;
         match $reader.peek_one() $(.$await)? {
             // `<!` - comment, CDATA or DOCTYPE declaration
             Ok(Some(b'!')) => match $reader
@@ -220,7 +225,7 @@ macro_rules! read_until_close {
                 $(.$await)?
             {
                 Ok(None) => Ok(Event::Eof),
-                Ok(Some((bang_type, bytes))) => $self.parser.read_bang(bang_type, bytes),
+                Ok(Some((bang_type, bytes))) => $self.parser.read_bang(bang_type, start, bytes),
                 Err(e) => Err(e),
             },
             // `</` - closing tag
@@ -229,7 +234,7 @@ macro_rules! read_until_close {
                 $(.$await)?
             {
                 Ok(None) => Ok(Event::Eof),
-                Ok(Some(bytes)) => $self.parser.read_end(bytes),
+                Ok(Some(bytes)) => $self.parser.read_end(start - 1, bytes),
                 Err(e) => Err(e),
             },
             // `<?` - processing instruction
@@ -238,7 +243,7 @@ macro_rules! read_until_close {
                 $(.$await)?
             {
                 Ok(None) => Ok(Event::Eof),
-                Ok(Some(bytes)) => $self.parser.read_question_mark(bytes),
+                Ok(Some(bytes)) => $self.parser.read_question_mark(start - 1, bytes),
                 Err(e) => Err(e),
             },
             // `<...` - opening or self-closed tag
@@ -247,7 +252,7 @@ macro_rules! read_until_close {
                 $(.$await)?
             {
                 Ok(None) => Ok(Event::Eof),
-                Ok(Some(bytes)) => $self.parser.read_start(bytes),
+                Ok(Some(bytes)) => $self.parser.read_start(start - 1, bytes),
                 Err(e) => Err(e),
             },
             Ok(None) => Ok(Event::Eof),
@@ -341,7 +346,9 @@ enum ParseState {
     /// Reader enters to this state when it is in a `ClosedTag` state and emits an
     /// [`Event::Start`] event. The next event emitted will be an [`Event::End`],
     /// after which reader returned to the `ClosedTag` state.
-    Empty,
+    ///
+    /// Contains start offset of the buffer, used to close empty tags
+    Empty(usize),
     /// Reader enters this state when `Eof` event generated or an error occurred.
     /// This is the last state, the reader stay in it forever.
     Exit,
@@ -1627,6 +1634,8 @@ mod test {
             /// Ensures, that no empty `Text` events are generated
             mod $read_event {
                 use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+                #[cfg(feature = "span")]
+                use crate::events::Spanned;
                 use crate::reader::Reader;
                 use pretty_assertions::assert_eq;
 
@@ -1639,9 +1648,13 @@ mod test {
                 $($async)? fn bom_from_reader() {
                     let mut reader = Reader::from_reader("\u{feff}\u{feff}".as_bytes());
 
+                    let expected = BytesText::from_escaped("\u{feff}");
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..3);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Text(BytesText::from_escaped("\u{feff}"))
+                        Event::Text(expected)
                     );
 
                     assert_eq!(
@@ -1659,9 +1672,13 @@ mod test {
                 $($async)? fn bom_from_str() {
                     let mut reader = Reader::from_str("\u{feff}\u{feff}");
 
+                    let expected = BytesText::from_escaped("\u{feff}");
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..3);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Text(BytesText::from_escaped("\u{feff}"))
+                        Event::Text(expected)
                     );
 
                     assert_eq!(
@@ -1674,9 +1691,14 @@ mod test {
                 $($async)? fn declaration() {
                     let mut reader = Reader::from_str("<?xml ?>");
 
+                    let expected = BytesDecl::from_start(BytesStart::from_content("xml ", 3));
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..8);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Decl(BytesDecl::from_start(BytesStart::from_content("xml ", 3)))
+                        Event::Decl(expected)
                     );
                 }
 
@@ -1684,9 +1706,14 @@ mod test {
                 $($async)? fn doctype() {
                     let mut reader = Reader::from_str("<!DOCTYPE x>");
 
+                    let expected = BytesText::from_escaped("x");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..12);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::DocType(BytesText::from_escaped("x"))
+                        Event::DocType(expected)
                     );
                 }
 
@@ -1694,9 +1721,14 @@ mod test {
                 $($async)? fn processing_instruction() {
                     let mut reader = Reader::from_str("<?xml-stylesheet?>");
 
+                    let expected = BytesText::from_escaped("xml-stylesheet");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..18);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::PI(BytesText::from_escaped("xml-stylesheet"))
+                        Event::PI(expected)
                     );
                 }
 
@@ -1704,9 +1736,14 @@ mod test {
                 $($async)? fn start() {
                     let mut reader = Reader::from_str("<tag>");
 
+                    let expected = BytesStart::new("tag");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..5);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Start(BytesStart::new("tag"))
+                        Event::Start(expected)
                     );
                 }
 
@@ -1717,9 +1754,14 @@ mod test {
                     // the end name paired with the start name
                     reader.check_end_names(false);
 
+                    let expected = BytesEnd::new("tag");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..6);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::End(BytesEnd::new("tag"))
+                        Event::End(expected)
                     );
                 }
 
@@ -1727,9 +1769,14 @@ mod test {
                 $($async)? fn empty() {
                     let mut reader = Reader::from_str("<tag/>");
 
+                    let expected = BytesStart::new("tag");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..6);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Empty(BytesStart::new("tag"))
+                        Event::Empty(expected)
                     );
                 }
 
@@ -1737,9 +1784,14 @@ mod test {
                 $($async)? fn text() {
                     let mut reader = Reader::from_str("text");
 
+                    let expected = BytesText::from_escaped("text");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..4);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Text(BytesText::from_escaped("text"))
+                        Event::Text(expected)
                     );
                 }
 
@@ -1747,9 +1799,14 @@ mod test {
                 $($async)? fn cdata() {
                     let mut reader = Reader::from_str("<![CDATA[]]>");
 
+                    let expected = BytesCData::new("");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..12);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::CData(BytesCData::new(""))
+                        Event::CData(expected)
                     );
                 }
 
@@ -1757,9 +1814,14 @@ mod test {
                 $($async)? fn comment() {
                     let mut reader = Reader::from_str("<!---->");
 
+                    let expected = BytesText::from_escaped("");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..7);
+
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Comment(BytesText::from_escaped(""))
+                        Event::Comment(expected)
                     );
                 }
 
@@ -1785,6 +1847,8 @@ mod test {
         ) => {
             mod small_buffers {
                 use crate::events::{BytesCData, BytesDecl, BytesStart, BytesText, Event};
+                #[cfg(feature = "span")]
+                use crate::events::Spanned;
                 use crate::reader::Reader;
                 use pretty_assertions::assert_eq;
 
@@ -1797,9 +1861,15 @@ mod test {
                     let mut reader = Reader::from_reader(br);
                     let mut buf = Vec::new();
 
+                    let expected = BytesDecl::from_start(BytesStart::from_content("xml ", 3));
+
+                    // We do not test correctness of spans here so just clear them
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..8);
+
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                        Event::Decl(BytesDecl::from_start(BytesStart::from_content("xml ", 3)))
+                        Event::Decl(expected)
                     );
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -1816,9 +1886,14 @@ mod test {
                     let mut reader = Reader::from_reader(br);
                     let mut buf = Vec::new();
 
+                    let expected = BytesText::new("pi");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..6);
+
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                        Event::PI(BytesText::new("pi"))
+                        Event::PI(expected)
                     );
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -1835,9 +1910,14 @@ mod test {
                     let mut reader = Reader::from_reader(br);
                     let mut buf = Vec::new();
 
+                    let expected = BytesStart::new("empty");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..8);
+
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                        Event::Empty(BytesStart::new("empty"))
+                        Event::Empty(expected)
                     );
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -1854,9 +1934,14 @@ mod test {
                     let mut reader = Reader::from_reader(br);
                     let mut buf = Vec::new();
 
+                    let expected = BytesCData::new("cdata");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..17);
+
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                        Event::CData(BytesCData::new("cdata"))
+                        Event::CData(expected)
                     );
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -1873,9 +1958,14 @@ mod test {
                     let mut reader = Reader::from_reader(br);
                     let mut buf = Vec::new();
 
+                    let expected = BytesCData::new("cdata");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..17);
+
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                        Event::CData(BytesCData::new("cdata"))
+                        Event::CData(expected)
                     );
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -1892,9 +1982,14 @@ mod test {
                     let mut reader = Reader::from_reader(br);
                     let mut buf = Vec::new();
 
+                    let expected = BytesText::new("comment");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..14);
+
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                        Event::Comment(BytesText::new("comment"))
+                        Event::Comment(expected)
                     );
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -1911,9 +2006,14 @@ mod test {
                     let mut reader = Reader::from_reader(br);
                     let mut buf = Vec::new();
 
+                    let expected = BytesText::new("comment");
+
+                    #[cfg(feature = "span")]
+                    let expected = expected.with_span(0..14);
+
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                        Event::Comment(BytesText::new("comment"))
+                        Event::Comment(expected)
                     );
                     assert_eq!(
                         reader.$read_event(&mut buf) $(.$await)? .unwrap(),

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -470,6 +470,8 @@ impl<R: BufRead> NsReader<R> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::name::{Namespace, ResolveResult};
     /// use quick_xml::reader::NsReader;
@@ -494,6 +496,9 @@ impl<R: BufRead> NsReader<R> {
     /// let ns = Namespace(b"namespace 1");
     /// let start = BytesStart::from_content(r#"outer xmlns="namespace 1""#, 5);
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..32);
     ///
     /// // First, we read a start event...
     /// assert_eq!(
@@ -707,6 +712,8 @@ impl<'i> NsReader<&'i [u8]> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::name::{Namespace, ResolveResult};
     /// use quick_xml::reader::NsReader;
@@ -730,6 +737,9 @@ impl<'i> NsReader<&'i [u8]> {
     /// let ns = Namespace(b"namespace 1");
     /// let start = BytesStart::from_content(r#"outer xmlns="namespace 1""#, 5);
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..32);
     ///
     /// // First, we read a start event...
     /// assert_eq!(
@@ -789,6 +799,8 @@ impl<'i> NsReader<&'i [u8]> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// # use std::borrow::Cow;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::reader::NsReader;
     ///
@@ -803,6 +815,9 @@ impl<'i> NsReader<&'i [u8]> {
     ///
     /// let start = BytesStart::new("html");
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..11);
     ///
     /// // First, we read a start event...
     /// assert_eq!(reader.read_event().unwrap(), Event::Start(start));

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -117,6 +117,8 @@ impl<'a> Reader<&'a [u8]> {
     ///
     /// ```
     /// # use pretty_assertions::assert_eq;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::reader::Reader;
     ///
@@ -134,6 +136,9 @@ impl<'a> Reader<&'a [u8]> {
     ///
     /// let start = BytesStart::new("outer");
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..12);
     ///
     /// // First, we read a start event...
     /// assert_eq!(reader.read_event().unwrap(), Event::Start(start));
@@ -184,6 +189,8 @@ impl<'a> Reader<&'a [u8]> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// # use std::borrow::Cow;
+    /// # #[cfg(feature = "span")]
+    /// # use quick_xml::events::Spanned;
     /// use quick_xml::events::{BytesStart, Event};
     /// use quick_xml::reader::Reader;
     ///
@@ -198,6 +205,9 @@ impl<'a> Reader<&'a [u8]> {
     ///
     /// let start = BytesStart::new("html");
     /// let end   = start.to_end().into_owned();
+    ///
+    /// # #[cfg(feature = "span")]
+    /// # let start = start.with_span(5..11);
     ///
     /// // First, we read a start event...
     /// assert_eq!(reader.read_event().unwrap(), Event::Start(start));

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -49,6 +49,20 @@ mod issue514 {
     use super::*;
     use pretty_assertions::assert_eq;
 
+    #[cfg(not(feature = "span"))]
+    fn read_event<'a>(reader: &'a mut Reader<&[u8]>) -> Event<'a> {
+        reader.read_event().unwrap()
+    }
+
+    // We do not test correctness of spans here so just clear them
+    #[cfg(feature = "span")]
+    fn read_event<'a>(reader: &'a mut Reader<&[u8]>) -> Event<'a> {
+        use quick_xml::events::Spanned;
+        use quick_xml::reader::Span;
+
+        reader.read_event().unwrap().with_span(Span::default())
+    }
+
     /// Check that there is no unexpected error
     #[test]
     fn no_mismatch() {
@@ -60,8 +74,8 @@ mod issue514 {
         let html_start = BytesStart::new("html");
         let html_end = html_start.to_end().into_owned();
 
-        assert_eq!(reader.read_event().unwrap(), Event::Start(outer_start));
-        assert_eq!(reader.read_event().unwrap(), Event::Start(html_start));
+        assert_eq!(read_event(&mut reader), Event::Start(outer_start));
+        assert_eq!(read_event(&mut reader), Event::Start(html_start));
 
         reader.check_end_names(false);
 
@@ -69,8 +83,8 @@ mod issue514 {
 
         reader.check_end_names(true);
 
-        assert_eq!(reader.read_event().unwrap(), Event::End(outer_end));
-        assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        assert_eq!(read_event(&mut reader), Event::End(outer_end));
+        assert_eq!(read_event(&mut reader), Event::Eof);
     }
 
     /// Canary check that legitimate error is reported
@@ -83,8 +97,8 @@ mod issue514 {
         let html_start = BytesStart::new("html");
         let html_end = html_start.to_end().into_owned();
 
-        assert_eq!(reader.read_event().unwrap(), Event::Start(outer_start));
-        assert_eq!(reader.read_event().unwrap(), Event::Start(html_start));
+        assert_eq!(read_event(&mut reader), Event::Start(outer_start));
+        assert_eq!(read_event(&mut reader), Event::Start(html_start));
 
         reader.check_end_names(false);
 


### PR DESCRIPTION
# Parser position tracking
Store an `Option<quick_xml::reader::Span>` inside each of the `quick_xml::events::Bytes*` structs. This span is computed by the parser during reading, and passed into the relevant `wrap()` function during value construction. It can be accessed by calling relevant `span()` methods, which will clone and return the span (`Range`, sadly, does not implement `Copy` due to its status as an `Iterator` implementation.)

~~Additionally, the derive implementations of `PartialEq` on the structs is replaced with a manual implementation of `PartialEq`. This is to prevent previously `true` equality comparisons such as `bytes == BytesStart::new("...", 4)` suddenly changing their behaviour to return `false`. This does mean that we lose our implementations of `StructuralPartialEq`, meaning that constants of the relevant types can no longer be used as patterns in match arms. However, since `quick_xml` exposes no way to construct values of these types at compile time, and since `StructuralPartialEq` is currently nightly-only and therefore cannot be used in trait bounds in stable Rust, I do not believe this change is sufficiently observable to require a major version bump under semver.~~ Paragraph rendered obsolete by design change.

Other than the above, I do not intend to make any other possibly breaking changes to the public API with this contribution.

## Changes
- Each of the `Bytes*` structs under `quick_xml::events` receives a new field, `span: crate::reader::Span`.
  - If created via parsing, this field will store a value of `n..m`, representing the start and end positions of that event's contents - for tags, this is the positions of the `<` and `>` character; while for text, it is the start and end of the text content, with respect to optional whitespace trimming.
  - If created via the API, this field will store `0..0`.
- Each of the structs receives a new trait, `Spanned`, which defines methods to retrieve and update the stored span.
- Altering data for a given event, such as its element name or adding attributes, does not alter the span it is given. This is because such edits do not alter the source it was initially read from.

## Progress
- [X] Events
  - [X] `quick_xml::events::BytesStart`
  - [X] `quick_xml::events::BytesDecl`
    - As far as I can tell, this one can just reuse the span inside `BytesStart`
  - [X] `quick_xml::events::BytesEnd`
  - [X] `quick_xml::events::BytesText`
  - [X] `quick_xml::events::BytesCData`
  - [X] Method on `quick_xml::events::Event` to return the underlying span if there is one
- [ ] Attributes
  - [ ] `quick_xml::events::attributes::Attributes`
  - [ ] `quick_xml::events::attributes::Attribute`
  - [ ] `quick_xml::events::attributes::Attr`
- [ ] Events
  - [ ] `quick_xml::errors::Error`
  - [ ] `quick_xml::escape::EscapeError`
  - [ ] `quick_xml::events::attributes::AttrError`
- [ ] Namespaces _(unsure whether this one makes sense)_
  - [ ] `quick_xml::name::QName`
  - [ ] `quick_xml::name::LocalName`
  - [ ] `quick_xml::name::Prefix`
  - [ ] `quick_xml::name::Namespace`
- [X] Figure out where to add tests for the new functionality
- [ ] Edit Changelog.md with new functionality

## PR changelog
- **2023/02/16 18:31 GMT**: Rebased PR source on an incomplete implementation that will be continued.
- **2023/02/17 07:16 GMT**: Restructured Progress section, added mini-changelog to PR.