### PR TITLE
Export EscapeError from the crate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,10 @@
 
 ### Misc Changes
 
+- [#584]: Export `EscapeError` from the crate
+
+[#584]: https://github.com/tafia/quick-xml/pull/584
+
 
 ## 0.28.1 -- 2023-03-19
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,7 @@ mod errors;
 mod escapei;
 pub mod escape {
     //! Manage xml character escapes
-    pub(crate) use crate::escapei::EscapeError;
-    pub use crate::escapei::{escape, partial_escape, unescape, unescape_with};
+    pub use crate::escapei::{escape, partial_escape, unescape, unescape_with, EscapeError};
 }
 pub mod events;
 pub mod name;


### PR DESCRIPTION
This is useful when manually calling `unscape`