### PR TITLE
Makes ElementWriter.write_inner_content take FnOnce instead of Fn

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@
 
 ### Misc Changes
 
+- [#579]: `ElementWriter.write_inner_content` now uses a `FnOnce` instead of a more restrictive `Fn` closure
+
 
 ## 0.28.0 -- 2023-03-13
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -331,7 +331,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     /// Create a new scope for writing XML inside the current element.
     pub fn write_inner_content<F>(self, closure: F) -> Result<&'a mut Writer<W>>
     where
-        F: Fn(&mut Writer<W>) -> Result<()>,
+        F: FnOnce(&mut Writer<W>) -> Result<()>,
     {
         self.writer
             .write_event(Event::Start(self.start_tag.borrow()))?;


### PR DESCRIPTION
This closure is only evaluated once