### PR TITLE
Add expand_empty_elements fn to Serializer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - [#609]: Added `Writer::write_serializable` to provide the capability to serialize
   arbitrary types using serde when using the lower-level `Writer` API.
 - [#615]: Added ability to set entity resolver when deserialize using borrowing reader.
+- [#620]: Added ability to enforce the expansion of empty elements.
 
 ### Bug Fixes
 
@@ -23,6 +24,7 @@
 
 [#609]: https://github.com/tafia/quick-xml/pull/609
 [#615]: https://github.com/tafia/quick-xml/pull/615
+[#620]: https://github.com/tafia/quick-xml/pull/620
 
 
 ## 0.29.0 -- 2023-06-13

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@
 - [#609]: Added `Writer::write_serializable` to provide the capability to serialize
   arbitrary types using serde when using the lower-level `Writer` API.
 - [#615]: Added ability to set entity resolver when deserialize using borrowing reader.
-- [#620]: Added ability to enforce the expansion of empty elements.
+- [#617]: Added ability to enforce the expansion of empty elements.
 
 ### Bug Fixes
 
@@ -24,7 +24,7 @@
 
 [#609]: https://github.com/tafia/quick-xml/pull/609
 [#615]: https://github.com/tafia/quick-xml/pull/615
-[#620]: https://github.com/tafia/quick-xml/pull/620
+[#617]: https://github.com/tafia/quick-xml/pull/617
 
 
 ## 0.29.0 -- 2023-06-13

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -96,9 +96,17 @@ impl<'w, 'i, W: Write> ContentSerializer<'w, 'i, W> {
     #[inline]
     pub(super) fn write_empty(mut self, name: XmlName) -> Result<(), DeError> {
         self.write_indent()?;
-        self.writer.write_char('<')?;
-        self.writer.write_str(name.0)?;
-        self.writer.write_str("/>")?;
+        if self.expand_empty_elements {
+            self.writer.write_char('<')?;
+            self.writer.write_str(name.0)?;
+            self.writer.write_str("></")?;
+            self.writer.write_str(name.0)?;
+            self.writer.write_char('>')?;
+        } else {
+            self.writer.write_str("<")?;
+            self.writer.write_str(name.0)?;
+            self.writer.write_str("/>")?;
+        }
         Ok(())
     }
 

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -56,6 +56,9 @@ pub struct ContentSerializer<'w, 'i, W: Write> {
     /// If `true`, then current indent will be written before writing the content,
     /// but only if content is not empty.
     pub write_indent: bool,
+    // If `true`, then empty elements will be serialized as `<element></element>`
+    // instead of `<element/>`.
+    pub expand_empty_elements: bool,
     //TODO: add settings to disallow consequent serialization of primitives
 }
 
@@ -85,6 +88,7 @@ impl<'w, 'i, W: Write> ContentSerializer<'w, 'i, W> {
             level: self.level,
             indent: self.indent.borrow(),
             write_indent: self.write_indent,
+            expand_empty_elements: false,
         }
     }
 
@@ -483,6 +487,7 @@ pub(super) mod tests {
                         level: QuoteLevel::Full,
                         indent: Indent::None,
                         write_indent: false,
+                        expand_empty_elements: false,
                     };
 
                     $data.serialize(ser).unwrap();
@@ -503,6 +508,7 @@ pub(super) mod tests {
                         level: QuoteLevel::Full,
                         indent: Indent::None,
                         write_indent: false,
+                        expand_empty_elements: false,
                     };
 
                     match $data.serialize(ser).unwrap_err() {
@@ -672,6 +678,7 @@ pub(super) mod tests {
                         level: QuoteLevel::Full,
                         indent: Indent::Owned(Indentation::new(b' ', 2)),
                         write_indent: false,
+                        expand_empty_elements: false,
                     };
 
                     $data.serialize(ser).unwrap();
@@ -692,6 +699,7 @@ pub(super) mod tests {
                         level: QuoteLevel::Full,
                         indent: Indent::Owned(Indentation::new(b' ', 2)),
                         write_indent: false,
+                        expand_empty_elements: false,
                     };
 
                     match $data.serialize(ser).unwrap_err() {

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -458,6 +458,7 @@ impl<'w, 'r, W: Write> Serializer<'w, 'r, W> {
                 level: QuoteLevel::Full,
                 indent: Indent::None,
                 write_indent: false,
+                expand_empty_elements: false,
             },
             root_tag: None,
         }
@@ -522,9 +523,16 @@ impl<'w, 'r, W: Write> Serializer<'w, 'r, W> {
                 level: QuoteLevel::Full,
                 indent: Indent::None,
                 write_indent: false,
+                expand_empty_elements: false,
             },
             root_tag: root_tag.map(|tag| XmlName::try_from(tag)).transpose()?,
         })
+    }
+
+    /// Enable or disable expansion of empty elements.
+    pub fn expand_empty_elements(&mut self, expand: bool) -> &mut Self {
+        self.ser.expand_empty_elements = expand;
+        self
     }
 
     /// Configure indent for a serializer

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -529,7 +529,34 @@ impl<'w, 'r, W: Write> Serializer<'w, 'r, W> {
         })
     }
 
-    /// Enable or disable expansion of empty elements.
+    /// Enable or disable expansion of empty elements. Defaults to `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pretty_assertions::assert_eq;
+    /// # use serde::Serialize;
+    /// # use quick_xml::se::Serializer;
+    ///
+    /// #[derive(Debug, PartialEq, Serialize)]
+    /// struct Struct {
+    ///     question: Option<String>,
+    /// }
+    ///
+    /// let mut buffer = String::new();
+    /// let mut ser = Serializer::new(&mut buffer);
+    /// ser.expand_empty_elements(true);
+    ///
+    /// let data = Struct {
+    ///   question: None,
+    /// };
+    ///
+    /// data.serialize(ser).unwrap();
+    /// assert_eq!(
+    ///     buffer,
+    ///     "<Struct><question></question></Struct>"
+    /// );
+    /// ```
     pub fn expand_empty_elements(&mut self, expand: bool) -> &mut Self {
         self.ser.expand_empty_elements = expand;
         self


### PR DESCRIPTION
Setting this to true will serialize empty elements to `<element></element>` instead of `<element/>`.

Fixes #617