### PR TITLE
Indicate minimum version 2.1 for memchr dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ document-features = { version = "0.2", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0.100", optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["io-util"] }
-memchr = "^2.1"
+memchr = "2.1"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ document-features = { version = "0.2", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0.100", optional = true }
 tokio = { version = "1.0", optional = true, default-features = false, features = ["io-util"] }
-memchr = "2.0"
+memchr = "^2.1"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,7 @@
   `DeEvent::CData` events was replaced by `DeEvent::Text` with merged content.
   The same behavior for the `Reader` does not implemented (yet?) and should be
   implemented manually
+- [#562]: Correctly set minimum required version of memchr dependency to 2.1
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -44,6 +44,7 @@
 [#540]: https://github.com/tafia/quick-xml/issues/540
 [#541]: https://github.com/tafia/quick-xml/pull/541
 [#556]: https://github.com/tafia/quick-xml/pull/556
+[#562]: https://github.com/tafia/quick-xml/pull/562
 
 ## 0.27.1 -- 2022-12-28
 


### PR DESCRIPTION
The 2.0 family of memchr doesn't build in this crate.  This is hard to see using cargo minimal-versions because tokio depends on memchr 2.2, which raises the dependency using minimal-versions even when tokio is disabled.  This is a known issue with cargo-minimal-versions:

https://github.com/taiki-e/cargo-minimal-versions/issues/6

So everything looks fine from the perspective of this crate, but consumers who use quick_xml without the optional features that enable the tokio dependency have a minimal version down to 2.0, which breaks.

To reproduce in this crate, I commented out the tokio and async_tokio lines in Cargo.toml and ran cargo minimal-versions, which produces the errors, and emulates the conditions an external user might experience.