### PR TITLE
Fix `UnexpectedEof` when deserialize `xs:list`s and newtypes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,9 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
 
 ### Bug Fixes
 
+- [#660]: Fixed incorrect deserialization of `xs:list`s from empty tags (`<tag/>`
+  or `<tag></tag>`). Previously an `DeError::UnexpectedEof")` was returned in that case
+
 ### Misc Changes
 
 - [#643]: Bumped MSRV to 1.56. In practice the previous MSRV was incorrect in many cases.
@@ -37,6 +40,7 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
 [#643]: https://github.com/tafia/quick-xml/pull/643
 [#649]: https://github.com/tafia/quick-xml/pull/646
 [#651]: https://github.com/tafia/quick-xml/pull/651
+[#660]: https://github.com/tafia/quick-xml/pull/660
 
 
 ## 0.30.0 -- 2023-07-23

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
 
 - [#660]: Fixed incorrect deserialization of `xs:list`s from empty tags (`<tag/>`
   or `<tag></tag>`). Previously an `DeError::UnexpectedEof")` was returned in that case
+- [#580]: Fixed incorrect deserialization of vectors of newtypes from sequences of tags.
 
 ### Misc Changes
 
@@ -35,6 +36,7 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
   (and newly added `ElementWriter::write_inner_content_async` of course).
 
 [#545]: https://github.com/tafia/quick-xml/pull/545
+[#580]: https://github.com/tafia/quick-xml/issues/580
 [#619]: https://github.com/tafia/quick-xml/issues/619
 [#635]: https://github.com/tafia/quick-xml/pull/635
 [#643]: https://github.com/tafia/quick-xml/pull/643

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -497,7 +497,6 @@ where
     ));
 
     forward!(deserialize_any);
-    forward!(deserialize_ignored_any);
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
     where
@@ -766,7 +765,6 @@ where
     ));
 
     forward!(deserialize_any);
-    forward!(deserialize_ignored_any);
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
     where

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -550,6 +550,19 @@ where
         deserialize_option!(self.map.de, self, visitor)
     }
 
+    /// Forwards deserialization of the inner type. Always calls [`Visitor::visit_newtype_struct`]
+    /// with the same deserializer.
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     /// Deserializes each `<tag>` in
     /// ```xml
     /// <any-tag>
@@ -867,6 +880,20 @@ where
         V: Visitor<'de>,
     {
         deserialize_option!(self.map.de, self, visitor)
+    }
+
+    /// Forwards deserialization of the inner type. Always calls [`Visitor::visit_newtype_struct`]
+    /// with the [`SimpleTypeDeserializer`].
+    fn deserialize_newtype_struct<V>(
+        mut self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let text = self.read_string()?;
+        visitor.visit_newtype_struct(SimpleTypeDeserializer::from_text(text))
     }
 
     /// This method deserializes a sequence inside of element that itself is a

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -485,7 +485,6 @@ where
 
     forward!(deserialize_unit);
 
-    forward!(deserialize_map);
     forward!(deserialize_struct(
         name: &'static str,
         fields: &'static [&'static str]
@@ -753,7 +752,6 @@ where
 
     forward!(deserialize_unit);
 
-    forward!(deserialize_map);
     forward!(deserialize_struct(
         name: &'static str,
         fields: &'static [&'static str]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2870,10 +2870,8 @@ where
         V: Visitor<'de>,
     {
         match self.peek()? {
-            DeEvent::Start(_) => self.deserialize_map(visitor),
-            // Redirect to deserialize_unit in order to consume an event and return an appropriate error
-            DeEvent::End(_) | DeEvent::Eof => self.deserialize_unit(visitor),
-            _ => self.deserialize_string(visitor),
+            DeEvent::Text(_) => self.deserialize_str(visitor),
+            _ => self.deserialize_map(visitor),
         }
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1937,6 +1937,16 @@ macro_rules! deserialize_primitives {
             self.deserialize_tuple(len, visitor)
         }
 
+        /// Forwards deserialization to the [`deserialize_struct`](#method.deserialize_struct)
+        /// with empty name and fields.
+        #[inline]
+        fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DeError>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_struct("", &[], visitor)
+        }
+
         /// Identifiers represented as [strings](#method.deserialize_str).
         fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
@@ -2846,13 +2856,6 @@ where
         V: Visitor<'de>,
     {
         visitor.visit_seq(self)
-    }
-
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_struct("", &[], visitor)
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1904,18 +1904,6 @@ macro_rules! deserialize_primitives {
             self.deserialize_unit(visitor)
         }
 
-        /// Representation of the newtypes the same as one-element [tuple](#method.deserialize_tuple).
-        fn deserialize_newtype_struct<V>(
-            self,
-            _name: &'static str,
-            visitor: V,
-        ) -> Result<V::Value, DeError>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_tuple(1, visitor)
-        }
-
         /// Representation of tuples the same as [sequences](#method.deserialize_seq).
         fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
         where
@@ -2837,6 +2825,19 @@ where
             DeEvent::End(e) => Err(DeError::UnexpectedEnd(e.name().as_ref().to_owned())),
             DeEvent::Eof => Err(DeError::UnexpectedEof),
         }
+    }
+
+    /// Forwards deserialization of the inner type. Always calls [`Visitor::visit_newtype_struct`]
+    /// with the same deserializer.
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
     }
 
     fn deserialize_enum<V>(

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -495,12 +495,16 @@ pub struct SimpleTypeDeserializer<'de, 'a> {
 
 impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
     /// Creates a deserializer from a value, that possible borrowed from input
-    pub fn from_text_content(value: Text<'de>) -> Self {
-        let content = match value.text {
+    pub fn from_text(text: Cow<'de, str>) -> Self {
+        let content = match text {
             Cow::Borrowed(slice) => CowRef::Input(slice.as_bytes()),
             Cow::Owned(content) => CowRef::Owned(content.into_bytes()),
         };
         Self::new(content, false, Decoder::utf8())
+    }
+    /// Creates a deserializer from a value, that possible borrowed from input
+    pub fn from_text_content(value: Text<'de>) -> Self {
+        Self::from_text(value.text)
     }
 
     /// Creates a deserializer from a part of value at specified range

--- a/tests/serde-de-seq.rs
+++ b/tests/serde-de-seq.rs
@@ -802,6 +802,15 @@ mod fixed_name {
             use super::*;
             use pretty_assertions::assert_eq;
 
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct List {
+                /// Outer list mapped to elements, inner -- to `xs:list`.
+                ///
+                /// `#[serde(default)]` is not required, because correct
+                /// XML will always contains at least 1 element.
+                item: [Vec<String>; 1],
+            }
+
             /// Special case: zero elements
             #[test]
             fn zero() {
@@ -832,15 +841,6 @@ mod fixed_name {
             /// Special case: one element
             #[test]
             fn one() {
-                #[derive(Debug, Deserialize, PartialEq)]
-                struct List {
-                    /// Outer list mapped to elements, inner -- to `xs:list`.
-                    ///
-                    /// `#[serde(default)]` is not required, because correct
-                    /// XML will always contains at least 1 element.
-                    item: [Vec<String>; 1],
-                }
-
                 let data: List = from_str(
                     r#"
                     <root>
@@ -856,6 +856,21 @@ mod fixed_name {
                         item: [vec!["first".to_string(), "list".to_string()]]
                     }
                 );
+            }
+
+            /// Special case: empty `xs:list`
+            #[test]
+            fn empty() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(data, List { item: [vec![]] });
             }
 
             /// Special case: outer list is always mapped to an elements sequence,
@@ -1667,6 +1682,21 @@ mod fixed_name {
                         item: vec![vec!["first".to_string(), "list".to_string()]]
                     }
                 );
+            }
+
+            /// Special case: empty `xs:list`
+            #[test]
+            fn empty() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(data, List { item: vec![vec![]] });
             }
 
             /// Special case: outer list is always mapped to an elements sequence,
@@ -2866,6 +2896,16 @@ mod variable_name {
             use super::*;
             use pretty_assertions::assert_eq;
 
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct List {
+                /// Outer list mapped to elements, inner -- to `xs:list`.
+                ///
+                /// `#[serde(default)]` is not required, because correct
+                /// XML will always contains at least 1 element.
+                #[serde(rename = "$value")]
+                element: [Vec<String>; 1],
+            }
+
             /// Special case: zero elements
             #[test]
             fn zero() {
@@ -2897,16 +2937,6 @@ mod variable_name {
             /// Special case: one element
             #[test]
             fn one() {
-                #[derive(Debug, Deserialize, PartialEq)]
-                struct List {
-                    /// Outer list mapped to elements, inner -- to `xs:list`.
-                    ///
-                    /// `#[serde(default)]` is not required, because correct
-                    /// XML will always contains at least 1 element.
-                    #[serde(rename = "$value")]
-                    element: [Vec<String>; 1],
-                }
-
                 let data: List = from_str(
                     r#"
                     <root>
@@ -2922,6 +2952,21 @@ mod variable_name {
                         element: [vec!["first".to_string(), "list".to_string()]]
                     }
                 );
+            }
+
+            /// Special case: empty `xs:list`
+            #[test]
+            fn empty() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(data, List { element: [vec![]] });
             }
 
             /// Special case: outer list is always mapped to an elements sequence,
@@ -4004,6 +4049,26 @@ mod variable_name {
                     data,
                     List {
                         element: vec![vec!["first".to_string(), "list".to_string()]]
+                    }
+                );
+            }
+
+            /// Special case: empty `xs:list`
+            #[test]
+            fn empty() {
+                let data: List = from_str(
+                    r#"
+                    <root>
+                        <item/>
+                    </root>
+                    "#,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    data,
+                    List {
+                        element: vec![vec![]]
                     }
                 );
             }


### PR DESCRIPTION
The problem with #590 was in `SeqItemDeserializer::deserialize_newtype_struct`. Previously it was the same as `SeqItemDeserializer::deserialize_seq`, but deserializing sequences in this deserializer assumes, that those sequences are `xs:list`s, because deserializer itself represents a list element.

Also, I noticed, that `<tag></tag>` (or `<tag/>`) could return and error when try to deserialize `xs:list` from it. Funny, that due to incorrect implementation instead of `Unsupported("unsupported event End")` the `UnexpectedEof` was returned.

Fixes #580