### PR TITLE
Implement correct handling of `$text` fields in enums and add roundtrip tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,8 +12,8 @@
 
 ### New Features
 
-- [#541]: Deserialize specially named `$text` enum variant in [externally tagged]
-  enums from textual content
+- [#541]: (De)serialize specially named `$text` enum variant in [externally tagged]
+  enums to / from textual content
 - [#556]: `to_writer` and `to_string` now accept `?Sized` types
 - [#556]: Add new `to_writer_with_root` and `to_string_with_root` helper functions
 - [#520]: Add methods `BytesText::inplace_trim_start` and `BytesText::inplace_trim_end`

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -1,7 +1,7 @@
 //! Contains serializer for content of an XML element
 
 use crate::errors::serialize::DeError;
-use crate::se::element::{ElementSerializer, Struct};
+use crate::se::element::{ElementSerializer, Struct, Tuple};
 use crate::se::simple_type::{QuoteTarget, SimpleTypeSerializer};
 use crate::se::{Indent, QuoteLevel, XmlName};
 use serde::ser::{
@@ -132,7 +132,7 @@ impl<'w, 'i, W: Write> Serializer for ContentSerializer<'w, 'i, W> {
     type SerializeSeq = Self;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
-    type SerializeTupleVariant = ElementSerializer<'w, 'i, W>;
+    type SerializeTupleVariant = Tuple<'w, 'i, W>;
     type SerializeMap = Impossible<Self::Ok, Self::Error>;
     type SerializeStruct = Impossible<Self::Ok, Self::Error>;
     type SerializeStructVariant = Struct<'w, 'i, W>;
@@ -258,7 +258,7 @@ impl<'w, 'i, W: Write> Serializer for ContentSerializer<'w, 'i, W> {
         // `ElementSerializer::serialize_tuple_variant` is the same as
         // `ElementSerializer::serialize_tuple_struct`, except that it replaces `.key`
         // to `variant` which is not required here
-        ser.serialize_tuple_struct(name, len)
+        ser.serialize_tuple_struct(name, len).map(Tuple::Element)
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -477,13 +477,17 @@ mod without_root {
                     </InternallyTagged>");
             // serde serializes internally tagged newtype structs by delegating
             // serialization to the inner type and augmenting it with a tag
-            serialize_as!(newtype:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(newtype:
                 InternallyTagged::Newtype(Nested { float: 4.2 })
                 => "<Nested>\
                         <tag>Newtype</tag>\
                         <float>4.2</float>\
                     </Nested>");
-            serialize_as!(struct_:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(struct_:
                 InternallyTagged::Struct {
                     float: 42.0,
                     string: "answer"
@@ -493,7 +497,9 @@ mod without_root {
                         <float>42</float>\
                         <string>answer</string>\
                     </InternallyTagged>");
-            serialize_as!(nested_struct:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(nested_struct:
                 InternallyTagged::Holder {
                     nested: Nested { float: 42.0 },
                     string: "answer",
@@ -518,7 +524,9 @@ mod without_root {
                 => "<InternallyTagged>\
                         <tag>Empty</tag>\
                     </InternallyTagged>");
-            serialize_as!(text:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(text:
                 InternallyTagged::Text {
                     float: 42.0,
                     string: "answer"
@@ -626,7 +634,9 @@ mod without_root {
                 => Unsupported("cannot serialize `bool` without defined root tag"));
             err!(tuple_struct: Untagged::Tuple(42.0, "answer")
                 => Unsupported("cannot serialize unnamed tuple without defined root tag"));
-            serialize_as!(struct_:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(struct_:
                 Untagged::Struct {
                     float: 42.0,
                     string: "answer",
@@ -635,7 +645,9 @@ mod without_root {
                         <float>42</float>\
                         <string>answer</string>\
                     </Untagged>");
-            serialize_as!(nested_struct:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(nested_struct:
                 Untagged::Holder {
                     nested: Nested { float: 42.0 },
                     string: "answer",
@@ -657,7 +669,9 @@ mod without_root {
             serialize_as!(empty_struct:
                 Untagged::Empty {}
                 => "<Untagged/>");
-            serialize_as!(text:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(text:
                 Untagged::Text {
                     float: 42.0,
                     string: "answer"
@@ -1270,7 +1284,9 @@ mod with_root {
                 </nested>\
                 <string>answer</string>\
             </root>");
-    serialize_as!(flatten_struct:
+    // NOTE: Cannot be deserialized in roundtrip due to
+    // https://github.com/serde-rs/serde/issues/1183
+    serialize_as_only!(flatten_struct:
         FlattenStruct {
             nested: Nested { float: 42.0 },
             string: "answer",
@@ -1404,13 +1420,17 @@ mod with_root {
                 => "<root>\
                         <tag>Unit</tag>\
                     </root>");
-            serialize_as!(newtype:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(newtype:
                 InternallyTagged::Newtype(Nested { float: 4.2 })
                 => "<root>\
                         <tag>Newtype</tag>\
                         <float>4.2</float>\
                     </root>");
-            serialize_as!(struct_:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(struct_:
                 InternallyTagged::Struct {
                     float: 42.0,
                     string: "answer",
@@ -1420,7 +1440,9 @@ mod with_root {
                         <float>42</float>\
                         <string>answer</string>\
                     </root>");
-            serialize_as!(nested_struct:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(nested_struct:
                 InternallyTagged::Holder {
                     nested: Nested { float: 42.0 },
                     string: "answer",
@@ -1449,7 +1471,9 @@ mod with_root {
                 => "<root>\
                         <tag>Empty</tag>\
                     </root>");
-            serialize_as!(text:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(text:
                 InternallyTagged::Text {
                     float: 42.0,
                     string: "answer"
@@ -1549,17 +1573,25 @@ mod with_root {
             use super::*;
             use pretty_assertions::assert_eq;
 
-            serialize_as!(unit:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(unit:
                 Untagged::Unit
                 => "<root/>");
-            serialize_as!(newtype:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(newtype:
                 Untagged::Newtype(true)
                 => "<root>true</root>");
-            serialize_as!(tuple_struct:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(tuple_struct:
                 Untagged::Tuple(42.0, "answer")
                 => "<root>42</root>\
                     <root>answer</root>");
-            serialize_as!(struct_:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(struct_:
                 Untagged::Struct {
                     float: 42.0,
                     string: "answer",
@@ -1568,7 +1600,9 @@ mod with_root {
                         <float>42</float>\
                         <string>answer</string>\
                     </root>");
-            serialize_as!(nested_struct:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(nested_struct:
                 Untagged::Holder {
                     nested: Nested { float: 42.0 },
                     string: "answer",
@@ -1593,7 +1627,9 @@ mod with_root {
             serialize_as!(empty_struct:
                 Untagged::Empty {}
                 => "<root/>");
-            serialize_as!(text:
+            // NOTE: Cannot be deserialized in roundtrip due to
+            // https://github.com/serde-rs/serde/issues/1183
+            serialize_as_only!(text:
                 Untagged::Text {
                     float: 42.0,
                     string: "answer"

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -351,8 +351,49 @@ mod without_root {
                         42\
                         <string>answer</string>\
                     </Text>");
+
+            /// Test serialization of the specially named variant `$text`
+            mod text {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Serialize)]
+                enum Unit {
+                    #[serde(rename = "$text")]
+                    Text,
+                }
+                #[derive(Serialize)]
+                enum Newtype<'a> {
+                    #[serde(rename = "$text")]
+                    Text(&'a str),
+                }
+                #[derive(Serialize)]
+                enum Tuple<'a> {
+                    #[serde(rename = "$text")]
+                    Text(f64, &'a str),
+                }
+                #[derive(Serialize)]
+                enum Struct<'a> {
+                    #[serde(rename = "$text")]
+                    Text { float: f64, string: &'a str },
+                }
+
+                // It is unknown how to exactly serialize unit to a text
+                err!(unit: Unit::Text => Unsupported("`Unit::$text` unit variant cannot be serialized"));
+                serialize_as!(newtype: Newtype::Text("newtype text") => "newtype text");
+                // Tuple variant serialized as an `xs:list`
+                serialize_as!(tuple: Tuple::Text(4.2, "newtype text") => "4.2 newtype&#32;text");
+                // Struct variant cannot be directly serialized to a text
+                err!(struct_:
+                    Struct::Text {
+                        float: 4.2,
+                        string: "newtype text",
+                    }
+                    => Unsupported("`Struct::$text` struct variant cannot be serialized"));
+            }
         }
 
+        /// Name `$text` has no special meaning in internally tagged enums
         mod internally_tagged {
             use super::*;
             use pretty_assertions::assert_eq;
@@ -417,6 +458,7 @@ mod without_root {
                     </InternallyTagged>");
         }
 
+        /// Name `$text` has no special meaning in adjacently tagged enums
         mod adjacently_tagged {
             use super::*;
             use pretty_assertions::assert_eq;
@@ -497,6 +539,7 @@ mod without_root {
                     </AdjacentlyTagged>");
         }
 
+        /// Name `$text` has no special meaning in untagged enums
         mod untagged {
             use super::*;
             use pretty_assertions::assert_eq;
@@ -745,8 +788,49 @@ mod without_root {
                             42\n  \
                             <string>answer</string>\n\
                         </Text>");
+
+                /// Test serialization of the specially named variant `$text`
+                mod text {
+                    use super::*;
+                    use pretty_assertions::assert_eq;
+
+                    #[derive(Serialize)]
+                    enum Unit {
+                        #[serde(rename = "$text")]
+                        Text,
+                    }
+                    #[derive(Serialize)]
+                    enum Newtype<'a> {
+                        #[serde(rename = "$text")]
+                        Text(&'a str),
+                    }
+                    #[derive(Serialize)]
+                    enum Tuple<'a> {
+                        #[serde(rename = "$text")]
+                        Text(f64, &'a str),
+                    }
+                    #[derive(Serialize)]
+                    enum Struct<'a> {
+                        #[serde(rename = "$text")]
+                        Text { float: f64, string: &'a str },
+                    }
+
+                    // It is unknown how to exactly serialize unit to a text
+                    err!(unit: Unit::Text => Unsupported("`Unit::$text` unit variant cannot be serialized"));
+                    serialize_as!(newtype: Newtype::Text("newtype text") => "newtype text");
+                    // Tuple variant serialized as an `xs:list`
+                    serialize_as!(tuple: Tuple::Text(4.2, "newtype text") => "4.2 newtype&#32;text");
+                    // Struct variant cannot be directly serialized to a text
+                    err!(struct_:
+                        Struct::Text {
+                            float: 4.2,
+                            string: "newtype text",
+                        }
+                        => Unsupported("`Struct::$text` struct variant cannot be serialized"));
+                }
             }
 
+            /// Name `$text` has no special meaning in untagged enums
             mod internally_tagged {
                 use super::*;
                 use pretty_assertions::assert_eq;
@@ -811,6 +895,7 @@ mod without_root {
                         </InternallyTagged>");
             }
 
+            /// Name `$text` has no special meaning in untagged enums
             mod adjacently_tagged {
                 use super::*;
                 use pretty_assertions::assert_eq;
@@ -891,6 +976,7 @@ mod without_root {
                         </AdjacentlyTagged>");
             }
 
+            /// Name `$text` has no special meaning in untagged enums
             mod untagged {
                 use super::*;
                 use pretty_assertions::assert_eq;
@@ -1156,8 +1242,49 @@ mod with_root {
                         42\
                         <string>answer</string>\
                     </Text>");
+
+            /// Test serialization of the specially named variant `$text`
+            mod text {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[derive(Serialize)]
+                enum Unit {
+                    #[serde(rename = "$text")]
+                    Text,
+                }
+                #[derive(Serialize)]
+                enum Newtype<'a> {
+                    #[serde(rename = "$text")]
+                    Text(&'a str),
+                }
+                #[derive(Serialize)]
+                enum Tuple<'a> {
+                    #[serde(rename = "$text")]
+                    Text(f64, &'a str),
+                }
+                #[derive(Serialize)]
+                enum Struct<'a> {
+                    #[serde(rename = "$text")]
+                    Text { float: f64, string: &'a str },
+                }
+
+                // It is unknown how to exactly serialize unit to a text
+                err!(unit: Unit::Text => Unsupported("`Unit::$text` unit variant cannot be serialized"));
+                serialize_as!(newtype: Newtype::Text("newtype text") => "newtype text");
+                // Tuple variant serialized as an `xs:list`
+                serialize_as!(tuple: Tuple::Text(4.2, "newtype text") => "4.2 newtype&#32;text");
+                // Struct variant cannot be directly serialized to a text
+                err!(struct_:
+                    Struct::Text {
+                        float: 4.2,
+                        string: "newtype text",
+                    }
+                    => Unsupported("`Struct::$text` struct variant cannot be serialized"));
+            }
         }
 
+        /// Name `$text` has no special meaning in adjacently tagged enums
         mod internally_tagged {
             use super::*;
             use pretty_assertions::assert_eq;
@@ -1222,6 +1349,7 @@ mod with_root {
                     </root>");
         }
 
+        /// Name `$text` has no special meaning in adjacently tagged enums
         mod adjacently_tagged {
             use super::*;
             use pretty_assertions::assert_eq;
@@ -1302,6 +1430,7 @@ mod with_root {
                     </root>");
         }
 
+        /// Name `$text` has no special meaning in untagged enums
         mod untagged {
             use super::*;
             use pretty_assertions::assert_eq;

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -454,7 +454,12 @@ mod without_root {
                 err!(unit: Unit::Text => Unsupported("`Unit::$text` unit variant cannot be serialized"));
                 serialize_as!(newtype: Newtype::Text("newtype text") => "newtype text");
                 // Tuple variant serialized as an `xs:list`
-                serialize_as!(tuple: Tuple::Text(4.2, "newtype text".into()) => "4.2 newtype&#32;text");
+                serialize_as!(tuple: Tuple::Text(4.2, "newtype-text".into()) => "4.2 newtype-text");
+                // Note, that spaces in strings, even escaped, would represent
+                // the list item delimiters. Non-symmetric serialization follows
+                // tradition: the XmlBeans Java library have the same behavior.
+                // See also <https://stackoverflow.com/questions/45494204/escape-space-in-xml-xslist>
+                serialize_as_only!(tuple_with_spaces: Tuple::Text(4.2, "newtype text".into()) => "4.2 newtype&#32;text");
                 // Struct variant cannot be directly serialized to a text
                 err!(struct_:
                     Struct::Text {
@@ -1401,7 +1406,12 @@ mod with_root {
                 err!(unit: Unit::Text => Unsupported("`Unit::$text` unit variant cannot be serialized"));
                 serialize_as!(newtype: Newtype::Text("newtype text") => "newtype text");
                 // Tuple variant serialized as an `xs:list`
-                serialize_as!(tuple: Tuple::Text(4.2, "newtype text".into()) => "4.2 newtype&#32;text");
+                serialize_as!(tuple: Tuple::Text(4.2, "newtype-text".into()) => "4.2 newtype-text");
+                // Note, that spaces in strings, even escaped, would represent
+                // the list item delimiters. Non-symmetric serialization follows
+                // tradition: the XmlBeans Java library have the same behavior.
+                // See also <https://stackoverflow.com/questions/45494204/escape-space-in-xml-xslist>
+                serialize_as_only!(tuple_with_spaces: Tuple::Text(4.2, "newtype text".into()) => "4.2 newtype&#32;text");
                 // Struct variant cannot be directly serialized to a text
                 err!(struct_:
                     Struct::Text {

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -440,9 +440,9 @@ mod without_root {
                     Text(&'a str),
                 }
                 #[derive(Debug, PartialEq, Deserialize, Serialize)]
-                enum Tuple<'a> {
+                enum Tuple {
                     #[serde(rename = "$text")]
-                    Text(f64, &'a str),
+                    Text(f64, String),
                 }
                 #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Struct<'a> {
@@ -454,7 +454,7 @@ mod without_root {
                 err!(unit: Unit::Text => Unsupported("`Unit::$text` unit variant cannot be serialized"));
                 serialize_as!(newtype: Newtype::Text("newtype text") => "newtype text");
                 // Tuple variant serialized as an `xs:list`
-                serialize_as!(tuple: Tuple::Text(4.2, "newtype text") => "4.2 newtype&#32;text");
+                serialize_as!(tuple: Tuple::Text(4.2, "newtype text".into()) => "4.2 newtype&#32;text");
                 // Struct variant cannot be directly serialized to a text
                 err!(struct_:
                     Struct::Text {
@@ -1222,10 +1222,11 @@ mod with_root {
     serialize_as!(char_amp:         '&'  => "<root>&amp;</root>");
     serialize_as!(char_apos:        '\'' => "<root>&apos;</root>");
     serialize_as!(char_quot:        '"'  => "<root>&quot;</root>");
-    serialize_as!(char_space:       ' '  => "<root> </root>");
+    // FIXME: Probably we should trim only for specified types when deserialize
+    serialize_as_only!(char_space:       ' '  => "<root> </root>");
 
     serialize_as!(str_non_escaped: "non-escaped string"; &str => "<root>non-escaped string</root>");
-    serialize_as!(str_escaped:  "<\"escaped & string'>"; &str => "<root>&lt;&quot;escaped &amp; string&apos;&gt;</root>");
+    serialize_as!(str_escaped: "<\"escaped & string'>"; String => "<root>&lt;&quot;escaped &amp; string&apos;&gt;</root>");
 
     err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported yet"));
 
@@ -1249,7 +1250,8 @@ mod with_root {
             <root>2</root>\
             <root>3</root>");
     serialize_as!(tuple:
-        ("<\"&'>", "with\t\r\n spaces", 3usize)
+        // Use to_string() to get owned type that is required for deserialization
+        ("<\"&'>".to_string(), "with\t\r\n spaces", 3usize)
         => "<root>&lt;&quot;&amp;&apos;&gt;</root>\
             <root>with\t\r\n spaces</root>\
             <root>3</root>");
@@ -1385,9 +1387,9 @@ mod with_root {
                     Text(&'a str),
                 }
                 #[derive(Debug, PartialEq, Deserialize, Serialize)]
-                enum Tuple<'a> {
+                enum Tuple {
                     #[serde(rename = "$text")]
-                    Text(f64, &'a str),
+                    Text(f64, String),
                 }
                 #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Struct<'a> {
@@ -1399,7 +1401,7 @@ mod with_root {
                 err!(unit: Unit::Text => Unsupported("`Unit::$text` unit variant cannot be serialized"));
                 serialize_as!(newtype: Newtype::Text("newtype text") => "newtype text");
                 // Tuple variant serialized as an `xs:list`
-                serialize_as!(tuple: Tuple::Text(4.2, "newtype text") => "4.2 newtype&#32;text");
+                serialize_as!(tuple: Tuple::Text(4.2, "newtype text".into()) => "4.2 newtype&#32;text");
                 // Struct variant cannot be directly serialized to a text
                 err!(struct_:
                     Struct::Text {

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -66,12 +66,13 @@ enum ExternallyTagged {
         nested: Nested,
         string: &'static str,
     },
-    Empty {},
+    /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
         float: f64,
         string: &'static str,
     },
+    Empty {},
 }
 
 #[derive(Serialize)]
@@ -94,12 +95,13 @@ enum InternallyTagged {
         nested: Nested,
         string: &'static str,
     },
-    Empty {},
+    /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
         float: f64,
         string: &'static str,
     },
+    Empty {},
 }
 
 #[derive(Serialize)]
@@ -121,12 +123,13 @@ enum AdjacentlyTagged {
         nested: Nested,
         string: &'static str,
     },
-    Empty {},
+    /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
         float: f64,
         string: &'static str,
     },
+    Empty {},
 }
 
 #[derive(Serialize)]
@@ -148,12 +151,13 @@ enum Untagged {
         nested: Nested,
         string: &'static str,
     },
-    Empty {},
+    /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
         float: f64,
         string: &'static str,
     },
+    Empty {},
 }
 
 mod without_root {

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -2,53 +2,53 @@ use quick_xml::se::Serializer;
 use quick_xml::utils::Bytes;
 use quick_xml::DeError;
 
-use serde::{serde_if_integer128, Serialize};
+use serde::{serde_if_integer128, Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Unit;
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Newtype(bool);
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Tuple(f32, &'static str);
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Struct {
     float: f64,
     string: &'static str,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct NestedStruct {
     nested: Nested,
     string: &'static str,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct FlattenStruct {
     #[serde(flatten)]
     nested: Nested,
     string: &'static str,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Nested {
     float: f64,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Empty {}
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 struct Text {
     #[serde(rename = "$text")]
     float: f64,
     string: &'static str,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 enum ExternallyTagged {
     Unit,
     Newtype(bool),
@@ -61,11 +61,6 @@ enum ExternallyTagged {
         nested: Nested,
         string: &'static str,
     },
-    Flatten {
-        #[serde(flatten)]
-        nested: Nested,
-        string: &'static str,
-    },
     /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
@@ -75,7 +70,23 @@ enum ExternallyTagged {
     Empty {},
 }
 
+/// Having both `#[serde(flatten)]` and `'static` fields in one struct leads to
+/// incorrect code generation when deriving `Deserialize`.
+///
+/// TODO: Merge into main enum after fixing <https://github.com/serde-rs/serde/issues/2371>
+///
+/// Anyway, deserialization of that type in roundtrip suffers from
+/// <https://github.com/serde-rs/serde/issues/1183>
 #[derive(Serialize)]
+enum ExternallyTaggedWorkaround {
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+        string: &'static str,
+    },
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "tag")]
 enum InternallyTagged {
     Unit,
@@ -90,11 +101,6 @@ enum InternallyTagged {
         nested: Nested,
         string: &'static str,
     },
-    Flatten {
-        #[serde(flatten)]
-        nested: Nested,
-        string: &'static str,
-    },
     /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
@@ -104,7 +110,24 @@ enum InternallyTagged {
     Empty {},
 }
 
-#[derive(Serialize)]
+/// Having both `#[serde(flatten)]` and `'static` fields in one struct leads to
+/// incorrect code generation when deriving `Deserialize`.
+///
+/// TODO: Merge into main enum after fixing <https://github.com/serde-rs/serde/issues/2371>
+///
+/// Anyway, deserialization of that type in roundtrip suffers from
+/// <https://github.com/serde-rs/serde/issues/1183>
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(tag = "tag")]
+enum InternallyTaggedWorkaround {
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+        string: &'static str,
+    },
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "tag", content = "content")]
 enum AdjacentlyTagged {
     Unit,
@@ -118,11 +141,6 @@ enum AdjacentlyTagged {
         nested: Nested,
         string: &'static str,
     },
-    Flatten {
-        #[serde(flatten)]
-        nested: Nested,
-        string: &'static str,
-    },
     /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
@@ -132,7 +150,24 @@ enum AdjacentlyTagged {
     Empty {},
 }
 
+/// Having both `#[serde(flatten)]` and `'static` fields in one struct leads to
+/// incorrect code generation when deriving `Deserialize`.
+///
+/// TODO: Merge into main enum after fixing <https://github.com/serde-rs/serde/issues/2371>
+///
+/// Anyway, deserialization of that type in roundtrip suffers from
+/// <https://github.com/serde-rs/serde/issues/1183>
 #[derive(Serialize)]
+#[serde(tag = "tag", content = "content")]
+enum AdjacentlyTaggedWorkaround {
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+        string: &'static str,
+    },
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 enum Untagged {
     Unit,
@@ -146,11 +181,6 @@ enum Untagged {
         nested: Nested,
         string: &'static str,
     },
-    Flatten {
-        #[serde(flatten)]
-        nested: Nested,
-        string: &'static str,
-    },
     /// `float` field serialized as textual content instead of a tag
     Text {
         #[serde(rename = "$text")]
@@ -158,6 +188,23 @@ enum Untagged {
         string: &'static str,
     },
     Empty {},
+}
+
+/// Having both `#[serde(flatten)]` and `'static` fields in one struct leads to
+/// incorrect code generation when deriving `Deserialize`.
+///
+/// TODO: Merge into main enum after fixing <https://github.com/serde-rs/serde/issues/2371>
+///
+/// Anyway, deserialization of that type in roundtrip suffers from
+/// <https://github.com/serde-rs/serde/issues/1183>
+#[derive(Serialize)]
+#[serde(untagged)]
+enum UntaggedWorkaround {
+    Flatten {
+        #[serde(flatten)]
+        nested: Nested,
+        string: &'static str,
+    },
 }
 
 mod without_root {
@@ -335,7 +382,7 @@ mod without_root {
                         <string>answer</string>\
                     </Holder>");
             serialize_as!(flatten_struct:
-                ExternallyTagged::Flatten {
+                ExternallyTaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }
@@ -361,22 +408,22 @@ mod without_root {
                 use super::*;
                 use pretty_assertions::assert_eq;
 
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Unit {
                     #[serde(rename = "$text")]
                     Text,
                 }
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Newtype<'a> {
                     #[serde(rename = "$text")]
                     Text(&'a str),
                 }
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Tuple<'a> {
                     #[serde(rename = "$text")]
                     Text(f64, &'a str),
                 }
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Struct<'a> {
                     #[serde(rename = "$text")]
                     Text { float: f64, string: &'a str },
@@ -440,7 +487,7 @@ mod without_root {
             // serde serializes flatten structs as maps, and we do not support
             // serialization of maps without root tag
             err!(flatten_struct:
-                InternallyTagged::Flatten {
+                InternallyTaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }
@@ -512,17 +559,17 @@ mod without_root {
                         </content>\
                     </AdjacentlyTagged>");
             serialize_as!(flatten_struct:
-                AdjacentlyTagged::Flatten {
+                AdjacentlyTaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }
-                => "<AdjacentlyTagged>\
+                => "<AdjacentlyTaggedWorkaround>\
                         <tag>Flatten</tag>\
                         <content>\
                             <float>42</float>\
                             <string>answer</string>\
                         </content>\
-                    </AdjacentlyTagged>");
+                    </AdjacentlyTaggedWorkaround>");
             serialize_as!(empty_struct:
                 AdjacentlyTagged::Empty {}
                 => "<AdjacentlyTagged>\
@@ -577,7 +624,7 @@ mod without_root {
                         <string>answer</string>\
                     </Untagged>");
             err!(flatten_struct:
-                Untagged::Flatten {
+                UntaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }
@@ -772,7 +819,7 @@ mod without_root {
                             <string>answer</string>\n\
                         </Holder>");
                 serialize_as!(flatten_struct:
-                    ExternallyTagged::Flatten {
+                    ExternallyTaggedWorkaround::Flatten {
                         nested: Nested { float: 42.0 },
                         string: "answer",
                     }
@@ -798,22 +845,22 @@ mod without_root {
                     use super::*;
                     use pretty_assertions::assert_eq;
 
-                    #[derive(Serialize)]
+                    #[derive(Debug, PartialEq, Deserialize, Serialize)]
                     enum Unit {
                         #[serde(rename = "$text")]
                         Text,
                     }
-                    #[derive(Serialize)]
+                    #[derive(Debug, PartialEq, Deserialize, Serialize)]
                     enum Newtype<'a> {
                         #[serde(rename = "$text")]
                         Text(&'a str),
                     }
-                    #[derive(Serialize)]
+                    #[derive(Debug, PartialEq, Deserialize, Serialize)]
                     enum Tuple<'a> {
                         #[serde(rename = "$text")]
                         Text(f64, &'a str),
                     }
-                    #[derive(Serialize)]
+                    #[derive(Debug, PartialEq, Deserialize, Serialize)]
                     enum Struct<'a> {
                         #[serde(rename = "$text")]
                         Text { float: f64, string: &'a str },
@@ -877,7 +924,7 @@ mod without_root {
                 // serde serializes flatten structs as maps, and we do not support
                 // serialization of maps without root tag
                 err!(flatten_struct:
-                    InternallyTagged::Flatten {
+                    InternallyTaggedWorkaround::Flatten {
                         nested: Nested { float: 42.0 },
                         string: "answer",
                     }
@@ -949,17 +996,17 @@ mod without_root {
                             </content>\n\
                         </AdjacentlyTagged>");
                 serialize_as!(flatten_struct:
-                    AdjacentlyTagged::Flatten {
+                    AdjacentlyTaggedWorkaround::Flatten {
                         nested: Nested { float: 42.0 },
                         string: "answer",
                     }
-                    => "<AdjacentlyTagged>\n  \
+                    => "<AdjacentlyTaggedWorkaround>\n  \
                             <tag>Flatten</tag>\n  \
                             <content>\n    \
                                 <float>42</float>\n    \
                                 <string>answer</string>\n  \
                             </content>\n\
-                        </AdjacentlyTagged>");
+                        </AdjacentlyTaggedWorkaround>");
                 serialize_as!(empty_struct:
                     AdjacentlyTagged::Empty {}
                     => "<AdjacentlyTagged>\n  \
@@ -1012,7 +1059,7 @@ mod without_root {
                             <string>answer</string>\n\
                         </Untagged>");
                 err!(flatten_struct:
-                    Untagged::Flatten {
+                    UntaggedWorkaround::Flatten {
                         nested: Nested { float: 42.0 },
                         string: "answer",
                     }
@@ -1226,7 +1273,7 @@ mod with_root {
                         <string>answer</string>\
                     </Holder>");
             serialize_as!(flatten_struct:
-                ExternallyTagged::Flatten {
+                ExternallyTaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }
@@ -1252,22 +1299,22 @@ mod with_root {
                 use super::*;
                 use pretty_assertions::assert_eq;
 
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Unit {
                     #[serde(rename = "$text")]
                     Text,
                 }
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Newtype<'a> {
                     #[serde(rename = "$text")]
                     Text(&'a str),
                 }
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Tuple<'a> {
                     #[serde(rename = "$text")]
                     Text(f64, &'a str),
                 }
-                #[derive(Serialize)]
+                #[derive(Debug, PartialEq, Deserialize, Serialize)]
                 enum Struct<'a> {
                     #[serde(rename = "$text")]
                     Text { float: f64, string: &'a str },
@@ -1327,7 +1374,7 @@ mod with_root {
                         <string>answer</string>\
                     </root>");
             serialize_as!(flatten_struct:
-                InternallyTagged::Flatten {
+                InternallyTaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }
@@ -1403,7 +1450,7 @@ mod with_root {
                         </content>\
                     </root>");
             serialize_as!(flatten_struct:
-                AdjacentlyTagged::Flatten {
+                AdjacentlyTaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }
@@ -1470,7 +1517,7 @@ mod with_root {
                         <string>answer</string>\
                     </root>");
             serialize_as!(flatten_struct:
-                Untagged::Flatten {
+                UntaggedWorkaround::Flatten {
                     nested: Nested { float: 42.0 },
                     string: "answer",
                 }


### PR DESCRIPTION
This is follow-up PR for #541 in which I forgot to make a corresponding serialization for the deserialization. In order to not make this mistake again, the last 6 commits enables serialization-deserialization roundtrip in serialization tests -- we try to deserialize what was serialized and check that we get the same object.

During that I found that some roundrips does not work, mostly because of serde-rs/serde#1183. That tests does not check the roundtrip.

Some structs failed to derive `Deserialize` due to serde-rs/serde#2371. Although it is possible to implement it manually or use [my fork](https://github.com/Mingun/serde/tree/serde-next) where that error is fixed specially for that, the same tests suffers from the serde-rs/serde#1183 too, so I ended up with the current approach in order to reduce dependencies.