### PR TITLE
Fix incorrect test for 580 and get rid of allocations in hot path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
 - [#649]: Make features linkable and reference them in the docs.
 - [#619]: Allow to raise application errors in `ElementWriter::write_inner_content`
   (and newly added `ElementWriter::write_inner_content_async` of course).
+- [#662]: Get rid of some allocations during serde deserialization.
 
 [#545]: https://github.com/tafia/quick-xml/pull/545
 [#580]: https://github.com/tafia/quick-xml/issues/580
@@ -47,6 +48,7 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
 [#651]: https://github.com/tafia/quick-xml/pull/651
 [#660]: https://github.com/tafia/quick-xml/pull/660
 [#661]: https://github.com/tafia/quick-xml/pull/661
+[#662]: https://github.com/tafia/quick-xml/pull/662
 
 
 ## 0.30.0 -- 2023-07-23

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -883,17 +883,16 @@ where
     }
 
     /// Forwards deserialization of the inner type. Always calls [`Visitor::visit_newtype_struct`]
-    /// with the [`SimpleTypeDeserializer`].
+    /// with this deserializer.
     fn deserialize_newtype_struct<V>(
-        mut self,
+        self,
         _name: &'static str,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let text = self.read_string()?;
-        visitor.visit_newtype_struct(SimpleTypeDeserializer::from_text(text))
+        visitor.visit_newtype_struct(self)
     }
 
     /// This method deserializes a sequence inside of element that itself is a

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -543,11 +543,14 @@ where
 
     forward!(deserialize_any);
 
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        deserialize_option!(self.map.de, self, visitor)
+        match self.map.de.peek()? {
+            DeEvent::Text(t) if t.is_empty() => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
     }
 
     /// Forwards deserialization of the inner type. Always calls [`Visitor::visit_newtype_struct`]
@@ -870,11 +873,14 @@ where
 
     forward!(deserialize_any);
 
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        deserialize_option!(self.map.de, self, visitor)
+        match self.map.de.peek()? {
+            DeEvent::Text(t) if t.is_empty() => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
     }
 
     /// Forwards deserialization of the inner type. Always calls [`Visitor::visit_newtype_struct`]

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -597,11 +597,6 @@ where
             filter,
         })
     }
-
-    #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.map.de.is_human_readable()
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -913,11 +908,6 @@ where
     {
         let text = self.read_string()?;
         SimpleTypeDeserializer::from_text(text).deserialize_seq(visitor)
-    }
-
-    #[inline]
-    fn is_human_readable(&self) -> bool {
-        self.map.de.is_human_readable()
     }
 }
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -289,9 +289,14 @@ where
                     seed.deserialize(de).map(Some)
                 }
                 // Stop iteration after reaching a closing tag
-                DeEvent::End(e) if e.name() == self.start.name() => Ok(None),
-                // This is a unmatched closing tag, so the XML is invalid
-                DeEvent::End(e) => Err(DeError::UnexpectedEnd(e.name().as_ref().to_owned())),
+                // The matching tag name is guaranteed by the reader if our
+                // deserializer implementation is correct
+                DeEvent::End(e) => {
+                    debug_assert_eq!(self.start.name(), e.name());
+                    // Consume End
+                    self.de.next()?;
+                    Ok(None)
+                }
                 // We cannot get `Eof` legally, because we always inside of the
                 // opened tag `self.start`
                 DeEvent::Eof => Err(DeError::UnexpectedEof),

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -164,16 +164,16 @@ enum ValueSource {
 ///   internal buffer of deserializer (i.e. deserializer itself) or an input
 ///   (in that case it is possible to approach zero-copy deserialization).
 ///
-/// - `'a` lifetime represents a parent deserializer, which could own the data
+/// - `'d` lifetime represents a parent deserializer, which could own the data
 ///   buffer.
-pub(crate) struct ElementMapAccess<'de, 'a, R, E>
+pub(crate) struct ElementMapAccess<'de, 'd, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
 {
     /// Tag -- owner of attributes
     start: BytesStart<'de>,
-    de: &'a mut Deserializer<'de, R, E>,
+    de: &'d mut Deserializer<'de, R, E>,
     /// State of the iterator over attributes. Contains the next position in the
     /// inner `start` slice, from which next attribute should be parsed.
     iter: IterState,
@@ -192,14 +192,14 @@ where
     has_value_field: bool,
 }
 
-impl<'de, 'a, R, E> ElementMapAccess<'de, 'a, R, E>
+impl<'de, 'd, R, E> ElementMapAccess<'de, 'd, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
 {
     /// Create a new ElementMapAccess
     pub fn new(
-        de: &'a mut Deserializer<'de, R, E>,
+        de: &'d mut Deserializer<'de, R, E>,
         start: BytesStart<'de>,
         fields: &'static [&'static str],
     ) -> Result<Self, DeError> {
@@ -214,7 +214,7 @@ where
     }
 }
 
-impl<'de, 'a, R, E> MapAccess<'de> for ElementMapAccess<'de, 'a, R, E>
+impl<'de, 'd, R, E> MapAccess<'de> for ElementMapAccess<'de, 'd, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
@@ -419,14 +419,14 @@ macro_rules! forward {
 ///
 /// [`deserialize_tuple`]: #method.deserialize_tuple
 /// [`deserialize_struct`]: #method.deserialize_struct
-struct MapValueDeserializer<'de, 'a, 'm, R, E>
+struct MapValueDeserializer<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
 {
     /// Access to the map that created this deserializer. Gives access to the
     /// context, such as list of fields, that current map known about.
-    map: &'m mut ElementMapAccess<'de, 'a, R, E>,
+    map: &'m mut ElementMapAccess<'de, 'd, R, E>,
     /// Determines, should [`Deserializer::read_string_impl()`] expand the second
     /// level of tags or not.
     ///
@@ -504,7 +504,7 @@ where
     allow_start: bool,
 }
 
-impl<'de, 'a, 'm, R, E> MapValueDeserializer<'de, 'a, 'm, R, E>
+impl<'de, 'd, 'm, R, E> MapValueDeserializer<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
@@ -520,7 +520,7 @@ where
     }
 }
 
-impl<'de, 'a, 'm, R, E> de::Deserializer<'de> for MapValueDeserializer<'de, 'a, 'm, R, E>
+impl<'de, 'd, 'm, R, E> de::Deserializer<'de> for MapValueDeserializer<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
@@ -691,14 +691,14 @@ impl<'de> TagFilter<'de> {
 ///
 /// [`Text`]: crate::events::Event::Text
 /// [`CData`]: crate::events::Event::CData
-struct MapValueSeqAccess<'de, 'a, 'm, R, E>
+struct MapValueSeqAccess<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
 {
     /// Accessor to a map that creates this accessor and to a deserializer for
     /// a sequence items.
-    map: &'m mut ElementMapAccess<'de, 'a, R, E>,
+    map: &'m mut ElementMapAccess<'de, 'd, R, E>,
     /// Filter that determines whether a tag is a part of this sequence.
     ///
     /// When feature [`overlapped-lists`] is not activated, iteration will stop
@@ -718,7 +718,7 @@ where
 }
 
 #[cfg(feature = "overlapped-lists")]
-impl<'de, 'a, 'm, R, E> Drop for MapValueSeqAccess<'de, 'a, 'm, R, E>
+impl<'de, 'd, 'm, R, E> Drop for MapValueSeqAccess<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
@@ -728,7 +728,7 @@ where
     }
 }
 
-impl<'de, 'a, 'm, R, E> SeqAccess<'de> for MapValueSeqAccess<'de, 'a, 'm, R, E>
+impl<'de, 'd, 'm, R, E> SeqAccess<'de> for MapValueSeqAccess<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
@@ -824,17 +824,17 @@ where
 ///
 /// [`deserialize_tuple`]: #method.deserialize_tuple
 /// [`deserialize_struct`]: #method.deserialize_struct
-struct SeqItemDeserializer<'de, 'a, 'm, R, E>
+struct SeqItemDeserializer<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
 {
     /// Access to the map that created this deserializer. Gives access to the
     /// context, such as list of fields, that current map known about.
-    map: &'m mut ElementMapAccess<'de, 'a, R, E>,
+    map: &'m mut ElementMapAccess<'de, 'd, R, E>,
 }
 
-impl<'de, 'a, 'm, R, E> SeqItemDeserializer<'de, 'a, 'm, R, E>
+impl<'de, 'd, 'm, R, E> SeqItemDeserializer<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,
@@ -850,7 +850,7 @@ where
     }
 }
 
-impl<'de, 'a, 'm, R, E> de::Deserializer<'de> for SeqItemDeserializer<'de, 'a, 'm, R, E>
+impl<'de, 'd, 'm, R, E> de::Deserializer<'de> for SeqItemDeserializer<'de, 'd, 'm, R, E>
 where
     R: XmlRead<'de>,
     E: EntityResolver,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2216,8 +2216,8 @@ impl<'i, R: XmlRead<'i>, E: EntityResolver> XmlReader<'i, R, E> {
                 let result1 = self.reader.read_to_end(name);
                 let result2 = self.reader.read_to_end(name);
 
-                // In case of error `next` returns `Eof`
-                self.lookahead = self.reader.next();
+                // In case of error `next_impl` returns `Eof`
+                let _ = self.next_impl();
                 result1?;
                 result2?;
             }
@@ -2225,13 +2225,13 @@ impl<'i, R: XmlRead<'i>, E: EntityResolver> XmlReader<'i, R, E> {
             // Because this is end event, we already consume the whole tree, so
             // nothing to do, just update lookahead
             Ok(PayloadEvent::End(ref e)) if e.name() == name => {
-                self.lookahead = self.reader.next();
+                let _ = self.next_impl();
             }
             Ok(_) => {
                 let result = self.reader.read_to_end(name);
 
-                // In case of error `next` returns `Eof`
-                self.lookahead = self.reader.next();
+                // In case of error `next_impl` returns `Eof`
+                let _ = self.next_impl();
                 result?;
             }
             // Read next lookahead event, unpack error from the current lookahead

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1954,16 +1954,6 @@ macro_rules! deserialize_primitives {
     };
 }
 
-macro_rules! deserialize_option {
-    ($de:expr, $deserializer:ident, $visitor:ident) => {
-        match $de.peek()? {
-            DeEvent::Text(t) if t.is_empty() => $visitor.visit_none(),
-            DeEvent::Eof => $visitor.visit_none(),
-            _ => $visitor.visit_some($deserializer),
-        }
-    };
-}
-
 mod key;
 mod map;
 mod resolver;
@@ -2875,7 +2865,11 @@ where
     where
         V: Visitor<'de>,
     {
-        deserialize_option!(self, self, visitor)
+        match self.peek()? {
+            DeEvent::Text(t) if t.is_empty() => visitor.visit_none(),
+            DeEvent::Eof => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
     }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2785,13 +2785,7 @@ where
         V: Visitor<'de>,
     {
         match self.next()? {
-            DeEvent::Start(e) => {
-                let name = e.name().as_ref().to_vec();
-                let map = ElementMapAccess::new(self, e, fields)?;
-                let value = visitor.visit_map(map)?;
-                self.read_to_end(QName(&name))?;
-                Ok(value)
-            }
+            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self, e, fields)?),
             DeEvent::End(e) => Err(DeError::UnexpectedEnd(e.name().as_ref().to_owned())),
             DeEvent::Text(_) => Err(DeError::ExpectedStart),
             DeEvent::Eof => Err(DeError::UnexpectedEof),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1964,6 +1964,7 @@ pub use crate::errors::serialize::DeError;
 pub use resolver::{EntityResolver, NoEntityResolver};
 
 use crate::{
+    de::map::ElementMapAccess,
     encoding::Decoder,
     errors::Error,
     events::{BytesCData, BytesEnd, BytesStart, BytesText, Event},
@@ -2786,7 +2787,7 @@ where
         match self.next()? {
             DeEvent::Start(e) => {
                 let name = e.name().as_ref().to_vec();
-                let map = map::MapAccess::new(self, e, fields)?;
+                let map = ElementMapAccess::new(self, e, fields)?;
                 let value = visitor.visit_map(map)?;
                 self.read_to_end(QName(&name))?;
                 Ok(value)

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -17,10 +17,7 @@ where
 
     // If type was deserialized, the whole XML document should be consumed
     if let Ok(_) = result {
-        match <()>::deserialize(&mut de) {
-            Err(DeError::UnexpectedEof) => (),
-            e => panic!("Expected end `UnexpectedEof`, but got {:?}", e),
-        }
+        assert!(de.is_empty(), "the whole XML document should be consumed");
     }
 
     result

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -5,7 +5,8 @@
 use pretty_assertions::assert_eq;
 use quick_xml::de::from_str;
 use quick_xml::se::{to_string, to_string_with_root};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::de::{Deserializer, IgnoredAny};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Regression tests for https://github.com/tafia/quick-xml/issues/252.
@@ -393,10 +394,13 @@ fn issue580() {
     #[derive(Debug, PartialEq, Eq)]
     struct Item;
     impl Item {
-        fn parse<'de, D>(_deserializer: D) -> Result<Self, D::Error>
+        fn parse<'de, D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
+            // We should consume something from the deserializer, otherwise this
+            // leads to infinity loop
+            IgnoredAny::deserialize(deserializer)?;
             Ok(Item)
         }
     }


### PR DESCRIPTION
The first commit fixes the mistake I made when fixing #580, that becomes obvious after some refactoring that coming soon for #567.

Deserialization should consume something from deserializer, otherwise an infinity cycle is possible. That is the reason why fixed `SeqItemDeserializer::deserialize_newtype_struct` taken `SimpleTypeDeserializer` instead of `self`. But when I realized that the problem in the test itself, it become obvious that it should take `self`, as it does in `deserialize_option`, for example.

Next commits fixes some pinholes and removes allocation on a hot path. It is expected that XML can have many elements and allocating an array just to read one `End` event after deserializing it is an overkill.