### PR TITLE
Fix #540

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@
   mappings (`xmlns:xxx`) that was broken since [#490]
 - [#510]: Fix an error of deserialization of `Option<T>` fields where `T` is some
   sequence type (for example, `Vec` or tuple)
+- [#540]: Fix a compilation error (probably a rustc bug) in some circumstances.
+  `Serializer::new` and `Serializer::with_root` now accepts only references to `Write`r.
 
 ### Misc Changes
 
@@ -30,6 +32,7 @@
 [#490]: https://github.com/tafia/quick-xml/pull/490
 [#510]: https://github.com/tafia/quick-xml/issues/510
 [#537]: https://github.com/tafia/quick-xml/issues/537
+[#540]: https://github.com/tafia/quick-xml/issues/540
 [#541]: https://github.com/tafia/quick-xml/pull/541
 [#556]: https://github.com/tafia/quick-xml/pull/556
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@
 
 - [#541]: Deserialize specially named `$text` enum variant in [externally tagged]
   enums from textual content
+- [#556]: `to_writer` and `to_string` now accept `?Sized` types
+- [#556]: Add new `to_writer_with_root` and `to_string_with_root` helper functions
 
 ### Bug Fixes
 
@@ -29,6 +31,7 @@
 [#510]: https://github.com/tafia/quick-xml/issues/510
 [#537]: https://github.com/tafia/quick-xml/issues/537
 [#541]: https://github.com/tafia/quick-xml/pull/541
+[#556]: https://github.com/tafia/quick-xml/pull/556
 
 ## 0.27.1 -- 2022-12-28
 

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -477,14 +477,15 @@ pub(super) mod tests {
             ($name:ident: $data:expr => $expected:literal) => {
                 #[test]
                 fn $name() {
+                    let mut buffer = String::new();
                     let ser = ContentSerializer {
-                        writer: String::new(),
+                        writer: &mut buffer,
                         level: QuoteLevel::Full,
                         indent: Indent::None,
                         write_indent: false,
                     };
 
-                    let buffer = $data.serialize(ser).unwrap();
+                    $data.serialize(ser).unwrap();
                     assert_eq!(buffer, $expected);
                 }
             };
@@ -665,14 +666,15 @@ pub(super) mod tests {
             ($name:ident: $data:expr => $expected:literal) => {
                 #[test]
                 fn $name() {
+                    let mut buffer = String::new();
                     let ser = ContentSerializer {
-                        writer: String::new(),
+                        writer: &mut buffer,
                         level: QuoteLevel::Full,
                         indent: Indent::Owned(Indentation::new(b' ', 2)),
                         write_indent: false,
                     };
 
-                    let buffer = $data.serialize(ser).unwrap();
+                    $data.serialize(ser).unwrap();
                     assert_eq!(buffer, $expected);
                 }
             };

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -524,9 +524,10 @@ mod tests {
             ($name:ident: $data:expr => $expected:expr) => {
                 #[test]
                 fn $name() {
+                    let mut buffer = String::new();
                     let ser = ElementSerializer {
                         ser: ContentSerializer {
-                            writer: String::new(),
+                            writer: &mut buffer,
                             level: QuoteLevel::Full,
                             indent: Indent::None,
                             write_indent: false,
@@ -534,7 +535,7 @@ mod tests {
                         key: XmlName("root"),
                     };
 
-                    let buffer = $data.serialize(ser).unwrap();
+                    $data.serialize(ser).unwrap();
                     assert_eq!(buffer, $expected);
                 }
             };
@@ -1482,9 +1483,10 @@ mod tests {
             ($name:ident: $data:expr => $expected:expr) => {
                 #[test]
                 fn $name() {
+                    let mut buffer = String::new();
                     let ser = ElementSerializer {
                         ser: ContentSerializer {
-                            writer: String::new(),
+                            writer: &mut buffer,
                             level: QuoteLevel::Full,
                             indent: Indent::Owned(Indentation::new(b' ', 2)),
                             write_indent: false,
@@ -1492,7 +1494,7 @@ mod tests {
                         key: XmlName("root"),
                     };
 
-                    let buffer = $data.serialize(ser).unwrap();
+                    $data.serialize(ser).unwrap();
                     assert_eq!(buffer, $expected);
                 }
             };

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -24,13 +24,13 @@ macro_rules! write_primitive {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// A serializer used to serialize element with specified name.
-pub struct ElementSerializer<'k, W: Write> {
-    pub ser: ContentSerializer<'k, W>,
+pub struct ElementSerializer<'w, 'k, W: Write> {
+    pub ser: ContentSerializer<'w, 'k, W>,
     /// Tag name used to wrap serialized types except enum variants which uses the variant name
     pub(super) key: XmlName<'k>,
 }
 
-impl<'k, W: Write> Serializer for ElementSerializer<'k, W> {
+impl<'w, 'k, W: Write> Serializer for ElementSerializer<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 
@@ -38,9 +38,9 @@ impl<'k, W: Write> Serializer for ElementSerializer<'k, W> {
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
     type SerializeTupleVariant = Self;
-    type SerializeMap = Map<'k, W>;
-    type SerializeStruct = Struct<'k, W>;
-    type SerializeStructVariant = Struct<'k, W>;
+    type SerializeMap = Map<'w, 'k, W>;
+    type SerializeStruct = Struct<'w, 'k, W>;
+    type SerializeStructVariant = Struct<'w, 'k, W>;
 
     write_primitive!(serialize_bool(bool));
 
@@ -200,7 +200,7 @@ impl<'k, W: Write> Serializer for ElementSerializer<'k, W> {
     }
 }
 
-impl<'k, W: Write> SerializeSeq for ElementSerializer<'k, W> {
+impl<'w, 'k, W: Write> SerializeSeq for ElementSerializer<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 
@@ -223,7 +223,7 @@ impl<'k, W: Write> SerializeSeq for ElementSerializer<'k, W> {
     }
 }
 
-impl<'k, W: Write> SerializeTuple for ElementSerializer<'k, W> {
+impl<'w, 'k, W: Write> SerializeTuple for ElementSerializer<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 
@@ -241,7 +241,7 @@ impl<'k, W: Write> SerializeTuple for ElementSerializer<'k, W> {
     }
 }
 
-impl<'k, W: Write> SerializeTupleStruct for ElementSerializer<'k, W> {
+impl<'w, 'k, W: Write> SerializeTupleStruct for ElementSerializer<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 
@@ -259,7 +259,7 @@ impl<'k, W: Write> SerializeTupleStruct for ElementSerializer<'k, W> {
     }
 }
 
-impl<'k, W: Write> SerializeTupleVariant for ElementSerializer<'k, W> {
+impl<'w, 'k, W: Write> SerializeTupleVariant for ElementSerializer<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 
@@ -286,8 +286,8 @@ impl<'k, W: Write> SerializeTupleVariant for ElementSerializer<'k, W> {
 /// - attributes written directly to the higher serializer
 /// - elements buffered into internal buffer and at the end written into higher
 ///   serializer
-pub struct Struct<'k, W: Write> {
-    ser: ElementSerializer<'k, W>,
+pub struct Struct<'w, 'k, W: Write> {
+    ser: ElementSerializer<'w, 'k, W>,
     /// Buffer to store serialized elements
     // TODO: Customization point: allow direct writing of elements, but all
     // attributes should be listed first. Fail, if attribute encountered after
@@ -295,7 +295,7 @@ pub struct Struct<'k, W: Write> {
     children: String,
 }
 
-impl<'k, W: Write> Struct<'k, W> {
+impl<'w, 'k, W: Write> Struct<'w, 'k, W> {
     #[inline]
     fn write_field<T>(&mut self, key: &str, value: &T) -> Result<(), DeError>
     where
@@ -370,7 +370,7 @@ impl<'k, W: Write> Struct<'k, W> {
     }
 }
 
-impl<'k, W: Write> SerializeStruct for Struct<'k, W> {
+impl<'w, 'k, W: Write> SerializeStruct for Struct<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 
@@ -400,7 +400,7 @@ impl<'k, W: Write> SerializeStruct for Struct<'k, W> {
     }
 }
 
-impl<'k, W: Write> SerializeStructVariant for Struct<'k, W> {
+impl<'w, 'k, W: Write> SerializeStructVariant for Struct<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 
@@ -420,14 +420,14 @@ impl<'k, W: Write> SerializeStructVariant for Struct<'k, W> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pub struct Map<'k, W: Write> {
-    ser: Struct<'k, W>,
+pub struct Map<'w, 'k, W: Write> {
+    ser: Struct<'w, 'k, W>,
     /// Key, serialized by `QNameSerializer` if consumer uses `serialize_key` +
     /// `serialize_value` calls instead of `serialize_entry`
     key: Option<String>,
 }
 
-impl<'k, W: Write> Map<'k, W> {
+impl<'w, 'k, W: Write> Map<'w, 'k, W> {
     fn make_key<T>(&mut self, key: &T) -> Result<String, DeError>
     where
         T: ?Sized + Serialize,
@@ -438,7 +438,7 @@ impl<'k, W: Write> Map<'k, W> {
     }
 }
 
-impl<'k, W: Write> SerializeMap for Map<'k, W> {
+impl<'w, 'k, W: Write> SerializeMap for Map<'w, 'k, W> {
     type Ok = ();
     type Error = DeError;
 

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -31,7 +31,7 @@ pub struct ElementSerializer<'k, W: Write> {
 }
 
 impl<'k, W: Write> Serializer for ElementSerializer<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     type SerializeSeq = Self;
@@ -201,7 +201,7 @@ impl<'k, W: Write> Serializer for ElementSerializer<'k, W> {
 }
 
 impl<'k, W: Write> SerializeSeq for ElementSerializer<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -219,12 +219,12 @@ impl<'k, W: Write> SerializeSeq for ElementSerializer<'k, W> {
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(self.ser.writer)
+        Ok(())
     }
 }
 
 impl<'k, W: Write> SerializeTuple for ElementSerializer<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     #[inline]
@@ -242,7 +242,7 @@ impl<'k, W: Write> SerializeTuple for ElementSerializer<'k, W> {
 }
 
 impl<'k, W: Write> SerializeTupleStruct for ElementSerializer<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     #[inline]
@@ -260,7 +260,7 @@ impl<'k, W: Write> SerializeTupleStruct for ElementSerializer<'k, W> {
 }
 
 impl<'k, W: Write> SerializeTupleVariant for ElementSerializer<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     #[inline]
@@ -371,7 +371,7 @@ impl<'k, W: Write> Struct<'k, W> {
 }
 
 impl<'k, W: Write> SerializeStruct for Struct<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
@@ -396,12 +396,12 @@ impl<'k, W: Write> SerializeStruct for Struct<'k, W> {
             self.ser.ser.writer.write_str(self.ser.key.0)?;
             self.ser.ser.writer.write_char('>')?;
         }
-        Ok(self.ser.ser.writer)
+        Ok(())
     }
 }
 
 impl<'k, W: Write> SerializeStructVariant for Struct<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     #[inline]
@@ -439,7 +439,7 @@ impl<'k, W: Write> Map<'k, W> {
 }
 
 impl<'k, W: Write> SerializeMap for Map<'k, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -122,7 +122,7 @@ use std::str::from_utf8;
 ///     </Root>"
 /// );
 /// ```
-pub fn to_writer<W, T>(writer: W, value: &T) -> Result<W, DeError>
+pub fn to_writer<W, T>(writer: W, value: &T) -> Result<(), DeError>
 where
     W: Write,
     T: ?Sized + Serialize,
@@ -208,7 +208,7 @@ where
 /// ```
 ///
 /// [XML name]: https://www.w3.org/TR/REC-xml/#NT-Name
-pub fn to_writer_with_root<W, T>(writer: W, root_tag: &str, value: &T) -> Result<W, DeError>
+pub fn to_writer_with_root<W, T>(writer: W, root_tag: &str, value: &T) -> Result<(), DeError>
 where
     W: Write,
     T: ?Sized + Serialize,
@@ -560,7 +560,7 @@ impl<'r, W: Write> Serializer<'r, W> {
 }
 
 impl<'r, W: Write> ser::Serializer for Serializer<'r, W> {
-    type Ok = W;
+    type Ok = ();
     type Error = DeError;
 
     type SerializeSeq = <ElementSerializer<'r, W> as ser::Serializer>::SerializeSeq;
@@ -598,7 +598,7 @@ impl<'r, W: Write> ser::Serializer for Serializer<'r, W> {
     forward!(serialize_bytes(&[u8]));
 
     fn serialize_none(self) -> Result<Self::Ok, DeError> {
-        Ok(self.ser.writer)
+        Ok(())
     }
 
     fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, DeError> {

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -110,8 +110,10 @@ use std::str::from_utf8;
 ///     text: "text content",
 /// };
 ///
+/// let mut buffer = String::new();
+/// to_writer(&mut buffer, &data).unwrap();
 /// assert_eq!(
-///     to_writer(String::new(), &data).unwrap(),
+///     buffer,
 ///     // The root tag name is automatically deduced from the struct name
 ///     // This will not work for other types or struct with #[serde(flatten)] fields
 ///     "<Root attribute=\"attribute content\">\
@@ -165,7 +167,9 @@ pub fn to_string<T>(value: &T) -> Result<String, DeError>
 where
     T: ?Sized + Serialize,
 {
-    to_writer(String::new(), value)
+    let mut buffer = String::new();
+    to_writer(&mut buffer, value)?;
+    Ok(buffer)
 }
 
 /// Serialize struct into a `Write`r using specified root tag name.
@@ -192,8 +196,10 @@ where
 ///     text: "text content",
 /// };
 ///
+/// let mut buffer = String::new();
+/// to_writer_with_root(&mut buffer, "top-level", &data).unwrap();
 /// assert_eq!(
-///     to_writer_with_root(String::new(), "top-level", &data).unwrap(),
+///     buffer,
 ///     "<top-level attribute=\"attribute content\">\
 ///         <element>element content</element>\
 ///         text content\
@@ -248,7 +254,9 @@ pub fn to_string_with_root<T>(root_tag: &str, value: &T) -> Result<String, DeErr
 where
     T: ?Sized + Serialize,
 {
-    to_writer_with_root(String::new(), root_tag, value)
+    let mut buffer = String::new();
+    to_writer_with_root(&mut buffer, root_tag, value)?;
+    Ok(buffer)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -467,12 +475,11 @@ impl<'r, W: Write> Serializer<'r, W> {
     /// # use serde::Serialize;
     /// # use quick_xml::se::Serializer;
     ///
-    /// let ser = Serializer::with_root(String::new(), Some("root")).unwrap();
+    /// let mut buffer = String::new();
+    /// let ser = Serializer::with_root(&mut buffer, Some("root")).unwrap();
     ///
-    /// assert_eq!(
-    ///     "node".serialize(ser).unwrap(),
-    ///     "<root>node</root>"
-    /// );
+    /// "node".serialize(ser).unwrap();
+    /// assert_eq!(buffer, "<root>node</root>");
     /// ```
     ///
     /// When serializing a struct, newtype struct, unit struct or tuple `root_tag`
@@ -489,15 +496,17 @@ impl<'r, W: Write> Serializer<'r, W> {
     ///     answer: u32,
     /// }
     ///
-    /// let ser = Serializer::with_root(String::new(), Some("root")).unwrap();
+    /// let mut buffer = String::new();
+    /// let ser = Serializer::with_root(&mut buffer, Some("root")).unwrap();
     ///
     /// let data = Struct {
     ///     question: "The Ultimate Question of Life, the Universe, and Everything".into(),
     ///     answer: 42,
     /// };
     ///
+    /// data.serialize(ser).unwrap();
     /// assert_eq!(
-    ///     data.serialize(ser).unwrap(),
+    ///     buffer,
     ///     "<root>\
     ///         <question>The Ultimate Question of Life, the Universe, and Everything</question>\
     ///         <answer>42</answer>\

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -4,7 +4,7 @@
 
 use pretty_assertions::assert_eq;
 use quick_xml::de::from_str;
-use quick_xml::se::to_string;
+use quick_xml::se::{to_string, to_string_with_root};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -334,4 +334,29 @@ mod issue537 {
             r#"<Bindings xmlns="default" xmlns:named="named" attribute="attribute"/>"#
         );
     }
+}
+
+#[test]
+fn issue540() {
+    #[derive(Serialize)]
+    pub enum Enum {
+        Variant {},
+    }
+
+    #[derive(Serialize)]
+    pub struct Struct {
+        #[serde(flatten)]
+        flatten: Enum,
+    }
+
+    assert_eq!(
+        to_string_with_root(
+            "root",
+            &Struct {
+                flatten: Enum::Variant {},
+            }
+        )
+        .unwrap(),
+        "<root><Variant/></root>"
+    );
 }

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -164,9 +164,11 @@ mod without_root {
         ($name:ident: $data:expr => $expected:literal) => {
             #[test]
             fn $name() {
-                let ser = Serializer::new(String::new());
+                let mut buffer = String::new();
+                let ser = Serializer::new(&mut buffer);
 
-                assert_eq!($data.serialize(ser).unwrap(), $expected);
+                $data.serialize(ser).unwrap();
+                assert_eq!(buffer, $expected);
             }
         };
     }
@@ -556,10 +558,12 @@ mod without_root {
             ($name:ident: $data:expr => $expected:literal) => {
                 #[test]
                 fn $name() {
-                    let mut ser = Serializer::new(String::new());
+                    let mut buffer = String::new();
+                    let mut ser = Serializer::new(&mut buffer);
                     ser.indent(' ', 2);
 
-                    assert_eq!($data.serialize(ser).unwrap(), $expected);
+                    $data.serialize(ser).unwrap();
+                    assert_eq!(buffer, $expected);
                 }
             };
         }
@@ -948,9 +952,11 @@ mod with_root {
         ($name:ident: $data:expr => $expected:literal) => {
             #[test]
             fn $name() {
-                let ser = Serializer::with_root(String::new(), Some("root")).unwrap();
+                let mut buffer = String::new();
+                let ser = Serializer::with_root(&mut buffer, Some("root")).unwrap();
 
-                assert_eq!($data.serialize(ser).unwrap(), $expected);
+                $data.serialize(ser).unwrap();
+                assert_eq!(buffer, $expected);
             }
         };
     }


### PR DESCRIPTION
This PR slightly rewrites serializer, so rustc no more tries to recursively check traits on references. The consequence in that:
- `Serializer` now always store reference to the `Write`r instead writer itself
- do not return `writer` from the `Serialize::serialize` method

Based on #556 to use new function in the regression test.