### PR TITLE
Temporary restrict maximum supported version of serde to 1.0.180

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ include = ["src/*", "LICENSE-MIT.md", "README.md"]
 [dependencies]
 document-features = { version = "0.2", optional = true }
 encoding_rs = { version = "0.8", optional = true }
-serde = { version = "1.0.100", optional = true }
+# FIXME: remove upper bound when https://github.com/tafia/quick-xml/issues/630 is resolved
+serde = { version = ">=1.0.100,<1.0.181", optional = true }
 tokio = { version = "1.10", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.1"
 arbitrary = { version = "1.2.3", features = ["derive"], optional = true }


### PR DESCRIPTION
Until #630 is resolved this will allow us to run our tests on other PRs without failing