### PR TITLE
Use correct deserializer for enum tuple and newtype variants when enum is type of field

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -613,7 +613,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_enum(crate::de::var::EnumAccess::new(self.map.de))
+        visitor.visit_enum(self)
     }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -623,6 +623,122 @@ where
         match self.map.de.peek()? {
             DeEvent::Text(_) => self.deserialize_str(visitor),
             _ => self.deserialize_map(visitor),
+        }
+    }
+}
+
+impl<'de, 'd, 'm, R, E> de::EnumAccess<'de> for MapValueDeserializer<'de, 'd, 'm, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    type Error = DeError;
+    type Variant = MapValueVariantAccess<'de, 'm, R, E>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let decoder = self.map.de.reader.decoder();
+        let (name, is_text) = match self.map.de.peek()? {
+            DeEvent::Start(e) => (
+                seed.deserialize(QNameDeserializer::from_elem(e.raw_name(), decoder)?)?,
+                false,
+            ),
+            DeEvent::Text(_) => (
+                seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
+                true,
+            ),
+            DeEvent::End(e) => return Err(DeError::UnexpectedEnd(e.name().into_inner().to_vec())),
+            DeEvent::Eof => return Err(DeError::UnexpectedEof),
+        };
+        Ok((
+            name,
+            MapValueVariantAccess {
+                de: self.map.de,
+                is_text,
+            },
+        ))
+    }
+}
+
+struct MapValueVariantAccess<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    de: &'d mut Deserializer<'de, R, E>,
+    /// `true` if variant should be deserialized from a textual content
+    /// and `false` if from tag
+    is_text: bool,
+}
+
+impl<'de, 'd, R, E> de::VariantAccess<'de> for MapValueVariantAccess<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    type Error = DeError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        match self.de.next()? {
+            // Consume subtree
+            DeEvent::Start(e) => self.de.read_to_end(e.name()),
+            // Does not needed to deserialize using SimpleTypeDeserializer, because
+            // it returns `()` when `deserialize_unit()` is requested
+            DeEvent::Text(_) => Ok(()),
+            // SAFETY: the other events are filtered in `variant_seed()`
+            _ => unreachable!("Only `Start` or `Text` events are possible here"),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.is_text {
+            match self.de.next()? {
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
+                // SAFETY: the other events are filtered in `variant_seed()`
+                _ => unreachable!("Only `Text` events are possible here"),
+            }
+        } else {
+            seed.deserialize(&mut *self.de)
+        }
+    }
+
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.is_text {
+            match self.de.next()? {
+                DeEvent::Text(e) => {
+                    SimpleTypeDeserializer::from_text_content(e).deserialize_tuple(len, visitor)
+                }
+                // SAFETY: the other events are filtered in `variant_seed()`
+                _ => unreachable!("Only `Text` events are possible here"),
+            }
+        } else {
+            self.de.deserialize_tuple(len, visitor)
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.de.next()? {
+            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.de, e, fields)?),
+            DeEvent::Text(e) => {
+                SimpleTypeDeserializer::from_text_content(e).deserialize_struct("", fields, visitor)
+            }
+            // SAFETY: the other events are filtered in `variant_seed()`
+            _ => unreachable!("Only `Start` or `Text` events are possible here"),
         }
     }
 }

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -143,9 +143,8 @@ where
         } else {
             match self.de.next()? {
                 DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.de, e, fields)?),
-                DeEvent::End(e) => Err(DeError::UnexpectedEnd(e.name().as_ref().to_owned())),
-                DeEvent::Text(_) => Err(DeError::ExpectedStart),
-                DeEvent::Eof => Err(DeError::UnexpectedEof),
+                // SAFETY: the other events are filtered in `variant_seed()`
+                _ => unreachable!("Only `Start` events are possible here"),
             }
         }
     }


### PR DESCRIPTION
This PR fixes incorrect usage top-level deserializer for such situations:
```rust
enum Enum<T> {
  Newtype(T),
  Tuple(T, T),
}
struct Container {
  field: Enum<()>,
}
```
The type `T` of `Enum` should be deserialized using a `MapValueDeserializer` which is used to deserialize other (element) fields of a `Container`. Until now it was deserialized using top-level deserializer, which is supposed to deserialize only root types.

I was unable to find actual errors that changing the deserializer will solve. The obvious attempts like exploiting different behaviour of `Deserializer::deserialize_seq` and `MapValueDeserializer::deserialize_seq` when processing `Eof` event failed, because although `Deserializer::deserialize_seq` will return a success after reaching `Eof` (that means that top-level sequence is ended), but that `Eof` will be then seen by the `ElementMapAccess` and because it awaits closing tag, the deserialization will fail (as like using new correct deserializer).

I suspect, that the result of a change could be more visible if we report error position in errors, but because we do not do that yet, there is no visible changes in behavior.