### PR TITLE
Add accessors to underlying writer: .get_ref() and .get_mut()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@
   to trim leading and trailing spaces from text events
 - [#565]: Allow deserialize special field names `$value` and `$text` into borrowed
   fields when use serde deserializer
+- [#568]: Rename `Writter::inner` into `Writter::get_mut`
+- [#568]: Add method `Writter::get_ref`
 
 ### Bug Fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -52,6 +52,7 @@
 [#556]: https://github.com/tafia/quick-xml/pull/556
 [#562]: https://github.com/tafia/quick-xml/pull/562
 [#565]: https://github.com/tafia/quick-xml/pull/565
+[#568]: https://github.com/tafia/quick-xml/pull/568
 
 ## 0.27.1 -- 2022-12-28
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -81,19 +81,14 @@ impl<W: Write> Writer<W> {
         self.writer
     }
 
-    /// Get inner writer, keeping ownership
-    pub fn inner(&mut self) -> &mut W {
+    /// Get a mutable reference to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
         &mut self.writer
     }
 
     /// Get a reference to the underlying writer.
     pub fn get_ref(&self) -> &W {
         &self.writer
-    }
-
-    /// Get a mutable reference to the underlying writer.
-    pub fn get_mut(&mut self) -> &mut W {
-        &mut self.writer
     }
 
     /// Write a [Byte-Order-Mark] character to the document.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -86,6 +86,16 @@ impl<W: Write> Writer<W> {
         &mut self.writer
     }
 
+    /// Get a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        &self.writer
+    }
+
+    /// Get a mutable reference to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
+
     /// Write a [Byte-Order-Mark] character to the document.
     ///
     /// # Example


### PR DESCRIPTION
Not sure about `.get_mut()` as the writer already has `.inner()`.
Closes #566.