### PR TITLE
Fails on empty comments without 4 -"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,9 +18,12 @@
 
 ### Bug Fixes
 
+- [#604]: Avoid crashing on wrong comments like `<!-->` when using `read_event_into*` functions.
+
 ### Misc Changes
 
 
+[#604]: https://github.com/tafia/quick-xml/issue/604
 [#609]: https://github.com/tafia/quick-xml/pull/609
 [#615]: https://github.com/tafia/quick-xml/pull/615
 

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -117,7 +117,9 @@ macro_rules! impl_buffered_source {
                     // somewhere sane rather than at the EOF
                     Ok(n) if n.is_empty() => return Err(bang_type.to_err()),
                     Ok(available) => {
-                        if let Some((consumed, used)) = bang_type.parse(buf, available) {
+                        // We only parse from start because we don't want to consider
+                        // whatever is in the buffer before the bang element
+                        if let Some((consumed, used)) = bang_type.parse(&buf[start..], available) {
                             buf.extend_from_slice(consumed);
 
                             self $(.$reader)? .consume(used);


### PR DESCRIPTION
The parser was crashing because of bad slice bounds

Closes #604