### PR TITLE
Document some internal macros and other small improvements

### DIFF
--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -123,7 +123,7 @@ impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'de, 'd> {
         ignored_any
     }
 
-    /// According to the <https://www.w3.org/TR/xmlschema-2/#boolean>,
+    /// According to the <https://www.w3.org/TR/xmlschema11-2/#boolean>,
     /// valid boolean representations are only `"true"`, `"false"`, `"1"`,
     /// and `"0"`. But this method also handles following:
     ///

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2121,7 +2121,7 @@ where
     T::deserialize(&mut de)
 }
 
-// TODO: According to the https://www.w3.org/TR/xmlschema-2/#boolean,
+// TODO: According to the https://www.w3.org/TR/xmlschema11-2/#boolean,
 // valid boolean representations are only "true", "false", "1", and "0"
 fn str2bool<'de, V>(value: &str, visitor: V) -> Result<V::Value, DeError>
 where

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -163,7 +163,7 @@ impl<'de, 'a> Deserializer<'de> for AtomicDeserializer<'de, 'a> {
         self.deserialize_str(visitor)
     }
 
-    /// According to the <https://www.w3.org/TR/xmlschema-2/#boolean>,
+    /// According to the <https://www.w3.org/TR/xmlschema11-2/#boolean>,
     /// valid boolean representations are only `"true"`, `"false"`, `"1"`,
     /// and `"0"`. But this method also handles following:
     ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -199,7 +199,7 @@ pub mod serialize {
         /// would occur if map key is a complex type that cannot be serialized as
         /// a primitive type (i.e. string, char, bool, unit struct or unit variant).
         ///
-        /// [XML name]: https://www.w3.org/TR/REC-xml/#sec-common-syn
+        /// [XML name]: https://www.w3.org/TR/xml11/#sec-common-syn
         Unsupported(Cow<'static, str>),
         /// Too many events were skipped while deserializing a sequence, event limit
         /// exceeded. The limit was provided as an argument

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,13 @@
 //! Especially for nested XML elements, the user must keep track _where_ (how deep)
 //! in the XML document the current event is located.
 //!
-//! quick-xml contains optional support of asynchronous reading using [tokio].
+//! quick-xml contains optional support of asynchronous reading and writing using [tokio].
+//! To get it enable the `async-tokio` feature.
 //!
 //! Furthermore, quick-xml also contains optional [Serde] support to directly
 //! serialize and deserialize from structs, without having to deal with the XML events.
+//! To get it enable the `serialize` feature. Read more about mapping Rust types
+//! to XML in the documentation of [`de`] module.
 //!
 //! # Examples
 //!
@@ -33,6 +36,7 @@
 //! [StAX]: https://en.wikipedia.org/wiki/StAX
 //! [tokio]: https://tokio.rs/
 //! [Serde]: https://serde.rs/
+//! [`de`]: ./de/index.html
 #![cfg_attr(
     feature = "document-features",
     cfg_attr(doc, doc = ::document_features::document_features!())

--- a/src/name.rs
+++ b/src/name.rs
@@ -209,7 +209,7 @@ impl<'a> AsRef<[u8]> for Prefix<'a> {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// A namespace prefix declaration, `xmlns` or `xmlns:<name>`, as defined in
-/// [XML Schema specification](https://www.w3.org/TR/xml-names/#ns-decl)
+/// [XML Schema specification](https://www.w3.org/TR/xml-names11/#ns-decl)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PrefixDeclaration<'a> {
     /// XML attribute binds a default namespace. Corresponds to `xmlns` in `xmlns="..."`
@@ -250,7 +250,7 @@ impl<'a> Namespace<'a> {
     /// This is because XML entity references are expanded during attribute value
     /// normalization.
     ///
-    /// [non-normalized]: https://www.w3.org/TR/REC-xml/#AVNormalize
+    /// [non-normalized]: https://www.w3.org/TR/xml11/#AVNormalize
     /// [IRI reference]: https://datatracker.ietf.org/doc/html/rfc3987
     #[inline(always)]
     pub fn into_inner(self) -> &'a [u8] {

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -168,9 +168,11 @@ macro_rules! impl_buffered_source {
                             self $(.$reader)? .consume(used);
                             read += used;
 
+                            // Position now just after the `>` symbol
                             *position += read;
                             break;
                         } else {
+                            // The `>` symbol not yet found, continue reading
                             buf.extend_from_slice(available);
 
                             let used = available.len();

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -204,13 +204,15 @@ impl Parser {
         }
     }
 
-    /// reads `BytesElement` starting with any character except `/`, `!` or ``?`
-    /// return `Start` or `Empty` event
+    /// Converts content of a tag to a `Start` or an `Empty` event
+    ///
+    /// # Parameters
+    /// - `buf`: Content of a tag between `<` and `>`
     pub fn read_start<'b>(&mut self, buf: &'b [u8]) -> Result<Event<'b>> {
-        // TODO: do this directly when reading bufreader ...
         let len = buf.len();
         let name_end = buf.iter().position(|&b| is_whitespace(b)).unwrap_or(len);
         if let Some(&b'/') = buf.last() {
+            // This is self-closed tag `<something/>`
             let end = if name_end < len { name_end } else { len - 1 };
             if self.expand_empty_elements {
                 self.state = ParseState::Empty;

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -310,6 +310,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         let mut state = ReadElementState::Elem;
 
         if let Some((bytes, i)) = state.change(self) {
+            // Position now just after the `>` symbol
             *position += i;
             *self = &self[i..];
             return Ok(Some(bytes));

--- a/src/se/key.rs
+++ b/src/se/key.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
 /// [not allowed] in XML names, because in some cases it should pass names
 /// that would be filtered on higher level.
 ///
-/// [not allowed]: https://www.w3.org/TR/REC-xml/#sec-common-syn
+/// [not allowed]: https://www.w3.org/TR/xml11/#sec-common-syn
 pub struct QNameSerializer<W: Write> {
     /// Writer to which this serializer writes content
     pub writer: W,

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -207,7 +207,7 @@ where
 /// );
 /// ```
 ///
-/// [XML name]: https://www.w3.org/TR/REC-xml/#NT-Name
+/// [XML name]: https://www.w3.org/TR/xml11/#NT-Name
 pub fn to_writer_with_root<W, T>(mut writer: W, root_tag: &str, value: &T) -> Result<(), DeError>
 where
     W: Write,
@@ -249,7 +249,7 @@ where
 /// );
 /// ```
 ///
-/// [XML name]: https://www.w3.org/TR/REC-xml/#NT-Name
+/// [XML name]: https://www.w3.org/TR/xml11/#NT-Name
 pub fn to_string_with_root<T>(root_tag: &str, value: &T) -> Result<String, DeError>
 where
     T: ?Sized + Serialize,
@@ -369,7 +369,7 @@ pub(self) struct XmlName<'n>(&'n str);
 impl<'n> XmlName<'n> {
     /// Checks correctness of the XML name according to [XML 1.1 specification]
     ///
-    /// [XML 1.1 specification]: https://www.w3.org/TR/REC-xml/#NT-Name
+    /// [XML 1.1 specification]: https://www.w3.org/TR/xml11/#NT-Name
     pub fn try_from(name: &'n str) -> Result<XmlName<'n>, DeError> {
         //TODO: Customization point: allow user to decide if he want to reject or encode the name
         match name.chars().next() {
@@ -514,7 +514,7 @@ impl<'w, 'r, W: Write> Serializer<'w, 'r, W> {
     /// );
     /// ```
     ///
-    /// [XML name]: https://www.w3.org/TR/REC-xml/#NT-Name
+    /// [XML name]: https://www.w3.org/TR/xml11/#NT-Name
     pub fn with_root(writer: &'w mut W, root_tag: Option<&'r str>) -> Result<Self, DeError> {
         Ok(Self {
             ser: ContentSerializer {


### PR DESCRIPTION
1. First, fixed all references to the XML standard to point to the version 1.1 of the standard.
2. Second, document internal macros that performs reading.
3. The last, add a quick reference to the deserializer module from the introduction page. I noticed, I often need it.