### PR TITLE
Use memchr to search for characters to escape

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,6 +36,7 @@ pub fn write_byte_string(f: &mut Formatter, byte_string: &[u8]) -> fmt::Result {
     Ok(())
 }
 
+/// An iterator that merges two sorted iterators into one sorted iterator
 pub(crate) struct MergeIter<It1, It2>
 where
     It1: Iterator,
@@ -283,5 +284,37 @@ mod tests {
             67, 108, 97, 115, 115, 32, 73, 82, 73, 61, 34, 35, 66, 34,
         ]);
         assert_eq!(format!("{:?}", bytes), r##""Class IRI=\"#B\"""##);
+    }
+
+    #[test]
+    fn merge_empty() {
+        let iter = MergeIter::new(vec![].into_iter(), vec![].into_iter());
+        assert_eq!(iter.collect::<Vec<usize>>(), vec![]);
+    }
+
+    #[test]
+    fn merge_single_empty() {
+        let iter = MergeIter::new(vec![1].into_iter(), vec![].into_iter());
+        assert_eq!(iter.collect::<Vec<usize>>(), vec![1]);
+        let iter = MergeIter::new(vec![].into_iter(), vec![1].into_iter());
+        assert_eq!(iter.collect::<Vec<usize>>(), vec![1]);
+    }
+
+    #[test]
+    fn merge_whole_side_before() {
+        let iter = MergeIter::new(vec![1, 2, 3].into_iter(), vec![4, 5, 6].into_iter());
+        assert_eq!(iter.collect::<Vec<usize>>(), vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn merge_interleave() {
+        let iter = MergeIter::new(
+            vec![1, 2, 8, 20].into_iter(),
+            vec![3, 4, 22, 23].into_iter(),
+        );
+        assert_eq!(
+            iter.collect::<Vec<usize>>(),
+            vec![1, 2, 3, 4, 8, 20, 22, 23]
+        );
     }
 }


### PR DESCRIPTION
Use memchr iterators to search for characters to escape.

In some (most) cases, we need to combine multiple memchr searches (since memchr allows searching for up to 3 chars at the same time), so introduce a `MergeIter` type, which takes two iterators, and combines them in order.

This appears to be better for performance in almost all cases, ~~except it's very slightly slower for escaping small strings with escapes present~~ thanks to dcb2104, it's actually faster even in that case. However, it's _MUCH_ faster when there are no characters to escape, or when escaping a long string.

Only results shown with >1% change, reported by `critcmp`

<details>
<summary>Results for M1 Pro Macbook</summary>

```
One event/Comment
-----------------
after      1.00      61.3±0.63ns       ? ?/sec
before     1.02      62.2±1.13ns       ? ?/sec

attributes/with_checks = false
------------------------------
after      1.00      32.3±0.42µs       ? ?/sec
before     1.02      32.9±0.35µs       ? ?/sec

decode_and_parse_document/linescore.xml
---------------------------------------
after      1.00      10.1±0.15µs  350.9 MB/sec
before     1.02      10.2±0.09µs  345.4 MB/sec

decode_and_parse_document/players.xml
-------------------------------------
after      1.00      62.4±0.37µs  232.4 MB/sec
before     1.02      63.4±0.44µs  228.5 MB/sec

decode_and_parse_document/rpm_primary.xml
-----------------------------------------
after      1.00      60.6±0.40µs  334.7 MB/sec
before     1.01      61.3±0.58µs  330.4 MB/sec

decode_and_parse_document/sample_ns.xml
---------------------------------------
after      1.00       2.4±0.02µs  298.7 MB/sec
before     1.01       2.5±0.02µs  294.6 MB/sec

decode_and_parse_document/sample_rss.xml
----------------------------------------
after      1.00     244.4±1.83µs  771.8 MB/sec
before     1.01     247.0±1.83µs  763.4 MB/sec

decode_and_parse_document_with_namespaces/document.xml
------------------------------------------------------
after      1.00      64.0±0.68µs  171.8 MB/sec
before     1.01      64.8±0.62µs  169.5 MB/sec

decode_and_parse_document_with_namespaces/libreoffice_document.fodt
-------------------------------------------------------------------
after      1.00     232.2±3.44µs  235.1 MB/sec
before     1.01     235.3±4.81µs  232.1 MB/sec

decode_and_parse_document_with_namespaces/linescore.xml
-------------------------------------------------------
after      1.00      12.8±0.09µs  276.0 MB/sec
before     1.02      13.0±0.27µs  271.9 MB/sec

decode_and_parse_document_with_namespaces/players.xml
-----------------------------------------------------
after      1.00      78.1±0.49µs  185.5 MB/sec
before     1.01      79.2±0.83µs  183.0 MB/sec

decode_and_parse_document_with_namespaces/rpm_filelists.xml
-----------------------------------------------------------
after      1.00      39.7±0.33µs  277.0 MB/sec
before     1.02      40.5±0.42µs  271.4 MB/sec

decode_and_parse_document_with_namespaces/rpm_other.xml
-------------------------------------------------------
after      1.00      63.5±0.69µs  348.7 MB/sec
before     1.02      64.7±1.13µs  342.1 MB/sec

decode_and_parse_document_with_namespaces/rpm_primary.xml
---------------------------------------------------------
after      1.00      90.4±1.10µs  224.1 MB/sec
before     1.02      92.1±1.28µs  220.1 MB/sec

decode_and_parse_document_with_namespaces/rpm_primary2.xml
----------------------------------------------------------
after      1.00      29.3±0.31µs  244.6 MB/sec
before     1.03      30.1±0.22µs  237.9 MB/sec

decode_and_parse_document_with_namespaces/sample_1.xml
------------------------------------------------------
after      1.00       4.7±0.05µs  232.6 MB/sec
before     1.01       4.8±0.04µs  230.1 MB/sec

decode_and_parse_document_with_namespaces/sample_ns.xml
-------------------------------------------------------
after      1.00       3.9±0.03µs  187.5 MB/sec
before     1.01       3.9±0.02µs  184.9 MB/sec

decode_and_parse_document_with_namespaces/sample_rss.xml
--------------------------------------------------------
after      1.00     374.5±3.32µs  503.6 MB/sec
before     1.02     380.4±3.39µs  495.8 MB/sec

escape_text/escaped_chars_long
------------------------------
after      1.00     271.8±4.24ns       ? ?/sec
before     3.54     962.1±7.71ns       ? ?/sec

escape_text/escaped_chars_short
-------------------------------
before     1.00     223.3±3.96ns       ? ?/sec
after      1.10     246.5±1.40ns       ? ?/sec

escape_text/no_chars_to_escape_long
-----------------------------------
after      1.00      71.1±3.15ns       ? ?/sec
before    10.58     752.6±6.29ns       ? ?/sec

escape_text/no_chars_to_escape_short
------------------------------------
after      1.00       7.9±0.11ns       ? ?/sec
before     1.24       9.8±0.08ns       ? ?/sec

parse_document_nocopy/document.xml
----------------------------------
after      1.00      40.9±0.29µs  268.4 MB/sec
before     1.01      41.4±0.75µs  265.2 MB/sec

parse_document_nocopy/linescore.xml
-----------------------------------
after      1.00      10.1±0.09µs  350.2 MB/sec
before     1.01      10.2±0.14µs  346.0 MB/sec

parse_document_nocopy/rpm_other.xml
-----------------------------------
after      1.00      48.4±0.31µs  457.5 MB/sec
before     1.02      49.5±1.26µs  447.7 MB/sec

parse_document_nocopy/sample_rss.xml
------------------------------------
after      1.00     260.5±1.47µs  724.0 MB/sec
before     1.01     264.1±2.39µs  714.2 MB/sec

parse_document_nocopy_with_namespaces/document.xml
--------------------------------------------------
after      1.00      64.1±0.39µs  171.4 MB/sec
before     1.02      65.4±0.68µs  168.0 MB/sec

parse_document_nocopy_with_namespaces/libreoffice_document.fodt
---------------------------------------------------------------
after      1.00     241.4±2.64µs  226.2 MB/sec
before     1.01     244.5±2.95µs  223.3 MB/sec

parse_document_nocopy_with_namespaces/linescore.xml
---------------------------------------------------
after      1.00      12.7±0.11µs  278.7 MB/sec
before     1.02      12.9±0.14µs  273.3 MB/sec

parse_document_nocopy_with_namespaces/players.xml
-------------------------------------------------
after      1.00      78.5±0.55µs  184.6 MB/sec
before     1.01      79.5±0.60µs  182.4 MB/sec

parse_document_nocopy_with_namespaces/rpm_filelists.xml
-------------------------------------------------------
after      1.00      42.5±0.42µs  258.4 MB/sec
before     1.01      43.1±0.39µs  254.8 MB/sec

parse_document_nocopy_with_namespaces/rpm_other.xml
---------------------------------------------------
after      1.00      65.9±0.42µs  335.9 MB/sec
before     1.01      66.6±0.48µs  332.2 MB/sec

parse_document_nocopy_with_namespaces/rpm_primary2.xml
------------------------------------------------------
after      1.00      29.8±0.31µs  240.8 MB/sec
before     1.01      30.2±0.27µs  237.4 MB/sec

parse_document_nocopy_with_namespaces/sample_1.xml
--------------------------------------------------
after      1.00       4.6±0.05µs  241.0 MB/sec
before     1.02       4.7±0.07µs  235.9 MB/sec

parse_document_nocopy_with_namespaces/sample_ns.xml
---------------------------------------------------
after      1.00       3.7±0.03µs  193.3 MB/sec
before     1.01       3.8±0.04µs  191.2 MB/sec

parse_document_nocopy_with_namespaces/sample_rss.xml
----------------------------------------------------
after      1.00     397.2±2.82µs  474.8 MB/sec
before     1.02     404.5±5.94µs  466.3 MB/sec

parse_document_nocopy_with_namespaces/test_writer_ident.xml
-----------------------------------------------------------
after      1.00      13.7±0.10µs  309.8 MB/sec
before     1.02      14.0±0.12µs  303.0 MB/sec

read_event/trim_text = false
----------------------------
before     1.00      93.1±0.64µs       ? ?/sec
after      1.01      94.3±0.90µs       ? ?/sec

read_event/trim_text = true
---------------------------
before     1.00      94.7±0.80µs       ? ?/sec
after      1.02      96.9±1.12µs       ? ?/sec

unescape_text/char_reference
----------------------------
after      1.00     105.8±0.75ns       ? ?/sec
before     1.03     108.6±0.80ns       ? ?/sec

unescape_text/entity_reference
------------------------------
after      1.00     114.8±2.80ns       ? ?/sec
before     1.02     116.9±1.70ns       ? ?/sec

unescape_text/mixed
-------------------
after      1.00     127.3±0.79ns       ? ?/sec
before     1.01     128.8±1.15ns       ? ?/sec

unescape_text/no_chars_to_unescape_long
---------------------------------------
after      1.00      34.3±0.77ns       ? ?/sec
before     1.02      35.1±0.41ns       ? ?/sec

unescape_text/no_chars_to_unescape_short
----------------------------------------
after      1.00       4.4±0.03ns       ? ?/sec
before     1.03       4.5±0.03ns       ? ?/sec
```
</details>

<details>
<summary>Results for x64 i5-6600K Windows</summary>

```
NsReader::read_resolved_event_into/trim_text = true
---------------------------------------------------
after      1.00  1042.6±125.28µs       ? ?/sec
before     1.41  1469.3±354.43µs       ? ?/sec

One event/CData
---------------
after      1.00     94.5±66.69ns       ? ?/sec
before     2.16    204.0±22.39ns       ? ?/sec

One event/Comment
-----------------
after      1.00     129.3±5.60ns       ? ?/sec
before     3.63    468.9±29.17ns       ? ?/sec

One event/Start
---------------
after      1.00    335.9±20.11ns       ? ?/sec
before     2.31   776.9±106.31ns       ? ?/sec

attributes/try_get_attribute
----------------------------
before     1.00    376.1±51.69µs       ? ?/sec
after      1.05    395.3±48.46µs       ? ?/sec

attributes/with_checks = false
------------------------------
before     1.00    198.9±40.57µs       ? ?/sec
after      1.10    219.5±28.25µs       ? ?/sec

attributes/with_checks = true
-----------------------------
after      1.00    232.6±63.64µs       ? ?/sec
before     1.55    359.7±51.88µs       ? ?/sec

decode_and_parse_document/document.xml
--------------------------------------
after      1.00    357.3±43.03µs   30.8 MB/sec
before     1.10    393.0±46.29µs   28.0 MB/sec

decode_and_parse_document/libreoffice_document.fodt
---------------------------------------------------
after      1.00   625.6±461.14µs   87.3 MB/sec
before     2.16  1348.4±186.66µs   40.5 MB/sec

decode_and_parse_document/linescore.xml
---------------------------------------
after      1.00     77.3±16.13µs   45.7 MB/sec
before     1.31    100.9±10.21µs   35.0 MB/sec

decode_and_parse_document/players.xml
-------------------------------------
after      1.00   489.7±113.93µs   29.6 MB/sec
before     1.22    598.4±74.78µs   24.2 MB/sec

decode_and_parse_document/rpm_filelists.xml
-------------------------------------------
after      1.00      55.9±1.42µs  196.6 MB/sec
before     4.97    277.5±26.25µs   39.6 MB/sec

decode_and_parse_document/rpm_other.xml
---------------------------------------
after      1.00      90.8±2.71µs  243.8 MB/sec
before     5.10    463.0±44.96µs   47.8 MB/sec

decode_and_parse_document/rpm_primary.xml
-----------------------------------------
after      1.00     130.3±9.67µs  155.5 MB/sec
before     4.64    605.1±92.95µs   33.5 MB/sec

decode_and_parse_document/rpm_primary2.xml
------------------------------------------
after      1.00      41.7±0.97µs  171.9 MB/sec
before     5.41    225.8±21.91µs   31.8 MB/sec

decode_and_parse_document/sample_1.xml
--------------------------------------
after      1.00      29.3±4.07µs   37.5 MB/sec
before     1.41      41.3±2.50µs   26.6 MB/sec

decode_and_parse_document/sample_ns.xml
---------------------------------------
after      1.00      21.9±5.67µs   33.0 MB/sec
before     1.43      31.4±2.94µs   23.0 MB/sec

decode_and_parse_document/sample_rss.xml
----------------------------------------
after      1.00  1946.7±378.24µs   96.9 MB/sec
before     1.20       2.3±0.35ms   80.6 MB/sec

decode_and_parse_document/test_writer_ident.xml
-----------------------------------------------
after      1.00     88.9±14.65µs   47.7 MB/sec
before     1.06     94.4±12.79µs   44.9 MB/sec

decode_and_parse_document_with_namespaces/document.xml
------------------------------------------------------
before     1.00    619.9±35.60µs   17.7 MB/sec
after      1.24   769.0±185.44µs   14.3 MB/sec

decode_and_parse_document_with_namespaces/libreoffice_document.fodt
-------------------------------------------------------------------
before     1.00       2.2±0.13ms   24.7 MB/sec
after      1.08       2.4±0.62ms   22.8 MB/sec

decode_and_parse_document_with_namespaces/linescore.xml
-------------------------------------------------------
after      1.00     95.6±29.48µs   36.9 MB/sec
before     1.38    132.4±15.72µs   26.7 MB/sec

decode_and_parse_document_with_namespaces/players.xml
-----------------------------------------------------
after      1.00    568.8±94.68µs   25.5 MB/sec
before     1.33    758.9±94.28µs   19.1 MB/sec

decode_and_parse_document_with_namespaces/rpm_other.xml
-------------------------------------------------------
after      1.00   444.7±137.30µs   49.8 MB/sec
before     1.20   532.8±104.49µs   41.5 MB/sec

decode_and_parse_document_with_namespaces/rpm_primary.xml
---------------------------------------------------------
after      1.00   785.6±170.18µs   25.8 MB/sec
before     1.10   864.3±108.22µs   23.4 MB/sec

decode_and_parse_document_with_namespaces/rpm_primary2.xml
----------------------------------------------------------
after      1.00    128.7±52.72µs   55.7 MB/sec
before     2.24    288.2±38.70µs   24.9 MB/sec

decode_and_parse_document_with_namespaces/sample_1.xml
------------------------------------------------------
after      1.00      35.1±7.37µs   31.3 MB/sec
before     1.19      41.7±9.23µs   26.3 MB/sec

decode_and_parse_document_with_namespaces/sample_ns.xml
-------------------------------------------------------
before     1.00      43.0±5.07µs   16.8 MB/sec
after      1.11     47.7±10.96µs   15.1 MB/sec

decode_and_parse_document_with_namespaces/sample_rss.xml
--------------------------------------------------------
after      1.00       2.9±0.54ms   64.2 MB/sec
before     1.03       3.0±0.57ms   62.5 MB/sec

decode_and_parse_document_with_namespaces/test_writer_ident.xml
---------------------------------------------------------------
after      1.00     50.9±26.75µs   83.4 MB/sec
before     2.88    146.6±12.70µs   28.9 MB/sec

escape_text/escaped_chars_long
------------------------------
after      1.00  1802.4±127.81ns       ? ?/sec
before     5.00       9.0±1.51µs       ? ?/sec

escape_text/escaped_chars_short
-------------------------------
before     1.00  1945.6±253.72ns       ? ?/sec
after      1.21       2.4±0.32µs       ? ?/sec

escape_text/no_chars_to_escape_long
-----------------------------------
after      1.00    282.7±38.03ns       ? ?/sec
before    25.28       7.1±1.21µs       ? ?/sec

escape_text/no_chars_to_escape_short
------------------------------------
before     1.00      65.0±4.89ns       ? ?/sec
after      1.73     112.0±1.80ns       ? ?/sec

parse_document_nocopy/document.xml
----------------------------------
after      1.00    359.9±87.72µs   30.5 MB/sec
before     1.06    381.5±43.36µs   28.8 MB/sec

parse_document_nocopy/libreoffice_document.fodt
-----------------------------------------------
after      1.00  1296.6±231.55µs   42.1 MB/sec
before     1.05  1360.3±141.50µs   40.1 MB/sec

parse_document_nocopy/linescore.xml
-----------------------------------
after      1.00      23.1±2.63µs  152.7 MB/sec
before     4.18     96.7±12.06µs   36.5 MB/sec

parse_document_nocopy/players.xml
---------------------------------
after      1.00    199.5±17.16µs   72.6 MB/sec
before     2.96    591.6±92.83µs   24.5 MB/sec

parse_document_nocopy/rpm_other.xml
-----------------------------------
after      1.00    398.5±49.44µs   55.6 MB/sec
before     1.06    422.6±61.23µs   52.4 MB/sec

parse_document_nocopy/rpm_primary.xml
-------------------------------------
after      1.00    413.2±97.02µs   49.1 MB/sec
before     1.21    499.3±87.07µs   40.6 MB/sec

parse_document_nocopy/rpm_primary2.xml
--------------------------------------
after      1.00    149.8±41.54µs   47.9 MB/sec
before     1.43    213.5±19.55µs   33.6 MB/sec

parse_document_nocopy/sample_1.xml
----------------------------------
after      1.00      21.7±8.18µs   50.6 MB/sec
before     1.48      32.1±4.09µs   34.2 MB/sec

parse_document_nocopy/sample_ns.xml
-----------------------------------
after      1.00       8.0±3.02µs   89.9 MB/sec
before     3.35      27.0±3.00µs   26.8 MB/sec

parse_document_nocopy/sample_rss.xml
------------------------------------
after      1.00  1444.7±755.53µs  130.5 MB/sec
before     1.55       2.2±0.37ms   84.4 MB/sec

parse_document_nocopy/test_writer_ident.xml
-------------------------------------------
after      1.00     82.8±12.54µs   51.2 MB/sec
before     1.12     92.9±10.90µs   45.7 MB/sec

parse_document_nocopy_with_namespaces/document.xml
--------------------------------------------------
after      1.00    539.0±70.22µs   20.4 MB/sec
before     1.09    585.1±58.45µs   18.8 MB/sec

parse_document_nocopy_with_namespaces/libreoffice_document.fodt
---------------------------------------------------------------
after      1.00  1847.3±458.23µs   29.6 MB/sec
before     1.12       2.1±0.22ms   26.4 MB/sec

parse_document_nocopy_with_namespaces/linescore.xml
---------------------------------------------------
after      1.00      23.3±5.62µs  151.7 MB/sec
before     5.29    123.1±17.55µs   28.7 MB/sec

parse_document_nocopy_with_namespaces/players.xml
-------------------------------------------------
after      1.00   518.6±114.42µs   28.0 MB/sec
before     1.31   678.7±105.20µs   21.4 MB/sec

parse_document_nocopy_with_namespaces/rpm_filelists.xml
-------------------------------------------------------
before     1.00    374.3±38.16µs   29.3 MB/sec
after      1.06    395.6±41.30µs   27.8 MB/sec

parse_document_nocopy_with_namespaces/rpm_other.xml
---------------------------------------------------
after      1.00   511.8±102.05µs   43.3 MB/sec
before     1.12    573.7±67.94µs   38.6 MB/sec

parse_document_nocopy_with_namespaces/rpm_primary.xml
-----------------------------------------------------
after      1.00   610.4±236.10µs   33.2 MB/sec
before     1.41   859.5±100.28µs   23.6 MB/sec

parse_document_nocopy_with_namespaces/rpm_primary2.xml
------------------------------------------------------
after      1.00    163.3±97.45µs   43.9 MB/sec
before     1.58    257.8±42.44µs   27.8 MB/sec

parse_document_nocopy_with_namespaces/sample_1.xml
--------------------------------------------------
before     1.00      40.6±7.39µs   27.1 MB/sec
after      1.12     45.4±21.66µs   24.2 MB/sec

parse_document_nocopy_with_namespaces/sample_ns.xml
---------------------------------------------------
after      1.00      30.0±7.26µs   24.1 MB/sec
before     1.36      40.9±4.09µs   17.7 MB/sec

parse_document_nocopy_with_namespaces/sample_rss.xml
----------------------------------------------------
after      1.00       2.7±0.45ms   70.8 MB/sec
before     1.03       2.8±0.52ms   68.5 MB/sec

parse_document_nocopy_with_namespaces/test_writer_ident.xml
-----------------------------------------------------------
after      1.00     70.3±23.15µs   60.4 MB/sec
before     1.81    127.0±19.06µs   33.4 MB/sec

read_event/trim_text = false
----------------------------
after      1.00   520.7±240.59µs       ? ?/sec
before     1.62    846.1±92.54µs       ? ?/sec

read_event/trim_text = true
---------------------------
after      1.00    430.2±94.41µs       ? ?/sec
before     1.84    791.1±97.12µs       ? ?/sec

unescape_text/entity_reference
------------------------------
after      1.00  1302.7±146.69ns       ? ?/sec
before     1.12  1462.2±131.84ns       ? ?/sec

unescape_text/no_chars_to_unescape_long
---------------------------------------
after      1.00    132.6±11.71ns       ? ?/sec
before     1.05    139.7±17.07ns       ? ?/sec

unescape_text/no_chars_to_unescape_short
----------------------------------------
before     1.00      44.5±4.97ns       ? ?/sec
after      1.06      47.2±4.74ns       ? ?/sec
```