### PR TITLE
Improve serialization of `xs:list`s with empty elements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
 - [#619]: Allow to raise application errors in `ElementWriter::write_inner_content`
   (and newly added `ElementWriter::write_inner_content_async` of course).
 - [#662]: Get rid of some allocations during serde deserialization.
+- [#665]: Improve serialization of `xs:list`s when some elements serialized to an empty string.
 
 [#545]: https://github.com/tafia/quick-xml/pull/545
 [#567]: https://github.com/tafia/quick-xml/issues/567
@@ -51,6 +52,7 @@ MSRV bumped to 1.56! Crate now uses Rust 2021 edition.
 [#660]: https://github.com/tafia/quick-xml/pull/660
 [#661]: https://github.com/tafia/quick-xml/pull/661
 [#662]: https://github.com/tafia/quick-xml/pull/662
+[#665]: https://github.com/tafia/quick-xml/pull/665
 
 
 ## 0.30.0 -- 2023-07-23

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -316,6 +316,9 @@ mod tests {
     struct Newtype(String);
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Tuple((), ());
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     struct Struct {
         key: String,
         val: usize,
@@ -459,8 +462,8 @@ mod tests {
         => Custom("invalid type: string \"name\", expected a sequence"));
     err!(tuple: ((), ()) = "name"
         => Custom("invalid type: string \"name\", expected a tuple of size 2"));
-    err!(tuple_struct: ((), ()) = "name"
-        => Custom("invalid type: string \"name\", expected a tuple of size 2"));
+    err!(tuple_struct: Tuple = "name"
+        => Custom("invalid type: string \"name\", expected tuple struct Tuple"));
 
     err!(map: HashMap<(), ()> = "name"
         => Custom("invalid type: string \"name\", expected a map"));

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -953,16 +953,17 @@ mod tests {
                     assert_eq!(data, $result);
 
                     // Roundtrip to ensure that serializer corresponds to deserializer
-                    assert_eq!(
-                        data.serialize(AtomicSerializer {
-                            writer: String::new(),
+                    let mut buffer = String::new();
+                    let has_written = data
+                        .serialize(AtomicSerializer {
+                            writer: &mut buffer,
                             target: QuoteTarget::Text,
                             level: QuoteLevel::Full,
-                            indent: Indent::None,
+                            indent: Some(Indent::None),
                         })
-                        .unwrap(),
-                        $input
-                    );
+                        .unwrap();
+                    assert_eq!(buffer, $input);
+                    assert_eq!(has_written, !buffer.is_empty());
                 }
             };
         }

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -882,6 +882,9 @@ mod tests {
     struct Newtype(String);
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Tuple((), ());
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
     struct BorrowedNewtype<'a>(&'a str);
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -1040,7 +1043,7 @@ mod tests {
                 => Unsupported("sequences are not supported as `xs:list` items"));
         err!(tuple: ((), ()) = "non-escaped string"
                 => Unsupported("tuples are not supported as `xs:list` items"));
-        err!(tuple_struct: ((), ()) = "non-escaped string"
+        err!(tuple_struct: Tuple = "non-escaped string"
                 => Unsupported("tuples are not supported as `xs:list` items"));
 
         err!(map: HashMap<(), ()> = "non-escaped string"

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -958,6 +958,7 @@ mod tests {
                             writer: String::new(),
                             target: QuoteTarget::Text,
                             level: QuoteLevel::Full,
+                            indent: Indent::None,
                         })
                         .unwrap(),
                         $input

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -338,12 +338,12 @@ impl<'w, 'i, W: Write> SerializeTuple for ContentSerializer<'w, 'i, W> {
     where
         T: ?Sized + Serialize,
     {
-        <Self as SerializeSeq>::serialize_element(self, value)
+        SerializeSeq::serialize_element(self, value)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        <Self as SerializeSeq>::end(self)
+        SerializeSeq::end(self)
     }
 }
 
@@ -356,12 +356,12 @@ impl<'w, 'i, W: Write> SerializeTupleStruct for ContentSerializer<'w, 'i, W> {
     where
         T: ?Sized + Serialize,
     {
-        <Self as SerializeSeq>::serialize_element(self, value)
+        SerializeSeq::serialize_element(self, value)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        <Self as SerializeSeq>::end(self)
+        SerializeSeq::end(self)
     }
 }
 

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -265,12 +265,12 @@ impl<'w, 'k, W: Write> SerializeTuple for ElementSerializer<'w, 'k, W> {
     where
         T: ?Sized + Serialize,
     {
-        <Self as SerializeSeq>::serialize_element(self, value)
+        SerializeSeq::serialize_element(self, value)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        <Self as SerializeSeq>::end(self)
+        SerializeSeq::end(self)
     }
 }
 
@@ -283,12 +283,12 @@ impl<'w, 'k, W: Write> SerializeTupleStruct for ElementSerializer<'w, 'k, W> {
     where
         T: ?Sized + Serialize,
     {
-        <Self as SerializeSeq>::serialize_element(self, value)
+        SerializeSeq::serialize_element(self, value)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        <Self as SerializeSeq>::end(self)
+        SerializeSeq::end(self)
     }
 }
 
@@ -314,16 +314,16 @@ impl<'w, 'k, W: Write> SerializeTupleVariant for Tuple<'w, 'k, W> {
         T: ?Sized + Serialize,
     {
         match self {
-            Tuple::Element(ser) => SerializeTuple::serialize_element(ser, value),
-            Tuple::Text(ser) => SerializeTuple::serialize_element(ser, value),
+            Self::Element(ser) => SerializeTuple::serialize_element(ser, value),
+            Self::Text(ser) => SerializeTuple::serialize_element(ser, value),
         }
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
         match self {
-            Tuple::Element(ser) => SerializeTuple::end(ser),
-            Tuple::Text(ser) => SerializeTuple::end(ser).map(|_| ()),
+            Self::Element(ser) => SerializeTuple::end(ser),
+            Self::Text(ser) => SerializeTuple::end(ser).map(|_| ()),
         }
     }
 }
@@ -461,12 +461,12 @@ impl<'w, 'k, W: Write> SerializeStructVariant for Struct<'w, 'k, W> {
     where
         T: ?Sized + Serialize,
     {
-        <Self as SerializeStruct>::serialize_field(self, key, value)
+        SerializeStruct::serialize_field(self, key, value)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        <Self as SerializeStruct>::end(self)
+        SerializeStruct::end(self)
     }
 }
 

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -390,8 +390,12 @@ impl<'n> XmlName<'n> {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 pub(crate) enum Indent<'i> {
+    /// No indent should be written before the element
     None,
+    /// The specified indent should be written. The type owns the buffer with indent
     Owned(Indentation),
+    /// The specified indent should be written. The type borrows buffer with indent
+    /// from its owner
     Borrow(&'i mut Indentation),
 }
 

--- a/src/se/simple_type.rs
+++ b/src/se/simple_type.rs
@@ -509,12 +509,12 @@ impl<'i, W: Write> SerializeTuple for SimpleSeq<'i, W> {
     where
         T: ?Sized + Serialize,
     {
-        <Self as SerializeSeq>::serialize_element(self, value)
+        SerializeSeq::serialize_element(self, value)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        <Self as SerializeSeq>::end(self)
+        SerializeSeq::end(self)
     }
 }
 
@@ -527,12 +527,12 @@ impl<'i, W: Write> SerializeTupleStruct for SimpleSeq<'i, W> {
     where
         T: ?Sized + Serialize,
     {
-        <Self as SerializeSeq>::serialize_element(self, value)
+        SerializeSeq::serialize_element(self, value)
     }
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        <Self as SerializeSeq>::end(self)
+        SerializeSeq::end(self)
     }
 }
 

--- a/src/se/simple_type.rs
+++ b/src/se/simple_type.rs
@@ -1047,4 +1047,107 @@ mod tests {
         err!(enum_struct: Enum::Struct { key: "answer", val: 42 }
             => Unsupported("cannot serialize enum struct variant `Enum::Struct` as an attribute or text content value"));
     }
+
+    mod simple_seq {
+        use super::*;
+        use crate::writer::Indentation;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn empty_seq() {
+            let mut buffer = String::new();
+            let mut indent = Indentation::new(b'*', 2);
+            indent.grow();
+            let ser = SimpleSeq {
+                writer: &mut buffer,
+                target: QuoteTarget::Text,
+                level: QuoteLevel::Full,
+                indent: Indent::Owned(indent),
+                first: true,
+            };
+
+            SerializeSeq::end(ser).unwrap();
+            assert_eq!(buffer, "");
+        }
+
+        #[test]
+        fn all_items_empty() {
+            let mut buffer = String::new();
+            let mut indent = Indentation::new(b'*', 2);
+            indent.grow();
+            let mut ser = SimpleSeq {
+                writer: &mut buffer,
+                target: QuoteTarget::Text,
+                level: QuoteLevel::Full,
+                indent: Indent::Owned(indent),
+                first: true,
+            };
+
+            SerializeSeq::serialize_element(&mut ser, "").unwrap();
+            SerializeSeq::serialize_element(&mut ser, "").unwrap();
+            SerializeSeq::serialize_element(&mut ser, "").unwrap();
+            SerializeSeq::end(ser).unwrap();
+            assert_eq!(buffer, "");
+        }
+
+        #[test]
+        fn some_items_empty1() {
+            let mut buffer = String::new();
+            let mut indent = Indentation::new(b'*', 2);
+            indent.grow();
+            let mut ser = SimpleSeq {
+                writer: &mut buffer,
+                target: QuoteTarget::Text,
+                level: QuoteLevel::Full,
+                indent: Indent::Owned(indent),
+                first: true,
+            };
+
+            SerializeSeq::serialize_element(&mut ser, "").unwrap();
+            SerializeSeq::serialize_element(&mut ser, &1).unwrap();
+            SerializeSeq::serialize_element(&mut ser, "").unwrap();
+            SerializeSeq::end(ser).unwrap();
+            assert_eq!(buffer, "\n**1");
+        }
+
+        #[test]
+        fn some_items_empty2() {
+            let mut buffer = String::new();
+            let mut indent = Indentation::new(b'*', 2);
+            indent.grow();
+            let mut ser = SimpleSeq {
+                writer: &mut buffer,
+                target: QuoteTarget::Text,
+                level: QuoteLevel::Full,
+                indent: Indent::Owned(indent),
+                first: true,
+            };
+
+            SerializeSeq::serialize_element(&mut ser, &1).unwrap();
+            SerializeSeq::serialize_element(&mut ser, "").unwrap();
+            SerializeSeq::serialize_element(&mut ser, &2).unwrap();
+            SerializeSeq::end(ser).unwrap();
+            assert_eq!(buffer, "\n**1 2");
+        }
+
+        #[test]
+        fn items() {
+            let mut buffer = String::new();
+            let mut indent = Indentation::new(b'*', 2);
+            indent.grow();
+            let mut ser = SimpleSeq {
+                writer: &mut buffer,
+                target: QuoteTarget::Text,
+                level: QuoteLevel::Full,
+                indent: Indent::Owned(indent),
+                first: true,
+            };
+
+            SerializeSeq::serialize_element(&mut ser, &1).unwrap();
+            SerializeSeq::serialize_element(&mut ser, &2).unwrap();
+            SerializeSeq::serialize_element(&mut ser, &3).unwrap();
+            SerializeSeq::end(ser).unwrap();
+            assert_eq!(buffer, "\n**1 2 3");
+        }
+    }
 }

--- a/src/se/simple_type.rs
+++ b/src/se/simple_type.rs
@@ -177,9 +177,7 @@ pub struct AtomicSerializer<W: Write> {
 
 impl<W: Write> AtomicSerializer<W> {
     fn write_str(&mut self, value: &str) -> Result<(), DeError> {
-        Ok(self
-            .writer
-            .write_str(&escape_item(value, self.target, self.level))?)
+        Ok(self.writer.write_str(value)?)
     }
 }
 
@@ -198,7 +196,7 @@ impl<W: Write> Serializer for AtomicSerializer<W> {
     write_primitive!();
 
     fn serialize_str(mut self, value: &str) -> Result<Self::Ok, Self::Error> {
-        self.write_str(value)?;
+        self.write_str(&escape_item(value, self.target, self.level))?;
         Ok(self.writer)
     }
 
@@ -337,9 +335,7 @@ pub struct SimpleTypeSerializer<'i, W: Write> {
 impl<'i, W: Write> SimpleTypeSerializer<'i, W> {
     fn write_str(&mut self, value: &str) -> Result<(), DeError> {
         self.indent.write_indent(&mut self.writer)?;
-        Ok(self
-            .writer
-            .write_str(&escape_list(value, self.target, self.level))?)
+        Ok(self.writer.write_str(value)?)
     }
 }
 
@@ -358,10 +354,9 @@ impl<'i, W: Write> Serializer for SimpleTypeSerializer<'i, W> {
     write_primitive!();
 
     fn serialize_str(mut self, value: &str) -> Result<Self::Ok, Self::Error> {
-        if value.is_empty() {
-            self.indent = Indent::None;
+        if !value.is_empty() {
+            self.write_str(&escape_list(value, self.target, self.level))?;
         }
-        self.write_str(value)?;
         Ok(self.writer)
     }
 

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -384,7 +384,7 @@ mod without_root {
             serialize_as!(newtype:
                 ExternallyTagged::Newtype(true)
                 => "<Newtype>true</Newtype>");
-            serialize_as!(tuple_struct:
+            serialize_as!(tuple:
                 ExternallyTagged::Tuple(42.0, "answer")
                 => "<Tuple>42</Tuple>\
                     <Tuple>answer</Tuple>");
@@ -500,7 +500,7 @@ mod without_root {
                     => "<Root>\
                             <Newtype>true</Newtype>\
                         </Root>");
-                serialize_as_only!(tuple_struct:
+                serialize_as_only!(tuple:
                     Root { field: ExternallyTagged::Tuple(42.0, "answer") }
                     => "<Root>\
                             <Tuple>42</Tuple>\
@@ -589,7 +589,7 @@ mod without_root {
                                 <Newtype>true</Newtype>\
                             </field>\
                         </Root>");
-                serialize_as_only!(tuple_struct:
+                serialize_as_only!(tuple:
                     Root { field: Inner { inner: ExternallyTagged::Tuple(42.0, "answer") } }
                     => "<Root>\
                             <field>\
@@ -681,7 +681,7 @@ mod without_root {
                     => "<Root>\
                             <Newtype>true</Newtype>\
                         </Root>");
-                serialize_as!(tuple_struct:
+                serialize_as!(tuple:
                     Root { field: ExternallyTagged::Tuple(42.0, "answer") }
                     => "<Root>\
                             <Tuple>42</Tuple>\
@@ -767,7 +767,7 @@ mod without_root {
                                 <Newtype>true</Newtype>\
                             </field>\
                         </Root>");
-                serialize_as!(tuple_struct:
+                serialize_as!(tuple:
                     Root { field: Inner { inner: ExternallyTagged::Tuple(42.0, "answer") } }
                     => "<Root>\
                             <field>\
@@ -860,7 +860,7 @@ mod without_root {
                     Root { field: ExternallyTagged::Newtype(true) }
                     => Unsupported("cannot serialize enum newtype variant `ExternallyTagged::Newtype` as an attribute or text content value"),
                     "<Root");
-                err!(tuple_struct:
+                err!(tuple:
                     Root { field: ExternallyTagged::Tuple(42.0, "answer") }
                     => Unsupported("cannot serialize enum tuple variant `ExternallyTagged::Tuple` as an attribute or text content value"),
                     "<Root");
@@ -919,7 +919,7 @@ mod without_root {
                     Root { field: Inner { inner: ExternallyTagged::Newtype(true) } }
                     => Unsupported("cannot serialize enum newtype variant `ExternallyTagged::Newtype` as an attribute or text content value"),
                     "<Root");
-                err!(tuple_struct:
+                err!(tuple:
                     Root { field: Inner { inner: ExternallyTagged::Tuple(42.0, "answer") } }
                     => Unsupported("cannot serialize enum tuple variant `ExternallyTagged::Tuple` as an attribute or text content value"),
                     "<Root");
@@ -1048,7 +1048,7 @@ mod without_root {
                         <tag>Newtype</tag>\
                         <content>true</content>\
                     </AdjacentlyTagged>");
-            serialize_as!(tuple_struct:
+            serialize_as!(tuple:
                 AdjacentlyTagged::Tuple(42.0, "answer")
                 => "<AdjacentlyTagged>\
                         <tag>Tuple</tag>\
@@ -1126,7 +1126,7 @@ mod without_root {
                 => Unsupported("cannot serialize `()` without defined root tag"));
             err!(newtype: Untagged::Newtype(true)
                 => Unsupported("cannot serialize `bool` without defined root tag"));
-            err!(tuple_struct: Untagged::Tuple(42.0, "answer")
+            err!(tuple: Untagged::Tuple(42.0, "answer")
                 => Unsupported("cannot serialize unnamed tuple without defined root tag"));
             // NOTE: Cannot be deserialized in roundtrip due to
             // https://github.com/serde-rs/serde/issues/1183
@@ -1328,7 +1328,7 @@ mod without_root {
                 serialize_as!(newtype:
                     ExternallyTagged::Newtype(true)
                     => "<Newtype>true</Newtype>");
-                serialize_as!(tuple_struct:
+                serialize_as!(tuple:
                     ExternallyTagged::Tuple(42.0, "answer")
                     => "<Tuple>42</Tuple>\n\
                         <Tuple>answer</Tuple>");
@@ -1496,7 +1496,7 @@ mod without_root {
                             <tag>Newtype</tag>\n  \
                             <content>true</content>\n\
                         </AdjacentlyTagged>");
-                serialize_as!(tuple_struct:
+                serialize_as!(tuple:
                     AdjacentlyTagged::Tuple(42.0, "answer")
                     => "<AdjacentlyTagged>\n  \
                             <tag>Tuple</tag>\n  \
@@ -1570,7 +1570,7 @@ mod without_root {
                     => Unsupported("cannot serialize `()` without defined root tag"));
                 err!(newtype: Untagged::Newtype(true)
                     => Unsupported("cannot serialize `bool` without defined root tag"));
-                err!(tuple_struct: Untagged::Tuple(42.0, "answer")
+                err!(tuple: Untagged::Tuple(42.0, "answer")
                     => Unsupported("cannot serialize unnamed tuple without defined root tag"));
                 serialize_as!(struct_:
                     Untagged::Struct {
@@ -1817,7 +1817,7 @@ mod with_root {
             serialize_as!(newtype:
                 ExternallyTagged::Newtype(true)
                 => "<Newtype>true</Newtype>");
-            serialize_as!(tuple_struct:
+            serialize_as!(tuple:
                 ExternallyTagged::Tuple(42.0, "answer")
                 => "<Tuple>42</Tuple>\
                     <Tuple>answer</Tuple>");
@@ -2002,7 +2002,7 @@ mod with_root {
                         <tag>Newtype</tag>\
                         <content>true</content>\
                     </root>");
-            serialize_as!(tuple_struct:
+            serialize_as!(tuple:
                 AdjacentlyTagged::Tuple(42.0, "answer")
                 => "<root>\
                         <tag>Tuple</tag>\
@@ -2086,7 +2086,7 @@ mod with_root {
                 => "<root>true</root>");
             // NOTE: Cannot be deserialized in roundtrip due to
             // https://github.com/serde-rs/serde/issues/1183
-            serialize_as_only!(tuple_struct:
+            serialize_as_only!(tuple:
                 Untagged::Tuple(42.0, "answer")
                 => "<root>42</root>\
                     <root>answer</root>");


### PR DESCRIPTION
In this PR serialization I implement skipping unnecessary indentation or writing list delimiters, if list element was serialized to an empty string.

Also fixed minor bugs in tests for `SimpleTypeDeserializer` and `QNameDeserializer` -- I realized, that some tuple struct tests actually duplicate tuple tests.