### PR TITLE
Add check for minimal versions and fix compilation + more borrow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,23 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.52.0
     - run: cargo check
 
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install tools
+      run: cargo install cargo-hack cargo-minimal-versions
+    - name: Install nightly rust
+      uses: dtolnay/rust-toolchain@nightly
+    - name: Check with minimal versions
+      run: cargo minimal-versions check
+    - name: Check with minimal versions (serialize)
+      run: cargo minimal-versions check --features serialize
+    - name: Check with minimal versions (encoding)
+      run: cargo minimal-versions check --features encoding
+    - name: Check with minimal versions (async-tokio)
+      run: cargo minimal-versions check --features async-tokio
+
   test:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,16 @@ include = ["src/*", "LICENSE-MIT.md", "README.md"]
 document-features = { version = "0.2", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0.100", optional = true }
-tokio = { version = "1.0", optional = true, default-features = false, features = ["io-util"] }
+tokio = { version = "1.10", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.1"
 
 [dev-dependencies]
 criterion = "0.4"
 pretty_assertions = "1.3"
 regex = "1"
-serde = { version = "1.0", features = ["derive"] }
+# #[serde(other)] allowed not only inside field_identifier since 1.0.79
+# serde does not follow semver in numbering and their dependencies, so we specifying patch here
+serde_derive = { version = "1.0.79" }
 serde-value = "0.7"
 tokio = { version = "1.21", default-features = false, features = ["macros", "rt"] }
 tokio-test = "0.4"

--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@
   The same behavior for the `Reader` does not implemented (yet?) and should be
   implemented manually
 - [#562]: Correctly set minimum required version of memchr dependency to 2.1
+- [#565]: Correctly set minimum required version of tokio dependency to 1.10
 - [#565]: Fix compilation error when build with serde <1.0.139
 
 ### Misc Changes

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@
 - [#556]: Add new `to_writer_with_root` and `to_string_with_root` helper functions
 - [#520]: Add methods `BytesText::inplace_trim_start` and `BytesText::inplace_trim_end`
   to trim leading and trailing spaces from text events
+- [#565]: Allow deserialize special field names `$value` and `$text` into borrowed
+  fields when use serde deserializer
 
 ### Bug Fixes
 
@@ -33,6 +35,7 @@
   The same behavior for the `Reader` does not implemented (yet?) and should be
   implemented manually
 - [#562]: Correctly set minimum required version of memchr dependency to 2.1
+- [#565]: Fix compilation error when build with serde <1.0.139
 
 ### Misc Changes
 
@@ -45,6 +48,7 @@
 [#541]: https://github.com/tafia/quick-xml/pull/541
 [#556]: https://github.com/tafia/quick-xml/pull/556
 [#562]: https://github.com/tafia/quick-xml/pull/562
+[#565]: https://github.com/tafia/quick-xml/pull/565
 
 ## 0.27.1 -- 2022-12-28
 

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -4,7 +4,7 @@ use crate::{
     de::{DeEvent, Deserializer, XmlRead, TEXT_KEY},
     errors::serialize::DeError,
 };
-use serde::de::value::StrDeserializer;
+use serde::de::value::BorrowedStrDeserializer;
 use serde::de::{self, DeserializeSeed, Deserializer as _, Visitor};
 
 /// An enum access
@@ -42,7 +42,7 @@ where
                 false,
             ),
             DeEvent::Text(_) => (
-                seed.deserialize(StrDeserializer::<DeError>::new(TEXT_KEY))?,
+                seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
                 true,
             ),
             DeEvent::End(e) => return Err(DeError::UnexpectedEnd(e.name().into_inner().to_vec())),


### PR DESCRIPTION
While I was determining the actual minimum version of `serde`, I found the following:
- `StrDeserializer::new` was introduced in https://github.com/serde-rs/serde/pull/2246 in `serde` v1.0.139 only. I've replaced it with `BorrowedStrDeserializer::new`, which is available since `serde` v1.0
- As a result of the previous change, `$text` and `$value` special fields now can be deserialized into borrowed fields, for example, into `BTreeMap<&str, T>`
- `serde` does not follow semver neither in version numbering neither in the specifying its dependencies to sibling crates (serde->serde_derive). As a result, `cargo minimal-versions` tries to downgrade `serde` to 1.0.100, but `serde_derive` to 1.0.0 which is not compiled. For example, `serde_derive` at least up to 1.0.60 depends on the `syn` v0.13 which does not have a used method `make_where_clause`, which was introduced only in `syn` v0.14. The other thing, that we are use in our tests, are `#[serde(other)` which are allowed not only in `#[serde(field_identifier)]` enums only since `serde_derive` v1.0.79. So I explicitly indicate dependency from `serde_derive` v1.0.79
- method [fill_buf](https://docs.rs/tokio/1.10.0/tokio/io/trait.AsyncBufReadExt.html#method.fill_buf) in `tokio` was introduced only since 1.10