### PR TITLE
Add ability to set entity resolver when deserialize using borrowing reader

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 
 - [#609]: Added `Writer::write_serializable` to provide the capability to serialize
   arbitrary types using serde when using the lower-level `Writer` API.
+- [#615]: Added ability to set entity resolver when deserialize using borrowing reader.
 
 ### Bug Fixes
 
@@ -21,6 +22,7 @@
 
 
 [#609]: https://github.com/tafia/quick-xml/issues/609
+[#615]: https://github.com/tafia/quick-xml/pull/615
 
 
 ## 0.29.0 -- 2023-06-13

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,7 +21,7 @@
 ### Misc Changes
 
 
-[#609]: https://github.com/tafia/quick-xml/issues/609
+[#609]: https://github.com/tafia/quick-xml/pull/609
 [#615]: https://github.com/tafia/quick-xml/pull/615
 
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1813,14 +1813,6 @@ macro_rules! deserialize_primitives {
             str2bool(&text, visitor)
         }
 
-        /// Representation of owned strings the same as [non-owned](#method.deserialize_str).
-        fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DeError>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_str(visitor)
-        }
-
         /// Character represented as [strings](#method.deserialize_str).
         fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
@@ -1840,6 +1832,14 @@ macro_rules! deserialize_primitives {
             }
         }
 
+        /// Representation of owned strings the same as [non-owned](#method.deserialize_str).
+        fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DeError>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_str(visitor)
+        }
+
         /// Returns [`DeError::Unsupported`]
         fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DeError>
         where
@@ -1856,7 +1856,7 @@ macro_rules! deserialize_primitives {
             self.deserialize_bytes(visitor)
         }
 
-        /// Representation of the named units the same as [unnamed units](#method.deserialize_unit)
+        /// Representation of the named units the same as [unnamed units](#method.deserialize_unit).
         fn deserialize_unit_struct<V>(
             self,
             _name: &'static str,
@@ -1868,6 +1868,7 @@ macro_rules! deserialize_primitives {
             self.deserialize_unit(visitor)
         }
 
+        /// Representation of the newtypes the same as one-element [tuple](#method.deserialize_tuple).
         fn deserialize_newtype_struct<V>(
             self,
             _name: &'static str,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2652,7 +2652,7 @@ impl<'de> Deserializer<'de, SliceReader<'de>> {
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(source: &'de str) -> Self {
         let mut reader = Reader::from_str(source);
-        reader.expand_empty_elements(true).check_end_names(true);
+        reader.expand_empty_elements(true);
 
         Self::new(
             SliceReader {
@@ -2688,7 +2688,7 @@ where
     /// is known to represent UTF-8, you can decode it first before using [`from_str`].
     pub fn with_resolver(reader: R, entity_resolver: E) -> Self {
         let mut reader = Reader::from_reader(reader);
-        reader.expand_empty_elements(true).check_end_names(true);
+        reader.expand_empty_elements(true);
 
         Self::new(
             IoReader {
@@ -3588,10 +3588,7 @@ mod tests {
             start_trimmer: StartTrimmer::default(),
         };
 
-        reader
-            .reader
-            .expand_empty_elements(true)
-            .check_end_names(true);
+        reader.reader.expand_empty_elements(true);
 
         let mut events = Vec::new();
 


### PR DESCRIPTION
I noticed, that after #583 there is no way to create a deserializer that will borrow from string and provide ability to resolve custom entities. This PR fixes this gap.