### PR TITLE
Borrow element names when deserialize using serde

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@
 - [#568]: Rename `Writter::inner` into `Writter::get_mut`
 - [#568]: Add method `Writter::get_ref`
 - [#569]: Rewrite the `Reader::read_event_into_async` as an async fn, making the future `Send` if possible.
+- [#571]: Borrow element names (`<element>`) when deserialize with serde.
+  This change allow to deserialize into `HashMap<&str, T>`, for example
 
 ### Bug Fixes
 
@@ -55,6 +57,7 @@
 [#565]: https://github.com/tafia/quick-xml/pull/565
 [#568]: https://github.com/tafia/quick-xml/pull/568
 [#569]: https://github.com/tafia/quick-xml/pull/569
+[#571]: https://github.com/tafia/quick-xml/pull/571
 
 ## 0.27.1 -- 2022-12-28
 

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -2,6 +2,7 @@ use crate::de::str2bool;
 use crate::encoding::Decoder;
 use crate::errors::serialize::DeError;
 use crate::name::QName;
+use crate::utils::CowRef;
 use serde::de::{DeserializeSeed, Deserializer, EnumAccess, VariantAccess, Visitor};
 use serde::{forward_to_deserialize_any, serde_if_integer128};
 use std::borrow::Cow;
@@ -60,18 +61,19 @@ fn decode_name<'n>(name: QName<'n>, decoder: Decoder) -> Result<Cow<'n, str>, De
 ///
 /// `deserialize_any()` returns the same result as `deserialize_identifier()`.
 ///
-/// # Lifetime
+/// # Lifetimes
 ///
+/// - `'i`: lifetime of the data that the deserializer borrows from the parsed input
 /// - `'d`: lifetime of a deserializer that holds a buffer with content of events
 ///
 /// [`attribute`]: Self::from_attr
 /// [`local_name()`]: QName::local_name
 /// [`Deserialize`]: serde::Deserialize
-pub struct QNameDeserializer<'d> {
-    name: Cow<'d, str>,
+pub struct QNameDeserializer<'i, 'd> {
+    name: CowRef<'i, 'd, str>,
 }
 
-impl<'d> QNameDeserializer<'d> {
+impl<'i, 'd> QNameDeserializer<'i, 'd> {
     /// Creates deserializer from name of an attribute
     pub fn from_attr(name: QName<'d>, decoder: Decoder) -> Result<Self, DeError> {
         // https://github.com/tafia/quick-xml/issues/537
@@ -83,19 +85,22 @@ impl<'d> QNameDeserializer<'d> {
         };
 
         Ok(Self {
-            name: Cow::Owned(format!("@{field}")),
+            name: CowRef::Owned(format!("@{field}")),
         })
     }
 
     /// Creates deserializer from name of an element
     pub fn from_elem(name: QName<'d>, decoder: Decoder) -> Result<Self, DeError> {
-        let local = decode_name(name, decoder)?;
+        let local = match decode_name(name, decoder)? {
+            Cow::Borrowed(borrowed) => CowRef::Slice(borrowed),
+            Cow::Owned(owned) => CowRef::Owned(owned),
+        };
 
         Ok(Self { name: local })
     }
 }
 
-impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'d> {
+impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'de, 'd> {
     type Error = DeError;
 
     forward_to_deserialize_any! {
@@ -202,8 +207,9 @@ impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'d> {
         V: Visitor<'de>,
     {
         match self.name {
-            Cow::Borrowed(name) => visitor.visit_str(name),
-            Cow::Owned(name) => visitor.visit_string(name),
+            CowRef::Input(name) => visitor.visit_borrowed_str(name),
+            CowRef::Slice(name) => visitor.visit_str(name),
+            CowRef::Owned(name) => visitor.visit_string(name),
         }
     }
 
@@ -220,7 +226,7 @@ impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'d> {
     }
 }
 
-impl<'de, 'd> EnumAccess<'de> for QNameDeserializer<'d> {
+impl<'de, 'd> EnumAccess<'de> for QNameDeserializer<'de, 'd> {
     type Error = DeError;
     type Variant = QNameUnitOnly;
 
@@ -337,7 +343,7 @@ mod tests {
             #[test]
             fn $name() {
                 let de = QNameDeserializer {
-                    name: Cow::Borrowed($input),
+                    name: CowRef::Input($input),
                 };
                 let data: $type = Deserialize::deserialize(de).unwrap();
 
@@ -352,7 +358,7 @@ mod tests {
             #[test]
             fn $name() {
                 let de = QNameDeserializer {
-                    name: Cow::Borrowed($input),
+                    name: CowRef::Input($input),
                 };
                 let data: $type = Deserialize::deserialize(de).unwrap();
 
@@ -377,7 +383,7 @@ mod tests {
             #[test]
             fn $name() {
                 let de = QNameDeserializer {
-                    name: Cow::Borrowed($input),
+                    name: CowRef::Input($input),
                 };
                 let err = <$type as Deserialize>::deserialize(de).unwrap_err();
 
@@ -420,8 +426,7 @@ mod tests {
         => Custom("invalid value: string \"&lt;\", expected a character"));
 
     deserialized_to!(string: String = "&lt;escaped&#x20;string" => "&lt;escaped&#x20;string");
-    err!(borrowed_str: &str = "name"
-        => Custom("invalid type: string \"name\", expected a borrowed string"));
+    deserialized_to!(borrowed_str: &str = "name" => "name");
 
     err!(byte_buf: ByteBuf = "&lt;escaped&#x20;string"
         => Custom("invalid type: string \"&lt;escaped&#x20;string\", expected byte data"));

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -281,7 +281,7 @@ where
                 DeEvent::Start(e) => {
                     self.source = ValueSource::Nested;
 
-                    let de = QNameDeserializer::from_elem(e.name(), decoder)?;
+                    let de = QNameDeserializer::from_elem(e.raw_name(), decoder)?;
                     seed.deserialize(de).map(Some)
                 }
                 // Stop iteration after reaching a closing tag

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -38,7 +38,7 @@ where
         let decoder = self.de.reader.decoder();
         let (name, is_text) = match self.de.peek()? {
             DeEvent::Start(e) => (
-                seed.deserialize(QNameDeserializer::from_elem(e.name(), decoder)?)?,
+                seed.deserialize(QNameDeserializer::from_elem(e.raw_name(), decoder)?)?,
                 false,
             ),
             DeEvent::Text(_) => (

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -49,7 +49,7 @@ use crate::errors::{Error, Result};
 use crate::escape::{escape, partial_escape, unescape_with};
 use crate::name::{LocalName, QName};
 use crate::reader::is_whitespace;
-use crate::utils::write_cow_string;
+use crate::utils::{write_cow_string, CowRef};
 use attributes::{Attribute, Attributes};
 use std::mem::replace;
 
@@ -188,6 +188,21 @@ impl<'a> BytesStart<'a> {
         bytes.splice(..self.name_len, name.iter().cloned());
         self.name_len = name.len();
         self
+    }
+
+    /// Gets the undecoded raw tag name, as present in the input stream, which
+    /// is borrowed either to the input, or to the event.
+    ///
+    /// # Lifetimes
+    ///
+    /// - `'a`: Lifetime of the input data from which this event is borrow
+    /// - `'e`: Lifetime of the concrete event instance
+    // TODO: We should made this is a part of public API, but with safe wrapped for a name
+    pub(crate) fn raw_name<'e>(&'e self) -> CowRef<'a, 'e, [u8]> {
+        match self.buf {
+            Cow::Borrowed(b) => CowRef::Input(&b[..self.name_len]),
+            Cow::Owned(ref o) => CowRef::Slice(&o[..self.name_len]),
+        }
     }
 }
 

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -6285,6 +6285,9 @@ fn from_str_should_ignore_encoding() {
 /// Checks that deserializer is able to borrow data from the input
 mod borrow {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use std::collections::BTreeMap;
+    use std::iter::FromIterator;
 
     /// Struct that should borrow input to be able to deserialize successfully.
     /// serde implicitly borrow `&str` and `&[u8]` even without `#[serde(borrow)]`
@@ -6402,5 +6405,25 @@ mod borrow {
                 ),
             }
         }
+    }
+
+    #[test]
+    fn element_name() {
+        let data: BTreeMap<&str, &str> = from_str(
+            r#"
+            <root>
+                <element>element content</element>
+                text content
+            </root>"#,
+        )
+        .unwrap();
+        assert_eq!(
+            data,
+            BTreeMap::from_iter([
+                // Comment to prevent formatting in one line
+                ("element", "element content"),
+                ("$text", "text content"),
+            ])
+        );
     }
 }

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -142,6 +142,23 @@ fn issue349() {
     );
 }
 
+/// Regression test for https://github.com/tafia/quick-xml/issues/352.
+#[test]
+fn issue352() {
+    use std::borrow::Cow;
+
+    #[derive(Deserialize)]
+    struct Root<'a> {
+        #[serde(borrow)]
+        #[serde(rename = "@attribute")]
+        attribute: Cow<'a, str>,
+    }
+
+    let r: Root = from_str("<Root attribute='borrowed value'></Root>").unwrap();
+
+    assert!(matches!(r.attribute, Cow::Borrowed(_)));
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/429.
 #[test]
 fn issue429() {


### PR DESCRIPTION
Makes it possible to deserialize 
```xml
<root>
  <element>element content<element>
</root>
```
into `HashMap<&str, &str>` (`"element" => "element content"` in this case), for example