### PR TITLE
Trim next element after DocType

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,9 +18,15 @@
 
 ### Bug Fixes
 
+- [#603]: Fix a regression from [#581] that an XML comment or a processing
+  instruction between a <!DOCTYPE> and the root element in the file brokes
+  deserialization of structs by returning `DeError::ExpectedStart`
+
 ### Misc Changes
 
+[#581]: https://github.com/tafia/quick-xml/pull/581
 [#601]: https://github.com/tafia/quick-xml/pull/601
+[#603]: https://github.com/tafia/quick-xml/pull/603
 [#606]: https://github.com/tafia/quick-xml/pull/606
 
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2880,7 +2880,7 @@ impl StartTrimmer {
     #[inline(always)]
     fn trim<'a>(&mut self, event: Event<'a>) -> Option<PayloadEvent<'a>> {
         let (event, trim_next_event) = match event {
-            Event::DocType(e) => (PayloadEvent::DocType(e), false),
+            Event::DocType(e) => (PayloadEvent::DocType(e), true),
             Event::Start(e) => (PayloadEvent::Start(e), true),
             Event::End(e) => (PayloadEvent::End(e), true),
             Event::Eof => (PayloadEvent::Eof, true),


### PR DESCRIPTION
Allow comment to exist between DocType and root element

With the new EntityResolver/Doctype changes, putting an xml comment between a doctype and the root element causes the parse to fail. Trimming the next element fixes this.