### PR TITLE
Use thiserror crate to make error definition more ergonomic.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = ">=1.0.100,<1.0.181", optional = true }
 tokio = { version = "1.10", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.1"
 arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
+thiserror = "1.0.47"
 
 [dev-dependencies]
 criterion = "0.4"


### PR DESCRIPTION
The thiserror crate takes care of a bunch of details of implementing errors for a library in rust. This will simplify the code around our errors by making it follow conventions that are widely used in the rust community. It also is much shorter in terms of lines of code.

Closes #638