### PR TITLE
Add support for binary blobs inside xml tags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,10 @@ serde-types = ["serde/derive"]
 ## If you need that, use the `serde-types` feature.
 serialize = ["serde"] # "dep:" prefix only avalible from Rust 1.60
 
+## Enables support for binary blobs in XML text locations. When this
+## feature is enabled, quick-xml accepts unescaped binary blobs in XML files.
+binary_text = []
+
 [package.metadata.docs.rs]
 # document all features
 all-features = true

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -470,6 +470,11 @@ where
     fn read_string(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
         self.map.de.read_string_impl(unescape, self.allow_start)
     }
+    /// Returns next slice of bytes.
+    #[inline]
+    fn read_bytes(&mut self) -> Result<Cow<'de, [u8]>, DeError> {
+        self.map.de.read_bytes()
+    }
 }
 
 impl<'de, 'a, 'm, R> de::Deserializer<'de> for MapValueDeserializer<'de, 'a, 'm, R>
@@ -730,6 +735,11 @@ where
     #[inline]
     fn read_string(&mut self, unescape: bool) -> Result<Cow<'de, str>, DeError> {
         self.map.de.read_string_impl(unescape, true)
+    }
+    /// Returns next slice of bytes.
+    #[inline]
+    fn read_bytes(&mut self) -> Result<Cow<'de, [u8]>, DeError> {
+        self.map.de.read_bytes()
     }
 }
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -471,6 +471,7 @@ where
         self.map.de.read_string_impl(unescape, self.allow_start)
     }
     /// Returns next slice of bytes.
+    #[cfg(feature = "binary_text")]
     #[inline]
     fn read_bytes(&mut self) -> Result<Cow<'de, [u8]>, DeError> {
         self.map.de.read_bytes()
@@ -737,6 +738,7 @@ where
         self.map.de.read_string_impl(unescape, true)
     }
     /// Returns next slice of bytes.
+    #[cfg(feature = "binary_text")]
     #[inline]
     fn read_bytes(&mut self) -> Result<Cow<'de, [u8]>, DeError> {
         self.map.de.read_bytes()

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1799,8 +1799,18 @@ macro_rules! deserialize_primitives {
             }
         }
 
+        /// Returns [`DeError::Unsupported`]
+        #[cfg(not(feature = "binary_text"))]
+        fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DeError>
+        where
+            V: Visitor<'de>,
+        {
+            Err(DeError::Unsupported("binary data content is not supported by XML format".into()))
+        }
+
         /// Deserializes raw bytes. While not officially supported by the XML format, there are
         /// hybrid formats that make use of binary data inside XML files.
+        #[cfg(feature = "binary_text")]
         fn deserialize_bytes<V>($($mut)? self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
@@ -2246,6 +2256,7 @@ where
         self.read_string_impl(unescape, true)
     }
 
+    #[cfg(feature = "binary_text")]
     #[inline]
     fn read_bytes(&mut self) -> Result<Cow<'de, [u8]>, DeError> {
         self.read_bytes_impl(true)
@@ -2319,6 +2330,7 @@ where
         }
     }
 
+    #[cfg(feature = "binary_text")]
     fn read_bytes_impl(&mut self, allow_start: bool) -> Result<Cow<'de, [u8]>, DeError> {
         match self.next()? {
             DeEvent::Text(e) => Ok(e.into_inner()),

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -864,13 +864,14 @@ mod tests {
                 // Roundtrip to ensure that serializer corresponds to deserializer
                 assert_eq!(
                     data.serialize(SimpleTypeSerializer {
-                        writer: String::new(),
+                        writer: Vec::new(),
                         target: QuoteTarget::Text,
                         level: QuoteLevel::Full,
                         indent: Indent::None,
                     })
-                    .unwrap(),
-                    xml
+                    .unwrap()
+                    .as_slice(),
+                    xml.as_bytes()
                 );
             }
         };
@@ -975,12 +976,13 @@ mod tests {
                     // Roundtrip to ensure that serializer corresponds to deserializer
                     assert_eq!(
                         data.serialize(AtomicSerializer {
-                            writer: String::new(),
+                            writer: Vec::new(),
                             target: QuoteTarget::Text,
                             level: QuoteLevel::Full,
                         })
-                        .unwrap(),
-                        $input
+                        .unwrap()
+                        .as_slice(),
+                        $input.as_bytes()
                     );
                 }
             };

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -604,6 +604,61 @@ impl<'a> Deref for BytesEnd<'a> {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+
+/// Data stored in binary
+#[derive(Clone, Eq, PartialEq)]
+pub struct BytesBytes<'a> {
+    // Arbitrary binary data.
+    content: Cow<'a, [u8]>,
+}
+
+impl<'a> BytesBytes<'a> {
+    /// Creates a new `BytesBytes` from a slice of bytes.
+    #[inline]
+    pub fn new(content: &'a [u8]) -> Self {
+        Self {
+            content: content.into(),
+        }
+    }
+
+    /// Ensures that all data is owned to extend the object's lifetime if
+    /// necessary.
+    #[inline]
+    pub fn into_owned(self) -> BytesBytes<'static> {
+        BytesBytes {
+            content: self.content.into_owned().into(),
+        }
+    }
+
+    /// Extracts the inner `Cow` from the `BytesBytes` event container.
+    #[inline]
+    pub fn into_inner(self) -> Cow<'a, [u8]> {
+        self.content
+    }
+
+    /// Converts the event into a borrowed event.
+    #[inline]
+    pub fn borrow(&self) -> BytesBytes {
+        BytesBytes {
+            content: Cow::Borrowed(&self.content),
+        }
+    }
+}
+
+impl<'a> Debug for BytesBytes<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "BytesBytes {{ binary }}")
+    }
+}
+
+impl<'a> Deref for BytesBytes<'a> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.content
+    }
+}
 
 /// Data from various events (most notably, `Event::Text`) that stored in XML
 /// in escaped form. Internally data is stored in escaped form
@@ -620,7 +675,7 @@ pub struct BytesText<'a> {
 impl<'a> BytesText<'a> {
     /// Creates a new `BytesText` from an escaped byte sequence in the specified encoding.
     #[inline]
-    pub(crate) fn wrap<C: Into<Cow<'a, [u8]>>>(content: C, decoder: Decoder) -> Self {
+    pub fn wrap<C: Into<Cow<'a, [u8]>>>(content: C, decoder: Decoder) -> Self {
         Self {
             content: content.into(),
             decoder,

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -158,6 +158,10 @@ impl<'i, W: Write> Serializer for ContentSerializer<'i, W> {
 
     write_primitive!(serialize_char(char));
 
+    #[cfg(not(feature = "binary_text"))]
+    write_primitive!(serialize_bytes(&[u8]));
+
+    #[cfg(feature = "binary_text")]
     #[inline]
     fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
         if value.is_empty() {
@@ -566,7 +570,10 @@ pub(super) mod tests {
         serialize_as!(str_non_escaped: "non-escaped string" => "non-escaped string");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+        #[cfg(feature = "binary_text")]
         serialize_as!(bytes_unescaped: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+        #[cfg(not(feature = "binary_text"))]
+        err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported"));
 
         serialize_as!(option_none: Option::<Enum>::None => "");
         serialize_as!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -760,7 +767,10 @@ pub(super) mod tests {
         serialize_as!(str_non_escaped: "non-escaped string" => "non-escaped string");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+        #[cfg(feature = "binary_text")]
         serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+        #[cfg(not(feature = "binary_text"))]
+        err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported"));
 
         serialize_as!(option_none: Option::<Enum>::None => "");
         serialize_as!(option_some: Some(Enum::Unit) => "<Unit/>");

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -64,6 +64,9 @@ impl<'k, W: Write> Serializer for ElementSerializer<'k, W> {
 
     write_primitive!(serialize_char(char));
 
+    #[cfg(feature = "binary_text")]
+    write_primitive!(serialize_bytes(&[u8]));
+    #[cfg(not(feature = "binary_text"))]
     fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
         if value.is_empty() {
             self.ser.write_empty(self.key)
@@ -613,7 +616,10 @@ mod tests {
         serialize_as!(str_non_escaped: "non-escaped string" => "<root>non-escaped string</root>");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "<root>&lt;&quot;escaped &amp; string&apos;&gt;</root>");
 
+        #[cfg(feature = "binary_text")]
         serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<root><\"unescaped & bytes'></root>");
+        #[cfg(not(feature = "binary_text"))]
+        err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported"));
 
         serialize_as!(option_none: Option::<&str>::None => "<root/>");
         serialize_as!(option_some: Some("non-escaped string") => "<root>non-escaped string</root>");
@@ -723,7 +729,16 @@ mod tests {
                 text!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 text!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 text!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    Text {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 text!(option_none: Option::<&str>::None);
                 text!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -844,15 +859,16 @@ mod tests {
                 text!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 text!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 text!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
-
-                // err!(bytes:
-                //     Text {
-                //         before: "answer",
-                //         content: Bytes(b"<\"escaped & bytes'>"),
-                //         after: "answer",
-                //     }
-                //     => Unsupported("`serialize_bytes` not supported yet"));
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    Text {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 text!(option_none: Option::<&str>::None => "");
                 text!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -973,7 +989,16 @@ mod tests {
                 text!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 text!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 text!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    SpecialEnum::Text {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 text!(option_none: Option::<&str>::None => "");
                 text!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -1098,10 +1123,12 @@ mod tests {
                 value!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 value!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 value!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
-                // err!(bytes:
-                //     BTreeMap::from([("$value", Bytes(b"<\"escaped & bytes'>"))])
-                //     => Unsupported("`serialize_bytes` not supported yet"));
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    BTreeMap::from([("$value", Bytes(b"<\"escaped & bytes'>"))])
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 value!(option_none: Option::<&str>::None);
                 value!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -1208,14 +1235,16 @@ mod tests {
                 value!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 value!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 value!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
-                // err!(bytes:
-                //     Value {
-                //         before: "answer",
-                //         content: Bytes(b"<\"escaped & bytes'>"),
-                //         after: "answer",
-                //     }
-                //     => Unsupported("`serialize_bytes` not supported yet"));
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    Value {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 value!(option_none: Option::<&str>::None => "");
                 value!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -1339,14 +1368,16 @@ mod tests {
                 value!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 value!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 value!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
-                // err!(bytes:
-                //     SpecialEnum::Value {
-                //         before: "answer",
-                //         content: Bytes(b"<\"escaped & bytes'>"),
-                //         after: "answer",
-                //     }
-                //     => Unsupported("`serialize_bytes` not supported yet"));
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    SpecialEnum::Value {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 value!(option_none: Option::<&str>::None => "");
                 value!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -1586,7 +1617,10 @@ mod tests {
         serialize_as!(str_non_escaped: "non-escaped string" => "<root>non-escaped string</root>");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "<root>&lt;&quot;escaped &amp; string&apos;&gt;</root>");
 
+        #[cfg(feature = "binary_text")]
         serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<root><\"unescaped & bytes'></root>");
+        #[cfg(not(feature = "binary_text"))]
+        err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported"));
 
         serialize_as!(option_none: Option::<&str>::None => "<root/>");
         serialize_as!(option_some: Some("non-escaped string") => "<root>non-escaped string</root>");
@@ -1696,7 +1730,16 @@ mod tests {
                 text!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 text!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 text!(bytes: Bytes(b"\n  <\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    Text {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 text!(option_none: Option::<&str>::None);
                 text!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -1829,7 +1872,16 @@ mod tests {
                 text!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 text!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 text!(bytes: Bytes(b"\n  <\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    Text {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 text!(option_none: Option::<&str>::None);
                 text!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -1962,7 +2014,16 @@ mod tests {
                 text!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 text!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 text!(bytes: Bytes(b"\n  <\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    SpecialEnum::Text {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 text!(option_none: Option::<&str>::None);
                 text!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -2087,7 +2148,12 @@ mod tests {
                 value!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 value!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 value!(bytes: Bytes(b"\n  <\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    BTreeMap::from([("$value", Bytes(b"<\"escaped & bytes'>"))])
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 value!(option_none: Option::<&str>::None);
                 value!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -2205,7 +2271,16 @@ mod tests {
                 value!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 value!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 value!(bytes: Bytes(b"\n  <\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    Value {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 value!(option_none: Option::<&str>::None);
                 value!(option_some: Some("non-escaped string") => "non-escaped string");
@@ -2341,7 +2416,16 @@ mod tests {
                 value!(str_non_escaped: "non-escaped string" => "non-escaped string");
                 value!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+                #[cfg(feature = "binary_text")]
                 value!(bytes: Bytes(b"\n  <\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+                #[cfg(not(feature = "binary_text"))]
+                err!(bytes:
+                    SpecialEnum::Value {
+                        before: "answer",
+                        content: Bytes(b"<\"escaped & bytes'>"),
+                        after: "answer",
+                    }
+                    => Unsupported("`serialize_bytes` not supported"));
 
                 value!(option_none: Option::<&str>::None);
                 value!(option_some: Some("non-escaped string") => "non-escaped string");

--- a/src/se/key.rs
+++ b/src/se/key.rs
@@ -37,6 +37,11 @@ impl<W: Write> Serializer for QNameSerializer<W> {
 
     write_primitive!();
 
+    fn serialize_bytes(mut self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.write_str(&String::from_utf8_lossy(value))?;
+        Ok(self.writer)
+    }
+
     fn serialize_str(mut self, value: &str) -> Result<Self::Ok, Self::Error> {
         self.write_str(value)?;
         Ok(self.writer)

--- a/src/se/key.rs
+++ b/src/se/key.rs
@@ -274,8 +274,9 @@ mod tests {
     serialize_as!(str_apos: "string'" => "string'");
     serialize_as!(str_quot: "string\"" => "string\"");
 
-    err!(bytes: Bytes(b"<\"escaped & bytes'>")
-        => Unsupported("`serialize_bytes` not supported yet"));
+    serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+    // err!(bytes: Bytes(b"<\"escaped & bytes'>")
+    //     => Unsupported("`serialize_bytes` not supported yet"));
 
     serialize_as!(option_none: Option::<&str>::None => "");
     serialize_as!(option_some: Some("non-escaped-string") => "non-escaped-string");

--- a/src/se/key.rs
+++ b/src/se/key.rs
@@ -37,6 +37,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
 
     write_primitive!();
 
+    #[cfg(feature = "binary_text")]
     fn serialize_bytes(mut self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
         self.write_str(&String::from_utf8_lossy(value))?;
         Ok(self.writer)
@@ -274,9 +275,11 @@ mod tests {
     serialize_as!(str_apos: "string'" => "string'");
     serialize_as!(str_quot: "string\"" => "string\"");
 
+    #[cfg(feature = "binary_text")]
     serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
-    // err!(bytes: Bytes(b"<\"escaped & bytes'>")
-    //     => Unsupported("`serialize_bytes` not supported yet"));
+    #[cfg(not(feature = "binary_text"))]
+    err!(bytes: Bytes(b"<\"escaped & bytes'>")
+        => Unsupported("`serialize_bytes` not supported"));
 
     serialize_as!(option_none: Option::<&str>::None => "");
     serialize_as!(option_some: Some("non-escaped-string") => "non-escaped-string");

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -37,12 +37,13 @@ macro_rules! write_primitive {
             self.serialize_str(&value.to_string())
         }
 
-        // fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
-        //     //TODO: customization point - allow user to decide how to encode bytes
-        //     Err(DeError::Unsupported(
-        //         "`serialize_bytes` not supported yet".into(),
-        //     ))
-        // }
+        #[cfg(not(feature = "binary_text"))]
+        fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+            //TODO: customization point - allow user to decide how to encode bytes
+            Err(DeError::Unsupported(
+                "`serialize_bytes` not supported".into(),
+            ))
+        }
 
         fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
             Ok(self.writer)

--- a/src/se/simple_type.rs
+++ b/src/se/simple_type.rs
@@ -918,8 +918,9 @@ mod tests {
         serialize_as!(str_non_escaped: "non-escaped-string" => "non-escaped-string");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped&#32;&amp;&#32;string&apos;&gt;");
 
-        err!(bytes: Bytes(b"<\"escaped & bytes'>")
-            => Unsupported("`serialize_bytes` not supported yet"));
+        serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+        // err!(bytes: Bytes(b"<\"escaped & bytes'>")
+        //     => Unsupported("`serialize_bytes` not supported yet"));
 
         serialize_as!(option_none: Option::<&str>::None => "");
         serialize_as!(option_some: Some("non-escaped-string") => "non-escaped-string");
@@ -1036,8 +1037,9 @@ mod tests {
         serialize_as!(str_non_escaped: "non-escaped string" => "non-escaped string");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
-        err!(bytes: Bytes(b"<\"escaped & bytes'>")
-            => Unsupported("`serialize_bytes` not supported yet"));
+        serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
+        // err!(bytes: Bytes(b"<\"escaped & bytes'>")
+        //     => Unsupported("`serialize_bytes` not supported yet"));
 
         serialize_as!(option_none: Option::<&str>::None => "");
         serialize_as!(option_some: Some("non-escaped string") => "non-escaped string");

--- a/src/se/simple_type.rs
+++ b/src/se/simple_type.rs
@@ -197,6 +197,7 @@ impl<W: Write> Serializer for AtomicSerializer<W> {
 
     write_primitive!();
 
+    #[cfg(feature = "binary_text")]
     fn serialize_bytes(mut self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
         self.writer.write(value)?;
         Ok(self.writer)
@@ -366,6 +367,7 @@ impl<'i, W: Write> Serializer for SimpleTypeSerializer<'i, W> {
 
     write_primitive!();
 
+    #[cfg(feature = "binary_text")]
     fn serialize_bytes(mut self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
         if value.is_empty() {
             self.indent = Indent::None;
@@ -918,9 +920,11 @@ mod tests {
         serialize_as!(str_non_escaped: "non-escaped-string" => "non-escaped-string");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped&#32;&amp;&#32;string&apos;&gt;");
 
+        #[cfg(feature = "binary_text")]
         serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
-        // err!(bytes: Bytes(b"<\"escaped & bytes'>")
-        //     => Unsupported("`serialize_bytes` not supported yet"));
+        #[cfg(not(feature = "binary_text"))]
+        err!(bytes: Bytes(b"<\"escaped & bytes'>")
+            => Unsupported("`serialize_bytes` not supported"));
 
         serialize_as!(option_none: Option::<&str>::None => "");
         serialize_as!(option_some: Some("non-escaped-string") => "non-escaped-string");
@@ -1037,9 +1041,11 @@ mod tests {
         serialize_as!(str_non_escaped: "non-escaped string" => "non-escaped string");
         serialize_as!(str_escaped: "<\"escaped & string'>" => "&lt;&quot;escaped &amp; string&apos;&gt;");
 
+        #[cfg(feature = "binary_text")]
         serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<\"unescaped & bytes'>");
-        // err!(bytes: Bytes(b"<\"escaped & bytes'>")
-        //     => Unsupported("`serialize_bytes` not supported yet"));
+        #[cfg(not(feature = "binary_text"))]
+        err!(bytes: Bytes(b"<\"escaped & bytes'>")
+            => Unsupported("`serialize_bytes` not supported"));
 
         serialize_as!(option_none: Option::<&str>::None => "");
         serialize_as!(option_some: Some("non-escaped string") => "non-escaped string");

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -145,33 +145,36 @@ mod trivial {
 
             eof!(string: String = $value);
 
-            /// XML does not able to store binary data
-            #[test]
-            fn byte_buf() {
-                match from_str::<ByteBuf>($value) {
-                    Err(DeError::Unsupported(msg)) => {
-                        assert_eq!(msg, "binary data content is not supported by XML format")
-                    }
-                    x => panic!(
-                        r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
-                        x
-                    ),
-                }
-            }
+            eof!(byte_buf: ByteBuf = $value);
+            eof!(bytes: Bytes = $value);
 
-            /// XML does not able to store binary data
-            #[test]
-            fn bytes() {
-                match from_str::<Bytes>($value) {
-                    Err(DeError::Unsupported(msg)) => {
-                        assert_eq!(msg, "binary data content is not supported by XML format")
-                    }
-                    x => panic!(
-                        r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
-                        x
-                    ),
-                }
-            }
+            // /// XML does not able to store binary data
+            // #[test]
+            // fn byte_buf() {
+            //     match from_str::<ByteBuf>($value) {
+            //         Err(DeError::Unsupported(msg)) => {
+            //             assert_eq!(msg, "binary data content is not supported by XML format")
+            //         }
+            //         x => panic!(
+            //             r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+            //             x
+            //         ),
+            //     }
+            // }
+
+            // /// XML does not able to store binary data
+            // #[test]
+            // fn bytes() {
+            //     match from_str::<Bytes>($value) {
+            //         Err(DeError::Unsupported(msg)) => {
+            //             assert_eq!(msg, "binary data content is not supported by XML format")
+            //         }
+            //         x => panic!(
+            //             r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+            //             x
+            //         ),
+            //     }
+            // }
 
             #[test]
             fn unit() {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -145,36 +145,40 @@ mod trivial {
 
             eof!(string: String = $value);
 
+            #[cfg(feature = "binary_text")]
             eof!(byte_buf: ByteBuf = $value);
+            #[cfg(feature = "binary_text")]
             eof!(bytes: Bytes = $value);
 
-            // /// XML does not able to store binary data
-            // #[test]
-            // fn byte_buf() {
-            //     match from_str::<ByteBuf>($value) {
-            //         Err(DeError::Unsupported(msg)) => {
-            //             assert_eq!(msg, "binary data content is not supported by XML format")
-            //         }
-            //         x => panic!(
-            //             r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
-            //             x
-            //         ),
-            //     }
-            // }
+            /// XML does not able to store binary data
+            #[cfg(not(feature = "binary_text"))]
+            #[test]
+            fn byte_buf() {
+                match from_str::<ByteBuf>($value) {
+                    Err(DeError::Unsupported(msg)) => {
+                        assert_eq!(msg, "binary data content is not supported by XML format")
+                    }
+                    x => panic!(
+                        r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                        x
+                    ),
+                }
+            }
 
-            // /// XML does not able to store binary data
-            // #[test]
-            // fn bytes() {
-            //     match from_str::<Bytes>($value) {
-            //         Err(DeError::Unsupported(msg)) => {
-            //             assert_eq!(msg, "binary data content is not supported by XML format")
-            //         }
-            //         x => panic!(
-            //             r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
-            //             x
-            //         ),
-            //     }
-            // }
+            /// XML does not able to store binary data
+            #[cfg(not(feature = "binary_text"))]
+            #[test]
+            fn bytes() {
+                match from_str::<Bytes>($value) {
+                    Err(DeError::Unsupported(msg)) => {
+                        assert_eq!(msg, "binary data content is not supported by XML format")
+                    }
+                    x => panic!(
+                        r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                        x
+                    ),
+                }
+            }
 
             #[test]
             fn unit() {
@@ -192,6 +196,7 @@ mod trivial {
     /// Empty document should considered invalid no matter what type we try to deserialize
     mod empty_doc {
         use super::*;
+        #[cfg(not(feature = "binary_text"))]
         use pretty_assertions::assert_eq;
 
         eof!("");
@@ -200,6 +205,7 @@ mod trivial {
     /// Document that contains only comment should be handled as if it is empty
     mod only_comment {
         use super::*;
+        #[cfg(not(feature = "binary_text"))]
         use pretty_assertions::assert_eq;
 
         eof!("<!--comment-->");

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -164,9 +164,12 @@ mod without_root {
         ($name:ident: $data:expr => $expected:literal) => {
             #[test]
             fn $name() {
-                let ser = Serializer::new(String::new());
+                let ser = Serializer::new(Vec::new());
 
-                assert_eq!($data.serialize(ser).unwrap(), $expected);
+                assert_eq!(
+                    $data.serialize(ser).unwrap().as_slice(),
+                    $expected.as_bytes()
+                );
             }
         };
     }
@@ -177,7 +180,7 @@ mod without_root {
         ($name:ident: $data:expr => $kind:ident($reason:literal)) => {
             #[test]
             fn $name() {
-                let mut buffer = String::new();
+                let mut buffer = Vec::new();
                 let ser = Serializer::new(&mut buffer);
 
                 match $data.serialize(ser) {
@@ -189,7 +192,7 @@ mod without_root {
                         e
                     ),
                 }
-                assert_eq!(buffer, "");
+                assert!(buffer.is_empty());
             }
         };
     }
@@ -556,10 +559,13 @@ mod without_root {
             ($name:ident: $data:expr => $expected:literal) => {
                 #[test]
                 fn $name() {
-                    let mut ser = Serializer::new(String::new());
+                    let mut ser = Serializer::new(Vec::new());
                     ser.indent(' ', 2);
 
-                    assert_eq!($data.serialize(ser).unwrap(), $expected);
+                    assert_eq!(
+                        $data.serialize(ser).unwrap().as_slice(),
+                        $expected.as_bytes()
+                    );
                 }
             };
         }
@@ -570,7 +576,7 @@ mod without_root {
             ($name:ident: $data:expr => $kind:ident($reason:literal)) => {
                 #[test]
                 fn $name() {
-                    let mut buffer = String::new();
+                    let mut buffer = Vec::new();
                     let ser = Serializer::new(&mut buffer);
 
                     match $data.serialize(ser) {
@@ -582,7 +588,7 @@ mod without_root {
                             e
                         ),
                     }
-                    assert_eq!(buffer, "");
+                    assert!(buffer.is_empty());
                 }
             };
         }
@@ -948,9 +954,12 @@ mod with_root {
         ($name:ident: $data:expr => $expected:literal) => {
             #[test]
             fn $name() {
-                let ser = Serializer::with_root(String::new(), Some("root")).unwrap();
+                let ser = Serializer::with_root(Vec::new(), Some("root")).unwrap();
 
-                assert_eq!($data.serialize(ser).unwrap(), $expected);
+                assert_eq!(
+                    $data.serialize(ser).unwrap().as_slice(),
+                    $expected.as_bytes()
+                );
             }
         };
     }
@@ -961,7 +970,7 @@ mod with_root {
         ($name:ident: $data:expr => $kind:ident($reason:literal)) => {
             #[test]
             fn $name() {
-                let mut buffer = String::new();
+                let mut buffer = Vec::new();
                 let ser = Serializer::with_root(&mut buffer, Some("root")).unwrap();
 
                 match $data.serialize(ser) {

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -966,6 +966,7 @@ mod with_root {
 
     /// Checks that attempt to serialize given `$data` results to a
     /// serialization error `$kind` with `$reason`
+    #[cfg(not(feature = "binary_text"))]
     macro_rules! err {
         ($name:ident: $data:expr => $kind:ident($reason:literal)) => {
             #[test]
@@ -1022,8 +1023,10 @@ mod with_root {
     serialize_as!(str_non_escaped: "non-escaped string" => "<root>non-escaped string</root>");
     serialize_as!(str_escaped:  "<\"escaped & string'>" => "<root>&lt;&quot;escaped &amp; string&apos;&gt;</root>");
 
+    #[cfg(feature = "binary_text")]
     serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<root><\"unescaped & bytes'></root>");
-    // err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported yet"));
+    #[cfg(not(feature = "binary_text"))]
+    err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported"));
 
     serialize_as!(option_none: Option::<&str>::None => "");
     serialize_as!(option_some: Some("non-escaped string") => "<root>non-escaped string</root>");

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -1022,7 +1022,8 @@ mod with_root {
     serialize_as!(str_non_escaped: "non-escaped string" => "<root>non-escaped string</root>");
     serialize_as!(str_escaped:  "<\"escaped & string'>" => "<root>&lt;&quot;escaped &amp; string&apos;&gt;</root>");
 
-    err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported yet"));
+    serialize_as!(bytes: Bytes(b"<\"unescaped & bytes'>") => "<root><\"unescaped & bytes'></root>");
+    // err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported yet"));
 
     serialize_as!(option_none: Option::<&str>::None => "");
     serialize_as!(option_some: Some("non-escaped string") => "<root>non-escaped string</root>");


### PR DESCRIPTION
In summary, this PR combines binary support with text events, to avoid copious code duplication. Also:
- Renamed text events to Content to avoid confusion, since these now represent raw byte slices.
- Swapped `String` for `Vec<u8>` in a few places involving Text (not everywhere) to facilitate this functionality.
- Fixed unblocked tests due to this change.

Some versions ago `quick-xml` had exposed a more low level API, which allowed reading/writing bytes directly between xml tags. This was very useful for working with [XML based VTK files](https://vtk.org/Wiki/VTK_XML_Formats) and I really wish to have this functionality again in `quick-xml`. This PR attempts to recreate this capability and is being tested in a [new release for vtkio](https://github.com/elrnv/vtkio/tree/release-0.7). Please let me know if there are any design changes needed here.