### PR TITLE
Make read_event_into_async an async-fn

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
   fields when use serde deserializer
 - [#568]: Rename `Writter::inner` into `Writter::get_mut`
 - [#568]: Add method `Writter::get_ref`
+- [#569]: Rewrite the `Reader::read_event_into_async` as an async fn, making the future `Send` if possible.
 
 ### Bug Fixes
 
@@ -53,6 +54,7 @@
 [#562]: https://github.com/tafia/quick-xml/pull/562
 [#565]: https://github.com/tafia/quick-xml/pull/565
 [#568]: https://github.com/tafia/quick-xml/pull/568
+[#569]: https://github.com/tafia/quick-xml/pull/569
 
 ## 0.27.1 -- 2022-12-28
 

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -28,15 +28,6 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
     /// An asynchronous version of [`read_event_into()`]. Reads the next event into
     /// given buffer.
     ///
-    /// > This function should be defined as
-    /// > ```ignore
-    /// > pub async fn read_event_into_async<'b>(
-    /// >     &mut self,
-    /// >     buf: &'b mut Vec<u8>
-    /// > ) -> Result<Event<'b>>;
-    /// > ```
-    /// > but Rust does not allow to write that for recursive asynchronous function
-    ///
     /// This is the main entry point for reading XML `Event`s when using an async reader.
     ///
     /// See the documentation of [`read_event_into()`] for more information.
@@ -79,8 +70,8 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
     /// ```
     ///
     /// [`read_event_into()`]: Reader::read_event_into
-    pub async fn read_event_into_async<'reader, 'b: 'reader>(
-        &'reader mut self,
+    pub async fn read_event_into_async<'b>(
+        &mut self,
         mut buf: &'b mut Vec<u8>,
     ) -> Result<Event<'b>> {
         read_event_impl!(
@@ -152,8 +143,8 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
 
     /// Read until '<' is found, moves reader to an `OpenedTag` state and returns a `Text` event.
     ///
-    /// Returns inner Ok if the loop should be broken and an event returned.
-    /// Returns inner Err with the same [buf] because Rust borrowck stumbles upon this case in particular.
+    /// Returns inner `Ok` if the loop should be broken and an event returned.
+    /// Returns inner `Err` with the same `buf` because Rust borrowck stumbles upon this case in particular.
     async fn read_until_open_async<'b>(
         &mut self,
         buf: &'b mut Vec<u8>,

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -386,4 +386,18 @@ mod test {
         read_event_into_async: tokio::io::BufReader<_>,
         async, await
     );
+
+    #[test]
+    fn test_future_is_send() {
+        // This test should just compile, no actual runtime checks are performed here.
+        use super::*;
+        use tokio::io::BufReader;
+        fn check_send<T: Send>(_: T) {}
+
+        let input = vec![];
+        let mut reading_buf = vec![];
+        let mut reader = Reader::from_reader(BufReader::new(input.as_slice()));
+
+        check_send(reader.read_event_into_async(&mut reading_buf));
+    }
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -205,7 +205,7 @@ macro_rules! read_event_impl {
         match event {
             Err(_) | Ok(Event::Eof) => $self.parser.state = ParseState::Exit,
             _ => {}
-        };
+        }
         event
     }};
 }
@@ -614,8 +614,8 @@ impl<R> Reader<R> {
 
     /// Read until '<' is found, moves reader to an `OpenedTag` state and returns a `Text` event.
     ///
-    /// Returns inner Ok if the loop should be broken and an event returned.
-    /// Returns inner Err with the same [buf] because Rust borrowck stumbles upon this case in particular.
+    /// Returns inner `Ok` if the loop should be broken and an event returned.
+    /// Returns inner `Err` with the same `buf` because Rust borrowck stumbles upon this case in particular.
     fn read_until_open<'i, B>(&mut self, buf: B) -> Result<std::result::Result<Event<'i>, B>>
     where
         R: XmlSource<'i, B>,

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -166,34 +166,46 @@ macro_rules! read_event_impl {
         $read_until_close:ident
         $(, $await:ident)?
     ) => {{
-        let event = match $self.parser.state {
-            ParseState::Init => {
-                // If encoding set explicitly, we not need to detect it. For example,
-                // explicit UTF-8 set automatically if Reader was created using `from_str`.
-                // But we still need to remove BOM for consistency with no encoding
-                // feature enabled path
-                #[cfg(feature = "encoding")]
-                if let Some(encoding) = $reader.detect_encoding() $(.$await)? ? {
-                    if $self.parser.encoding.can_be_refined() {
-                        $self.parser.encoding = crate::reader::EncodingRef::BomDetected(encoding);
+        let event = loop {
+            match $self.parser.state {
+                ParseState::Init => {
+                    // If encoding set explicitly, we not need to detect it. For example,
+                    // explicit UTF-8 set automatically if Reader was created using `from_str`.
+                    // But we still need to remove BOM for consistency with no encoding
+                    // feature enabled path
+                    #[cfg(feature = "encoding")]
+                    if let Some(encoding) = $reader.detect_encoding() $(.$await)? ? {
+                        if $self.parser.encoding.can_be_refined() {
+                            $self.parser.encoding = crate::reader::EncodingRef::BomDetected(encoding);
+                        }
                     }
-                }
 
-                // Removes UTF-8 BOM if it is present
-                #[cfg(not(feature = "encoding"))]
-                $reader.remove_utf8_bom() $(.$await)? ?;
+                    // Removes UTF-8 BOM if it is present
+                    #[cfg(not(feature = "encoding"))]
+                    $reader.remove_utf8_bom() $(.$await)? ?;
 
-                $self.$read_until_open($buf) $(.$await)?
-            },
-            ParseState::ClosedTag => $self.$read_until_open($buf) $(.$await)?,
-            ParseState::OpenedTag => $self.$read_until_close($buf) $(.$await)?,
-            ParseState::Empty => $self.parser.close_expanded_empty(),
-            ParseState::Exit => return Ok(Event::Eof),
+                    match $self.$read_until_open($buf) $(.$await)? {
+                        Ok(Ok(ev)) => break Ok(ev),
+                        Ok(Err(b)) => $buf = b,
+                        Err(err)   => break Err(err),
+                    }
+                },
+                ParseState::ClosedTag => {
+                    match $self.$read_until_open($buf) $(.$await)? {
+                        Ok(Ok(ev)) => break Ok(ev),
+                        Ok(Err(b)) => $buf = b,
+                        Err(err)   => break Err(err),
+                    }
+                },
+                ParseState::OpenedTag => break $self.$read_until_close($buf) $(.$await)?,
+                ParseState::Empty => break $self.parser.close_expanded_empty(),
+                ParseState::Exit => break Ok(Event::Eof),
+            };
         };
         match event {
             Err(_) | Ok(Event::Eof) => $self.parser.state = ParseState::Exit,
             _ => {}
-        }
+        };
         event
     }};
 }
@@ -213,15 +225,15 @@ macro_rules! read_until_open {
 
         // If we already at the `<` symbol, do not try to return an empty Text event
         if $reader.skip_one(b'<', &mut $self.parser.offset) $(.$await)? ? {
-            return $self.$read_event($buf) $(.$await)?;
+            return Ok(Err($buf));
         }
 
         match $reader
             .read_bytes_until(b'<', $buf, &mut $self.parser.offset)
             $(.$await)?
         {
-            Ok(Some(bytes)) => $self.parser.read_text(bytes),
-            Ok(None) => Ok(Event::Eof),
+            Ok(Some(bytes)) => $self.parser.read_text(bytes).map(Ok),
+            Ok(None) => Ok(Ok(Event::Eof)),
             Err(e) => Err(e),
         }
     }};
@@ -593,7 +605,7 @@ impl<R> Reader<R> {
     /// Read text into the given buffer, and return an event that borrows from
     /// either that buffer or from the input itself, based on the type of the
     /// reader.
-    fn read_event_impl<'i, B>(&mut self, buf: B) -> Result<Event<'i>>
+    fn read_event_impl<'i, B>(&mut self, mut buf: B) -> Result<Event<'i>>
     where
         R: XmlSource<'i, B>,
     {
@@ -601,7 +613,10 @@ impl<R> Reader<R> {
     }
 
     /// Read until '<' is found, moves reader to an `OpenedTag` state and returns a `Text` event.
-    fn read_until_open<'i, B>(&mut self, buf: B) -> Result<Event<'i>>
+    ///
+    /// Returns inner Ok if the loop should be broken and an event returned.
+    /// Returns inner Err with the same [buf] because Rust borrowck stumbles upon this case in particular.
+    fn read_until_open<'i, B>(&mut self, buf: B) -> Result<std::result::Result<Event<'i>, B>>
     where
         R: XmlSource<'i, B>,
     {


### PR DESCRIPTION
Unless I'm missing something, this compiles and passes test just fine. Found out it while digging for the reason why my future suddenly becomes non-Send.