### PR TITLE
Fix benchmarks in `compare` project

### DIFF
--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -17,7 +17,10 @@ xml-rs = "0.8"
 xml5ever = "0.17"
 xmlparser = "0.13"
 serde-xml-rs = "0.6"
-serde = { version = "1.0", features = [ "derive" ] }
+# Do not use "derive" feature, because it slowdown compilation
+# See https://github.com/serde-rs/serde/pull/2588
+serde = "1.0"
+serde_derive = "1.0"
 pretty_assertions = "1.4"
 
 [[bench]]

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -2,6 +2,7 @@
 name = "compare"
 version = "0.1.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
+publish = false
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -2,13 +2,13 @@
 name = "compare"
 version = "0.1.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-criterion = "0.3"
-maybe_xml = "0.2"
+criterion = "0.5"
+maybe_xml = "0.3"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
 rusty_xml = { version = "0.3", package = "RustyXML" }
@@ -16,9 +16,9 @@ xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"
 xmlparser = "0.13"
-serde-xml-rs = "0.5"
+serde-xml-rs = "0.6"
 serde = { version = "1.0", features = [ "derive" ] }
-pretty_assertions = "1.2"
+pretty_assertions = "1.4"
 
 [[bench]]
 name = "bench"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = { version = "0.5", features = ["html_reports"] }
 maybe_xml = "0.3"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -79,12 +79,12 @@ fn low_level_comparison(c: &mut Criterion) {
             BenchmarkId::new("maybe_xml", filename),
             *data,
             |b, input| {
-                use maybe_xml::eval::recv::RecvEvaluator;
+                use maybe_xml::eval::recv::Evaluator;
                 use maybe_xml::token::borrowed::Token;
 
                 b.iter(|| {
                     let mut input = input.as_bytes();
-                    let mut eval = RecvEvaluator::new();
+                    let mut eval = Evaluator::new();
 
                     let mut count = criterion::black_box(0);
                     loop {

--- a/compare/src/lib.rs
+++ b/compare/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,13 +3,13 @@ name = "quick-xml-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1.2.3", features = ["derive"] }
+arbitrary = { version = "1.3", features = ["derive"] }
 libfuzzer-sys = "0.4"
 
 [dependencies.quick-xml]


### PR DESCRIPTION
After #490 attributes should be names starting from `@`. The RSS document used in benchmarks have attributes that mapped to a struct, that was not updated for that, which is now fixed.

Also updated all dependencies of `compare` and `fuzz` projects and switch them to Rust 2021.