### PR TITLE
Update maybe_xml dependency 0.3 -> 0.6

### DIFF
--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-maybe_xml = "0.3"
+maybe_xml = "0.6"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
 rusty_xml = { version = "0.3", package = "RustyXML" }


### PR DESCRIPTION
[maybe_xml](https://github.com/bluk/maybe_xml) is still about 1.5x--2x faster that quick-xml in most tests, except those:
- rpm_other
- linescore
- test_writer_ident
- players

Here is criterion report: [comparison.zip](https://github.com/tafia/quick-xml/files/12936580/comparison.zip)
