### PR TITLE
Add support for async element writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ path = "benches/macrobenches.rs"
 [features]
 default = []
 
-## Enables support for asynchronous reading from `tokio`'s IO-Traits by enabling
+## Enables support for asynchronous reading and writing from `tokio`'s IO-Traits by enabling
 ## [reading events] from types implementing [`tokio::io::AsyncBufRead`].
 ##
 ## [reading events]: crate::reader::Reader::read_event_into_async


### PR DESCRIPTION
This PR adds support for writing to buffers implementing tokio's `AsyncWrite`. It mirrors the `ElementWriter` implementation, nearly identically. The only difference is in `write_inner_content`, the closure needs to return the Writer, I couldn't make the lifetimes line up any other way.

It also includes a full test suite, again mirrored from `ElementWriter` and docs.