### PR TITLE
Rework errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/*", "LICENSE-MIT.md", "README.md"]
 [dependencies]
 document-features = { version = "0.2", optional = true }
 encoding_rs = { version = "0.8", optional = true }
-serde = { version = ">=1.0.100", optional = true }
+serde = { version = ">=1.0.139", optional = true }
 tokio = { version = "1.10", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.1"
 arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,9 @@
 ### Misc Changes
 
 - [#675]: Minimum supported version of serde raised to 1.0.139
+- [#675]: Rework the `quick_xml::Error` type to provide more accurate information:
+  - `Error::UnexpectedBang` replaced by `SyntaxError`
+  - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases
 
 [#675]: https://github.com/tafia/quick-xml/pull/675
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - [#675]: Rework the `quick_xml::Error` type to provide more accurate information:
   - `Error::UnexpectedBang` replaced by `SyntaxError`
   - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases
+  - `Error::UnexpectedEof` replaced by `IllFormedError` in some cases
 
 [#675]: https://github.com/tafia/quick-xml/pull/675
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,10 @@
 
 ### Misc Changes
 
+- [#675]: Minimum supported version of serde raised to 1.0.139
+
+[#675]: https://github.com/tafia/quick-xml/pull/675
+
 
 ## 0.31.0 -- 2023-10-22
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - [#675]: Rework the `quick_xml::Error` type to provide more accurate information:
   - `Error::EndEventMismatch` replaced by `IllFormedError::MismatchedEnd` in some cases
   - `Error::EndEventMismatch` replaced by `IllFormedError::UnmatchedEnd` in some cases
+  - `Error::TextNotFound` was removed because not used
   - `Error::UnexpectedBang` replaced by `SyntaxError`
   - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases
   - `Error::UnexpectedEof` replaced by `IllFormedError` in some cases

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 
 - [#675]: Minimum supported version of serde raised to 1.0.139
 - [#675]: Rework the `quick_xml::Error` type to provide more accurate information:
+  - `Error::EndEventMismatch` replaced by `IllFormedError::MismatchedEnd` in some cases
   - `Error::EndEventMismatch` replaced by `IllFormedError::UnmatchedEnd` in some cases
   - `Error::UnexpectedBang` replaced by `SyntaxError`
   - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@
   - `Error::UnexpectedBang` replaced by `SyntaxError`
   - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases
   - `Error::UnexpectedEof` replaced by `IllFormedError` in some cases
+  - `Error::UnexpectedToken` replaced by `IllFormedError::DoubleHyphenInComment`
 
 [#675]: https://github.com/tafia/quick-xml/pull/675
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 
 - [#675]: Minimum supported version of serde raised to 1.0.139
 - [#675]: Rework the `quick_xml::Error` type to provide more accurate information:
+  - `Error::EndEventMismatch` replaced by `IllFormedError::UnmatchedEnd` in some cases
   - `Error::UnexpectedBang` replaced by `SyntaxError`
   - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases
   - `Error::UnexpectedEof` replaced by `IllFormedError` in some cases

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -405,7 +405,7 @@ mod tests {
                 match err {
                     DeError::$kind(e) => assert_eq!(e, $reason),
                     _ => panic!(
-                        "Expected `{}({})`, found `{:?}`",
+                        "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),
                         $reason,
                         err

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -1,9 +1,10 @@
+use crate::de::simple_type::UnitOnly;
 use crate::de::str2bool;
 use crate::encoding::Decoder;
 use crate::errors::serialize::DeError;
 use crate::name::QName;
 use crate::utils::CowRef;
-use serde::de::{DeserializeSeed, Deserializer, EnumAccess, VariantAccess, Visitor};
+use serde::de::{DeserializeSeed, Deserializer, EnumAccess, Visitor};
 use serde::{forward_to_deserialize_any, serde_if_integer128};
 use std::borrow::Cow;
 
@@ -240,60 +241,14 @@ impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'de, 'd> {
 
 impl<'de, 'd> EnumAccess<'de> for QNameDeserializer<'de, 'd> {
     type Error = DeError;
-    type Variant = QNameUnitOnly;
+    type Variant = UnitOnly;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
     where
         V: DeserializeSeed<'de>,
     {
         let name = seed.deserialize(self)?;
-        Ok((name, QNameUnitOnly))
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/// Deserializer of variant data, that supports only unit variants.
-/// Attempt to deserialize newtype, tuple or struct variant will return a
-/// [`DeError::Unsupported`] error.
-pub struct QNameUnitOnly;
-impl<'de> VariantAccess<'de> for QNameUnitOnly {
-    type Error = DeError;
-
-    #[inline]
-    fn unit_variant(self) -> Result<(), DeError> {
-        Ok(())
-    }
-
-    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, DeError>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        Err(DeError::Unsupported(
-            "enum newtype variants are not supported as an XML names".into(),
-        ))
-    }
-
-    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        Err(DeError::Unsupported(
-            "enum tuple variants are not supported as an XML names".into(),
-        ))
-    }
-
-    fn struct_variant<V>(
-        self,
-        _fields: &'static [&'static str],
-        _visitor: V,
-    ) -> Result<V::Value, DeError>
-    where
-        V: Visitor<'de>,
-    {
-        Err(DeError::Unsupported(
-            "enum struct variants are not supported as an XML names".into(),
-        ))
+        Ok((name, UnitOnly))
     }
 }
 
@@ -473,11 +428,11 @@ mod tests {
     deserialized_to!(enum_unit: Enum = "Unit" => Enum::Unit);
     deserialized_to!(enum_unit_for_attr: Enum = "@Attr" => Enum::Attr);
     err!(enum_newtype: Enum = "Newtype"
-        => Unsupported("enum newtype variants are not supported as an XML names"));
+        => Custom("invalid type: unit value, expected a string"));
     err!(enum_tuple: Enum = "Tuple"
-        => Unsupported("enum tuple variants are not supported as an XML names"));
+        => Custom("invalid type: unit value, expected tuple variant Enum::Tuple"));
     err!(enum_struct: Enum = "Struct"
-        => Unsupported("enum struct variants are not supported as an XML names"));
+        => Custom("invalid type: unit value, expected struct variant Enum::Struct"));
 
     // Field identifiers cannot be serialized, and IgnoredAny represented _something_
     // which is not concrete

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -8,6 +8,7 @@ use crate::{
     de::{str2bool, DeEvent, Deserializer, XmlRead, TEXT_KEY, VALUE_KEY},
     encoding::Decoder,
     errors::serialize::DeError,
+    errors::Error,
     events::attributes::IterState,
     events::BytesStart,
     name::QName,
@@ -300,7 +301,7 @@ where
                 }
                 // We cannot get `Eof` legally, because we always inside of the
                 // opened tag `self.start`
-                DeEvent::Eof => Err(DeError::UnexpectedEof),
+                DeEvent::Eof => Err(Error::missed_end(self.start.name(), decoder).into()),
             }
         }
     }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -616,9 +616,9 @@ where
         if self.fixed_name {
             match self.map.de.next()? {
                 // Handles <field>UnitEnumVariant</field>
-                DeEvent::Start(_) => {
+                DeEvent::Start(e) => {
                     // skip <field>, read text after it and ensure that it is ended by </field>
-                    let text = self.map.de.read_text()?;
+                    let text = self.map.de.read_text(e.name())?;
                     if text.is_empty() {
                         // Map empty text (<field/>) to a special `$text` variant
                         visitor.visit_enum(SimpleTypeDeserializer::from_text(TEXT_KEY.into()))
@@ -1022,7 +1022,7 @@ where
     /// [`CData`]: crate::events::Event::CData
     #[inline]
     fn read_string(&mut self) -> Result<Cow<'de, str>, DeError> {
-        self.de.read_text()
+        self.de.read_text(self.start.name())
     }
 }
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -670,10 +670,8 @@ where
                 seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
                 true,
             ),
-            // SAFETY: The reader is guaranteed that we don't have unmatched tags
-            // If we here, then out deserializer has a bug
-            DeEvent::End(e) => unreachable!("{:?}", e),
-            DeEvent::Eof => return Err(DeError::UnexpectedEof),
+            // SAFETY: we use that deserializer only when we peeked `Start` or `Text` event
+            _ => unreachable!(),
         };
         Ok((
             name,

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -937,7 +937,7 @@ where
                 }
                 // We cannot get `Eof` legally, because we always inside of the
                 // opened tag `self.map.start`
-                DeEvent::Eof => Err(DeError::UnexpectedEof),
+                DeEvent::Eof => Err(Error::missed_end(self.map.start.name(), decoder).into()),
 
                 DeEvent::Text(_) => match self.map.de.next()? {
                     DeEvent::Text(e) => seed.deserialize(TextDeserializer(e)).map(Some),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2681,7 +2681,7 @@ where
             // The matching tag name is guaranteed by the reader
             DeEvent::End(_) => Ok("".into()),
             DeEvent::Start(s) => Err(DeError::UnexpectedStart(s.name().as_ref().to_owned())),
-            DeEvent::Eof => Err(DeError::UnexpectedEof),
+            DeEvent::Eof => Err(Error::missed_end(name, self.reader.decoder()).into()),
         }
     }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3747,12 +3747,11 @@ mod tests {
     #[test]
     fn read_string() {
         match from_str::<String>(r#"</root>"#) {
-            Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                assert_eq!(expected, "");
-                assert_eq!(found, "root");
+            Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                assert_eq!(cause, IllFormedError::UnmatchedEnd("root".into()));
             }
             x => panic!(
-                "Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'root' }}))`, but got `{:?}`",
+                "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
                 x
             ),
         }
@@ -4090,11 +4089,13 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
                     match de.next() {
-                        Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                            assert_eq!(expected, "");
-                            assert_eq!(found, "tag2");
+                        Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag2".into()));
                         }
-                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag2' }}))`, but got `{:?}`", x),
+                        x => panic!(
+                            "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                            x
+                        ),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4231,11 +4232,13 @@ mod tests {
         fn end() {
             let mut de = make_de("</tag>");
             match de.next() {
-                Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                    assert_eq!(expected, "");
-                    assert_eq!(found, "tag");
+                Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                    assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
                 }
-                x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
+                x => panic!(
+                    "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                    x
+                ),
             }
             assert_eq!(de.next().unwrap(), DeEvent::Eof);
         }
@@ -4308,11 +4311,13 @@ mod tests {
                 // Text is trimmed from both sides
                 assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
                 match de.next() {
-                    Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                        assert_eq!(expected, "");
-                        assert_eq!(found, "tag");
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                        assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
                     }
-                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
+                    x => panic!(
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                        x
+                    ),
                 }
                 assert_eq!(de.next().unwrap(), DeEvent::Eof);
             }
@@ -4338,11 +4343,13 @@ mod tests {
                     // Text is trimmed from the start
                     assert_eq!(de.next().unwrap(), DeEvent::Text("text  cdata ".into()));
                     match de.next() {
-                        Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                            assert_eq!(expected, "");
-                            assert_eq!(found, "tag");
+                        Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
                         }
-                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
+                        x => panic!(
+                            "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                            x
+                        ),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4442,11 +4449,13 @@ mod tests {
                 let mut de = make_de("<![CDATA[ cdata ]]></tag>");
                 assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata ".into()));
                 match de.next() {
-                    Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                        assert_eq!(expected, "");
-                        assert_eq!(found, "tag");
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                        assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
                     }
-                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
+                    x => panic!(
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                        x
+                    ),
                 }
                 assert_eq!(de.next().unwrap(), DeEvent::Eof);
             }
@@ -4470,11 +4479,13 @@ mod tests {
                     // Text is trimmed from the end
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text".into()));
                     match de.next() {
-                        Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                            assert_eq!(expected, "");
-                            assert_eq!(found, "tag");
+                        Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
                         }
-                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
+                        x => panic!(
+                            "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                            x
+                        ),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4518,11 +4529,13 @@ mod tests {
                     let mut de = make_de("<![CDATA[ cdata ]]><![CDATA[ cdata2 ]]></tag>");
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  cdata2 ".into()));
                     match de.next() {
-                        Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                            assert_eq!(expected, "");
-                            assert_eq!(found, "tag");
+                        Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
                         }
-                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
+                        x => panic!(
+                            "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                            x
+                        ),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3760,14 +3760,14 @@ mod tests {
         assert_eq!(s, "");
 
         match from_str::<String>(r#"<root></other>"#) {
-            Err(DeError::InvalidXml(Error::EndEventMismatch { expected, found })) => {
-                assert_eq!(expected, "root");
-                assert_eq!(found, "other");
-            }
-            x => panic!(
-                "Expected `Err(InvalidXml(EndEventMismatch {{ expected = 'root', found = 'other' }}))`, but got `{:?}`",
-                x
+            Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
+                cause,
+                IllFormedError::MismatchedEnd {
+                    expected: "root".into(),
+                    found: "other".into(),
+                }
             ),
+            x => panic!("Expected `Err(InvalidXml(IllFormed(_))`, but got `{:?}`", x),
         }
     }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3055,7 +3055,7 @@ impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
 
     fn read_to_end(&mut self, name: QName) -> Result<(), DeError> {
         match self.reader.read_to_end_into(name, &mut self.buf) {
-            Err(Error::UnexpectedEof(_)) => Err(DeError::UnexpectedEof),
+            Err(Error::IllFormed(_)) => Err(DeError::UnexpectedEof),
             Err(e) => Err(e.into()),
             Ok(_) => Ok(()),
         }
@@ -3087,7 +3087,7 @@ impl<'de> XmlRead<'de> for SliceReader<'de> {
 
     fn read_to_end(&mut self, name: QName) -> Result<(), DeError> {
         match self.reader.read_to_end(name) {
-            Err(Error::UnexpectedEof(_)) => Err(DeError::UnexpectedEof),
+            Err(Error::IllFormed(_)) => Err(DeError::UnexpectedEof),
             Err(e) => Err(e.into()),
             Ok(_) => Ok(()),
         }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3539,7 +3539,7 @@ mod tests {
 
             match List::deserialize(&mut de) {
                 Err(DeError::TooManyEvents(count)) => assert_eq!(count.get(), 3),
-                e => panic!("Expected `Err(TooManyEvents(3))`, but found {:?}", e),
+                e => panic!("Expected `Err(TooManyEvents(3))`, but got `{:?}`", e),
             }
         }
 
@@ -3605,8 +3605,8 @@ mod tests {
             assert_eq!(de.peek().unwrap(), &Start(BytesStart::new("tag")));
 
             match de.read_to_end(QName(b"tag")) {
-                Err(DeError::UnexpectedEof) => (),
-                x => panic!("Expected `Err(UnexpectedEof)`, but found {:?}", x),
+                Err(DeError::UnexpectedEof) => {}
+                x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
             }
             assert_eq!(de.next().unwrap(), Eof);
         }
@@ -3619,8 +3619,8 @@ mod tests {
             assert_eq!(de.peek().unwrap(), &Text("".into()));
 
             match de.read_to_end(QName(b"tag")) {
-                Err(DeError::UnexpectedEof) => (),
-                x => panic!("Expected `Err(UnexpectedEof)`, but found {:?}", x),
+                Err(DeError::UnexpectedEof) => {}
+                x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
             }
             assert_eq!(de.next().unwrap(), Eof);
         }
@@ -3713,7 +3713,7 @@ mod tests {
                 assert_eq!(found, "root");
             }
             x => panic!(
-                r#"Expected `Err(InvalidXml(EndEventMismatch("", "root")))`, but found {:?}"#,
+                "Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'root' }}))`, but got `{:?}`",
                 x
             ),
         }
@@ -3727,7 +3727,7 @@ mod tests {
                 assert_eq!(found, "other");
             }
             x => panic!(
-                r#"Expected `Err(InvalidXml(EndEventMismatch("root", "other")))`, but found {:?}"#,
+                "Expected `Err(InvalidXml(EndEventMismatch {{ expected = 'root', found = 'other' }}))`, but got `{:?}`",
                 x
             ),
         }
@@ -4055,7 +4055,7 @@ mod tests {
                             assert_eq!(expected, "");
                             assert_eq!(found, "tag2");
                         }
-                        x => panic!("Expected `InvalidXml(EndEventMismatch {{ expected = '', found = 'tag2' }})`, but got {:?}", x),
+                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag2' }}))`, but got `{:?}`", x),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4196,7 +4196,7 @@ mod tests {
                     assert_eq!(expected, "");
                     assert_eq!(found, "tag");
                 }
-                x => panic!("Expected `InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }})`, but got {:?}", x),
+                x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
             }
             assert_eq!(de.next().unwrap(), DeEvent::Eof);
         }
@@ -4273,7 +4273,7 @@ mod tests {
                         assert_eq!(expected, "");
                         assert_eq!(found, "tag");
                     }
-                    x => panic!("Expected `InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }})`, but got {:?}", x),
+                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
                 }
                 assert_eq!(de.next().unwrap(), DeEvent::Eof);
             }
@@ -4303,7 +4303,7 @@ mod tests {
                             assert_eq!(expected, "");
                             assert_eq!(found, "tag");
                         }
-                        x => panic!("Expected `InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }})`, but got {:?}", x),
+                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4407,7 +4407,7 @@ mod tests {
                         assert_eq!(expected, "");
                         assert_eq!(found, "tag");
                     }
-                    x => panic!("Expected `InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }})`, but got {:?}", x),
+                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
                 }
                 assert_eq!(de.next().unwrap(), DeEvent::Eof);
             }
@@ -4435,7 +4435,7 @@ mod tests {
                             assert_eq!(expected, "");
                             assert_eq!(found, "tag");
                         }
-                        x => panic!("Expected `InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }})`, but got {:?}", x),
+                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4483,7 +4483,7 @@ mod tests {
                             assert_eq!(expected, "");
                             assert_eq!(found, "tag");
                         }
-                        x => panic!("Expected `InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }})`, but got {:?}", x),
+                        x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ expected = '', found = 'tag' }}))`, but got `{:?}`", x),
                     }
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1867,6 +1867,7 @@ macro_rules! deserialize_primitives {
         }
 
         /// Character represented as [strings](#method.deserialize_str).
+        #[inline]
         fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
@@ -1886,6 +1887,7 @@ macro_rules! deserialize_primitives {
         }
 
         /// Representation of owned strings the same as [non-owned](#method.deserialize_str).
+        #[inline]
         fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
@@ -1893,15 +1895,17 @@ macro_rules! deserialize_primitives {
             self.deserialize_str(visitor)
         }
 
-        /// Returns [`DeError::Unsupported`]
-        fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, DeError>
+        /// Forwards deserialization to the [`deserialize_any`](#method.deserialize_any).
+        #[inline]
+        fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
         {
-            Err(DeError::Unsupported("binary data content is not supported by XML format".into()))
+            self.deserialize_any(visitor)
         }
 
         /// Forwards deserialization to the [`deserialize_bytes`](#method.deserialize_bytes).
+        #[inline]
         fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
@@ -1910,6 +1914,7 @@ macro_rules! deserialize_primitives {
         }
 
         /// Representation of the named units the same as [unnamed units](#method.deserialize_unit).
+        #[inline]
         fn deserialize_unit_struct<V>(
             self,
             _name: &'static str,
@@ -1922,6 +1927,7 @@ macro_rules! deserialize_primitives {
         }
 
         /// Representation of tuples the same as [sequences](#method.deserialize_seq).
+        #[inline]
         fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
@@ -1930,6 +1936,7 @@ macro_rules! deserialize_primitives {
         }
 
         /// Representation of named tuples the same as [unnamed tuples](#method.deserialize_tuple).
+        #[inline]
         fn deserialize_tuple_struct<V>(
             self,
             _name: &'static str,
@@ -1953,6 +1960,7 @@ macro_rules! deserialize_primitives {
         }
 
         /// Identifiers represented as [strings](#method.deserialize_str).
+        #[inline]
         fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -509,8 +509,9 @@
 //!   /// Use unit variant, if you do not care of a content.
 //!   /// You can use tuple variant if you want to parse
 //!   /// textual content as an xs:list.
-//!   /// Struct variants are not supported and will return
-//!   /// Err(Unsupported)
+//!   /// Struct variants are will pass a string to the
+//!   /// struct enum variant visitor, which typically
+//!   /// returns Err(Custom)
 //!   #[serde(rename = "$text")]
 //!   Text(String),
 //! }
@@ -613,8 +614,9 @@
 //!   /// Use unit variant, if you do not care of a content.
 //!   /// You can use tuple variant if you want to parse
 //!   /// textual content as an xs:list.
-//!   /// Struct variants are not supported and will return
-//!   /// Err(Unsupported)
+//!   /// Struct variants are will pass a string to the
+//!   /// struct enum variant visitor, which typically
+//!   /// returns Err(Custom)
 //!   #[serde(rename = "$text")]
 //!   Text(String),
 //! }
@@ -1377,9 +1379,9 @@
 //! |Kind   |Top-level and in `$value` field          |In normal field      |In `$text` field     |
 //! |-------|-----------------------------------------|---------------------|---------------------|
 //! |Unit   |`<Unit/>`                                |`<field>Unit</field>`|`Unit`               |
-//! |Newtype|`<Newtype>42</Newtype>`                  |Err(Unsupported)     |Err(Unsupported)     |
-//! |Tuple  |`<Tuple>42</Tuple><Tuple>answer</Tuple>` |Err(Unsupported)     |Err(Unsupported)     |
-//! |Struct |`<Struct><q>42</q><a>answer</a></Struct>`|Err(Unsupported)     |Err(Unsupported)     |
+//! |Newtype|`<Newtype>42</Newtype>`                  |Err(Custom) [^0]     |Err(Custom) [^0]     |
+//! |Tuple  |`<Tuple>42</Tuple><Tuple>answer</Tuple>` |Err(Custom) [^0]     |Err(Custom) [^0]     |
+//! |Struct |`<Struct><q>42</q><a>answer</a></Struct>`|Err(Custom) [^0]     |Err(Custom) [^0]     |
 //!
 //! `$text` enum variant
 //! --------------------
@@ -1387,9 +1389,13 @@
 //! |Kind   |Top-level and in `$value` field          |In normal field      |In `$text` field     |
 //! |-------|-----------------------------------------|---------------------|---------------------|
 //! |Unit   |_(empty)_                                |`<field/>`           |_(empty)_            |
-//! |Newtype|`42`                                     |Err(Unsupported) [^1]|Err(Unsupported) [^2]|
-//! |Tuple  |`42 answer`                              |Err(Unsupported) [^3]|Err(Unsupported) [^4]|
-//! |Struct |Err(Unsupported)                         |Err(Unsupported)     |Err(Unsupported)     |
+//! |Newtype|`42`                                     |Err(Custom) [^0] [^1]|Err(Custom) [^0] [^2]|
+//! |Tuple  |`42 answer`                              |Err(Custom) [^0] [^3]|Err(Custom) [^0] [^4]|
+//! |Struct |Err(Custom) [^0]                         |Err(Custom) [^0]     |Err(Custom) [^0]     |
+//!
+//! [^0]: Error is returned by the deserialized type. In case of derived implementation a `Custom`
+//!       error will be returned, but custom deserialize implementation can successfully deserialize
+//!       value from a string which will be passed to it.
 //!
 //! [^1]: If this serialize as `<field>42</field>` then it will be ambiguity during deserialization,
 //!       because it clash with `Unit` representation in normal field.

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -886,7 +886,7 @@ mod tests {
                 match err {
                     DeError::$kind(e) => assert_eq!(e, $reason),
                     _ => panic!(
-                        "Expected `{}({})`, found `{:?}`",
+                        "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),
                         $reason,
                         err
@@ -1004,7 +1004,7 @@ mod tests {
                     match err {
                         DeError::$kind(e) => assert_eq!(e, $reason),
                         _ => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             err

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -50,7 +50,9 @@ where
                 seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
                 true,
             ),
-            DeEvent::End(e) => return Err(DeError::UnexpectedEnd(e.name().into_inner().to_vec())),
+            // SAFETY: The reader is guaranteed that we don't have unmatched tags
+            // If we here, then out deserializer has a bug
+            DeEvent::End(e) => unreachable!("{:?}", e),
             DeEvent::Eof => return Err(DeError::UnexpectedEof),
         };
         Ok((

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -205,12 +205,6 @@ pub mod serialize {
         /// [`Event::Start`]: crate::events::Event::Start
         /// [`Event::End`]: crate::events::Event::End
         UnexpectedEof,
-        /// This error indicates that [`deserialize_struct`] was called, but there
-        /// is no any XML element in the input. That means that you try to deserialize
-        /// a struct not from an XML element.
-        ///
-        /// [`deserialize_struct`]: serde::de::Deserializer::deserialize_struct
-        ExpectedStart,
         /// An attempt to deserialize to a type, that is not supported by the XML
         /// store at current position, for example, attempt to deserialize `struct`
         /// from attribute or attempt to deserialize binary data.
@@ -245,7 +239,6 @@ pub mod serialize {
                     f.write_str(")`")
                 }
                 DeError::UnexpectedEof => write!(f, "Unexpected `Event::Eof`"),
-                DeError::ExpectedStart => write!(f, "Expecting `Event::Start`"),
                 DeError::Unsupported(s) => write!(f, "Unsupported operation: {}", s),
                 #[cfg(feature = "overlapped-lists")]
                 DeError::TooManyEvents(s) => write!(f, "Deserializer buffers {} events, limit exceeded", s),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -140,8 +140,6 @@ pub enum Error {
     ///
     /// [`encoding`]: index.html#encoding
     NonDecodable(Option<Utf8Error>),
-    /// Text not found, expected `Event::Text`
-    TextNotFound,
     /// `Event::BytesDecl` must start with *version* attribute. Contains the attribute
     /// that was found or `None` if an xml declaration doesn't contain attributes.
     XmlDeclWithoutVersion(Option<String>),
@@ -248,7 +246,6 @@ impl fmt::Display for Error {
             Error::IllFormed(e) => write!(f, "ill-formed document: {}", e),
             Error::NonDecodable(None) => write!(f, "Malformed input, decoding impossible"),
             Error::NonDecodable(Some(e)) => write!(f, "Malformed UTF-8 input: {}", e),
-            Error::TextNotFound => write!(f, "Cannot read text, expecting Event::Text"),
             Error::XmlDeclWithoutVersion(e) => write!(
                 f,
                 "XmlDecl must start with 'version' attribute, found {:?}",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -74,6 +74,9 @@ pub enum IllFormedError {
     ///
     /// [`Reader::read_to_end`]: crate::reader::Reader::read_to_end
     MissedEnd(String),
+    /// The specified end tag was encountered without corresponding open tag at the
+    /// same level of hierarchy
+    UnmatchedEnd(String),
 }
 
 impl fmt::Display for IllFormedError {
@@ -84,6 +87,9 @@ impl fmt::Display for IllFormedError {
                 "start tag not closed: `</{}>` not found before end of input",
                 tag,
             ),
+            Self::UnmatchedEnd(tag) => {
+                write!(f, "close tag `</{}>` does not match any open tag", tag)
+            }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -196,14 +196,6 @@ pub mod serialize {
         /// not expecting. This happens when you try to deserialize a primitive
         /// value (numbers, strings, booleans) from an XML element.
         UnexpectedStart(Vec<u8>),
-        /// Deserializer encounter an end tag with a specified name when it is
-        /// not expecting. Usually that should not be possible, because XML reader
-        /// is not able to produce such stream of events that lead to this error.
-        ///
-        /// If you get this error this likely indicates and error in the `quick_xml`.
-        /// Please open an issue at <https://github.com/tafia/quick-xml>, provide
-        /// your Rust code and XML input.
-        UnexpectedEnd(Vec<u8>),
         /// The [`Reader`] produced [`Event::Eof`] when it is not expecting,
         /// for example, after producing [`Event::Start`] but before corresponding
         /// [`Event::End`].
@@ -249,11 +241,6 @@ pub mod serialize {
                 DeError::KeyNotRead => write!(f, "Invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
                 DeError::UnexpectedStart(e) => {
                     f.write_str("Unexpected `Event::Start(")?;
-                    write_byte_string(f, e)?;
-                    f.write_str(")`")
-                }
-                DeError::UnexpectedEnd(e) => {
-                    f.write_str("Unexpected `Event::End(")?;
                     write_byte_string(f, e)?;
                     f.write_str(")`")
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 #[cfg(feature = "serialize")]
 pub mod de;
 pub mod encoding;
-mod errors;
+pub mod errors;
 mod escapei;
 pub mod escape {
     //! Manage xml character escapes

--- a/src/name.rs
+++ b/src/name.rs
@@ -931,7 +931,7 @@ mod namespaces {
                         assert_eq!(namespace, b"not_correct_namespace");
                     }
                     x => panic!(
-                        "Expected `Error::ReservedNamespaceError`, but found {:?}",
+                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
                         x
                     ),
                 }
@@ -949,7 +949,7 @@ mod namespaces {
                         assert_eq!(namespace, b"");
                     }
                     x => panic!(
-                        "Expected `Error::ReservedNamespaceError`, but found {:?}",
+                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
                         x
                     ),
                 }
@@ -970,7 +970,7 @@ mod namespaces {
                         assert_eq!(namespace, b"http://www.w3.org/XML/1998/namespace");
                     }
                     x => panic!(
-                        "Expected `Error::ReservedNamespaceError`, but found {:?}",
+                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
                         x
                     ),
                 }
@@ -1016,7 +1016,7 @@ mod namespaces {
                         assert_eq!(namespace, b"http://www.w3.org/2000/xmlns/");
                     }
                     x => panic!(
-                        "Expected `Error::ReservedNamespaceError`, but found {:?}",
+                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
                         x
                     ),
                 }
@@ -1037,7 +1037,7 @@ mod namespaces {
                         assert_eq!(namespace, b"not_correct_namespace");
                     }
                     x => panic!(
-                        "Expected `Error::ReservedNamespaceError`, but found {:?}",
+                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
                         x
                     ),
                 }
@@ -1055,7 +1055,7 @@ mod namespaces {
                         assert_eq!(namespace, b"");
                     }
                     x => panic!(
-                        "Expected `Error::ReservedNamespaceError`, but found {:?}",
+                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
                         x
                     ),
                 }
@@ -1076,7 +1076,7 @@ mod namespaces {
                         assert_eq!(namespace, b"http://www.w3.org/2000/xmlns/");
                     }
                     x => panic!(
-                        "Expected `Error::ReservedNamespaceError`, but found {:?}",
+                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
                         x
                     ),
                 }

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -316,7 +316,7 @@ impl<R: BufRead> Reader<R> {
     /// Manages nested cases where parent and child elements have the _literally_
     /// same name.
     ///
-    /// If corresponding [`End`] event will not be found, the [`Error::UnexpectedEof`]
+    /// If a corresponding [`End`] event is not found, an error of type [`Error::IllFormed`]
     /// will be returned. In particularly, that error will be returned if you call
     /// this method without consuming the corresponding [`Start`] event first.
     ///

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -347,10 +347,7 @@ macro_rules! read_to_end {
                     }
                     depth -= 1;
                 }
-                Ok(Event::Eof) => {
-                    let name = $self.decoder().decode($end.as_ref());
-                    return Err(Error::UnexpectedEof(format!("</{:?}>", name)));
-                }
+                Ok(Event::Eof) => return Err(Error::missed_end($end, $self.decoder())),
                 _ => (),
             }
         }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1740,22 +1740,15 @@ mod test {
                     );
                 }
 
+                /// Lone closing tags are not allowed, so testing it together with start tag
                 #[$test]
-                $($async)? fn start() {
-                    let mut reader = Reader::from_str("<tag>");
+                $($async)? fn start_and_end() {
+                    let mut reader = Reader::from_str("<tag></tag>");
 
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
                         Event::Start(BytesStart::new("tag"))
                     );
-                }
-
-                #[$test]
-                $($async)? fn end() {
-                    let mut reader = Reader::from_str("</tag>");
-                    // Because we expect invalid XML, do not check that
-                    // the end name paired with the start name
-                    reader.check_end_names(false);
 
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1074,9 +1074,8 @@ mod test {
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::UnexpectedEof(s)) if s == "CData" => {}
-                            x => assert!(
-                                false,
-                                r#"Expected `UnexpectedEof("CData")`, but result is: {:?}"#,
+                            x => panic!(
+                                r#"Expected `Err(UnexpectedEof("CData"))`, but got `{:?}`"#,
                                 x
                             ),
                         }
@@ -1094,9 +1093,8 @@ mod test {
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::UnexpectedEof(s)) if s == "CData" => {}
-                            x => assert!(
-                                false,
-                                r#"Expected `UnexpectedEof("CData")`, but result is: {:?}"#,
+                            x => panic!(
+                                r#"Expected `Err(UnexpectedEof("CData"))`, but got `{:?}`"#,
                                 x
                             ),
                         }
@@ -1177,9 +1175,8 @@ mod test {
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
-                            x => assert!(
-                                false,
-                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                            x => panic!(
+                                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                                 x
                             ),
                         }
@@ -1195,9 +1192,8 @@ mod test {
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
-                            x => assert!(
-                                false,
-                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                            x => panic!(
+                                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                                 x
                             ),
                         }
@@ -1213,9 +1209,8 @@ mod test {
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
-                            x => assert!(
-                                false,
-                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                            x => panic!(
+                                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                                 x
                             ),
                         }
@@ -1231,9 +1226,8 @@ mod test {
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
-                            x => assert!(
-                                false,
-                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                            x => panic!(
+                                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                                 x
                             ),
                         }
@@ -1249,9 +1243,8 @@ mod test {
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
-                            x => assert!(
-                                false,
-                                r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                            x => panic!(
+                                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                                 x
                             ),
                         }
@@ -1315,9 +1308,8 @@ mod test {
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                                x => assert!(
-                                    false,
-                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                x => panic!(
+                                    r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                                     x
                                 ),
                             }
@@ -1333,9 +1325,8 @@ mod test {
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                                x => assert!(
-                                    false,
-                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                x => panic!(
+                                    r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                                     x
                                 ),
                             }
@@ -1369,9 +1360,8 @@ mod test {
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                                x => assert!(
-                                    false,
-                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                x => panic!(
+                                    r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                                     x
                                 ),
                             }
@@ -1395,9 +1385,8 @@ mod test {
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                                x => assert!(
-                                    false,
-                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                x => panic!(
+                                    r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                                     x
                                 ),
                             }
@@ -1413,9 +1402,8 @@ mod test {
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                                x => assert!(
-                                    false,
-                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                x => panic!(
+                                    r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                                     x
                                 ),
                             }
@@ -1449,9 +1437,8 @@ mod test {
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                                x => assert!(
-                                    false,
-                                    r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                                x => panic!(
+                                    r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                                     x
                                 ),
                             }
@@ -1644,9 +1631,8 @@ mod test {
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "CData" => {}
-                        x => assert!(
-                            false,
-                            r#"Expected `UnexpectedEof("CData")`, but result is: {:?}"#,
+                        x => panic!(
+                            r#"Expected `Err(UnexpectedEof("CData"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -1658,9 +1644,8 @@ mod test {
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "Comment" => {}
-                        x => assert!(
-                            false,
-                            r#"Expected `UnexpectedEof("Comment")`, but result is: {:?}"#,
+                        x => panic!(
+                            r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -1672,9 +1657,8 @@ mod test {
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                        x => assert!(
-                            false,
-                            r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                        x => panic!(
+                            r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -1686,9 +1670,8 @@ mod test {
 
                     match reader.$read_until_close($buf) $(.$await)? {
                         Err(Error::UnexpectedEof(s)) if s == "DOCTYPE" => {}
-                        x => assert!(
-                            false,
-                            r#"Expected `UnexpectedEof("DOCTYPE")`, but result is: {:?}"#,
+                        x => panic!(
+                            r#"Expected `Err(UnexpectedEof("DOCTYPE"))`, but got `{:?}`"#,
                             x
                         ),
                     }

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -420,7 +420,7 @@ impl<R: BufRead> NsReader<R> {
     /// Manages nested cases where parent and child elements have the _literally_
     /// same name.
     ///
-    /// If corresponding [`End`] event will not be found, the [`UnexpectedEof`]
+    /// If a corresponding [`End`] event is not found, an error of type [`IllFormed`]
     /// will be returned. In particularly, that error will be returned if you call
     /// this method without consuming the corresponding [`Start`] event first.
     ///
@@ -501,7 +501,7 @@ impl<R: BufRead> NsReader<R> {
     ///
     /// [`Start`]: Event::Start
     /// [`End`]: Event::End
-    /// [`UnexpectedEof`]: crate::errors::Error::UnexpectedEof
+    /// [`IllFormed`]: crate::errors::Error::IllFormed
     /// [`read_to_end()`]: Self::read_to_end
     /// [`BytesStart::to_end()`]: crate::events::BytesStart::to_end
     /// [`expand_empty_elements`]: Self::expand_empty_elements
@@ -663,7 +663,7 @@ impl<'i> NsReader<&'i [u8]> {
     /// Manages nested cases where parent and child elements have the _literally_
     /// same name.
     ///
-    /// If corresponding [`End`] event will not be found, the [`UnexpectedEof`]
+    /// If a corresponding [`End`] event is not found, an error of type [`IllFormed`]
     /// will be returned. In particularly, that error will be returned if you call
     /// this method without consuming the corresponding [`Start`] event first.
     ///
@@ -738,7 +738,7 @@ impl<'i> NsReader<&'i [u8]> {
     ///
     /// [`Start`]: Event::Start
     /// [`End`]: Event::End
-    /// [`UnexpectedEof`]: crate::errors::Error::UnexpectedEof
+    /// [`IllFormed`]: crate::errors::Error::IllFormed
     /// [`BytesStart::to_end()`]: crate::events::BytesStart::to_end
     /// [`expand_empty_elements`]: Self::expand_empty_elements
     /// [the specification]: https://www.w3.org/TR/xml11/#dt-etag

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -84,7 +84,7 @@ impl<'a> Reader<&'a [u8]> {
     /// Manages nested cases where parent and child elements have the _literally_
     /// same name.
     ///
-    /// If corresponding [`End`] event will not be found, the [`Error::UnexpectedEof`]
+    /// If a corresponding [`End`] event is not found, an error of type [`Error::IllFormed`]
     /// will be returned. In particularly, that error will be returned if you call
     /// this method without consuming the corresponding [`Start`] event first.
     ///

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -9,7 +9,7 @@ use crate::reader::EncodingRef;
 #[cfg(feature = "encoding")]
 use encoding_rs::{Encoding, UTF_8};
 
-use crate::errors::{Error, Result};
+use crate::errors::{Error, Result, SyntaxError};
 use crate::events::Event;
 use crate::name::QName;
 use crate::reader::{is_whitespace, BangType, ReadElementState, Reader, Span, XmlSource};
@@ -318,9 +318,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
 
         // Note: Do not update position, so the error points to a sane place
         // rather than at the EOF.
-        Err(Error::UnexpectedEof("Element".to_string()))
-
-        // FIXME: Figure out why the other one works without UnexpectedEof
+        Err(Error::Syntax(SyntaxError::UnclosedTag))
     }
 
     fn skip_whitespace(&mut self, position: &mut usize) -> Result<()> {

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -170,7 +170,7 @@ impl ReaderState {
 
                 self.opened_buffer.truncate(start);
             }
-            None if self.check_end_names => {
+            None => {
                 // Report error at start of the end tag at `<` character
                 // +2 for `<` and `>`
                 self.offset -= buf.len() + 2;
@@ -178,7 +178,6 @@ impl ReaderState {
                     decoder.decode(name).unwrap_or_default().into_owned(),
                 )));
             }
-            None => {}
         }
 
         Ok(Event::End(BytesEnd::wrap(name.into())))

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -173,7 +173,7 @@ impl ReaderState {
             }
             None => {
                 if self.check_end_names {
-                    return mismatch_err("".to_string(), &buf[1..], &mut self.offset);
+                    return mismatch_err("".to_string(), name, &mut self.offset);
                 }
             }
         }

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -161,10 +161,10 @@ impl ReaderState {
                         // Report error at start of the end tag at `<` character
                         // +2 for `<` and `>`
                         self.offset -= buf.len() + 2;
-                        return Err(Error::EndEventMismatch {
+                        return Err(Error::IllFormed(IllFormedError::MismatchedEnd {
                             expected,
                             found: decoder.decode(name).unwrap_or_default().into_owned(),
-                        });
+                        }));
                     }
                 }
 

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -2,7 +2,7 @@
 use encoding_rs::UTF_8;
 
 use crate::encoding::Decoder;
-use crate::errors::{Error, Result};
+use crate::errors::{Error, Result, SyntaxError};
 use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 #[cfg(feature = "encoding")]
 use crate::reader::EncodingRef;
@@ -203,7 +203,7 @@ impl ReaderState {
             }
         } else {
             self.offset -= len;
-            Err(Error::UnexpectedEof("XmlDecl".to_string()))
+            Err(Error::Syntax(SyntaxError::UnclosedPIOrXmlDecl))
         }
     }
 

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -148,7 +148,9 @@ impl ReaderState {
 
         let decoder = self.decoder();
         let mismatch_err = |expected: String, found: &[u8], offset: &mut usize| {
-            *offset -= buf.len();
+            // Report error at start of the end tag at `<` character
+            // +2 for `<` and `>`
+            *offset -= buf.len() + 2;
             Err(Error::EndEventMismatch {
                 expected,
                 found: decoder.decode(found).unwrap_or_default().into_owned(),

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -2,7 +2,7 @@
 use encoding_rs::UTF_8;
 
 use crate::encoding::Decoder;
-use crate::errors::{Error, Result, SyntaxError};
+use crate::errors::{Error, IllFormedError, Result, SyntaxError};
 use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 #[cfg(feature = "encoding")]
 use crate::reader::EncodingRef;
@@ -174,10 +174,9 @@ impl ReaderState {
                 // Report error at start of the end tag at `<` character
                 // +2 for `<` and `>`
                 self.offset -= buf.len() + 2;
-                return Err(Error::EndEventMismatch {
-                    expected: "".into(),
-                    found: decoder.decode(name).unwrap_or_default().into_owned(),
-                });
+                return Err(Error::IllFormed(IllFormedError::UnmatchedEnd(
+                    decoder.decode(name).unwrap_or_default().into_owned(),
+                )));
             }
             None => {}
         }

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -97,7 +97,7 @@ impl ReaderState {
                         .position(|p| buf[3 + p + 1] == b'-')
                     {
                         self.offset += len - p;
-                        return Err(Error::UnexpectedToken("--".to_string()));
+                        return Err(Error::IllFormed(IllFormedError::DoubleHyphenInComment));
                     }
                 }
                 Ok(Event::Comment(BytesText::wrap(

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -311,7 +311,7 @@ impl<'w, 'i, W: Write> Serializer for ContentSerializer<'w, 'i, W> {
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         Err(DeError::Unsupported(
-            format!("serialization of map types is not supported in `$value` field").into(),
+            "serialization of map types is not supported in `$value` field".into(),
         ))
     }
 

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -575,7 +575,7 @@ pub(super) mod tests {
                     match $data.serialize(ser).unwrap_err() {
                         DeError::$kind(e) => assert_eq!(e, $reason),
                         e => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             e
@@ -1015,7 +1015,7 @@ pub(super) mod tests {
                     match $data.serialize(ser).unwrap_err() {
                         DeError::$kind(e) => assert_eq!(e, $reason),
                         e => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             e

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -645,7 +645,7 @@ mod tests {
                     match $data.serialize(ser).unwrap_err() {
                         DeError::$kind(e) => assert_eq!(e, $reason),
                         e => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             e
@@ -1348,7 +1348,7 @@ mod tests {
                     match $data.serialize(ser).unwrap_err() {
                         DeError::$kind(e) => assert_eq!(e, $reason),
                         e => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             e

--- a/src/se/key.rs
+++ b/src/se/key.rs
@@ -216,7 +216,7 @@ mod tests {
                 match $data.serialize(ser).unwrap_err() {
                     DeError::$kind(e) => assert_eq!(e, $reason),
                     e => panic!(
-                        "Expected `{}({})`, found `{:?}`",
+                        "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),
                         $reason,
                         e

--- a/src/se/simple_type.rs
+++ b/src/se/simple_type.rs
@@ -956,7 +956,7 @@ mod tests {
                     match $data.serialize(ser).unwrap_err() {
                         DeError::$kind(e) => assert_eq!(e, $reason),
                         e => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             e
@@ -1074,7 +1074,7 @@ mod tests {
                     match $data.serialize(ser).unwrap_err() {
                         DeError::$kind(e) => assert_eq!(e, $reason),
                         e => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             e

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -4,7 +4,7 @@
 
 use std::sync::mpsc;
 
-use quick_xml::errors::SyntaxError;
+use quick_xml::errors::{IllFormedError, SyntaxError};
 use quick_xml::events::{BytesDecl, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 use quick_xml::reader::Reader;
@@ -145,14 +145,14 @@ mod issue514 {
         reader.check_end_names(true);
 
         match reader.read_event() {
-            Err(Error::EndEventMismatch { expected, found }) => {
-                assert_eq!(expected, "some-tag");
-                assert_eq!(found, "other-tag");
-            }
-            x => panic!(
-                "Expected `Err(EndEventMismatch {{ expected = 'some-tag', found = 'other-tag' }})`, but got `{:?}`",
-                x
+            Err(Error::IllFormed(cause)) => assert_eq!(
+                cause,
+                IllFormedError::MismatchedEnd {
+                    expected: "some-tag".into(),
+                    found: "other-tag".into(),
+                }
             ),
+            x => panic!("Expected `Err(IllFormed(_))`, but got `{:?}`", x),
         }
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
     }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -149,7 +149,7 @@ mod issue514 {
                 assert_eq!(found, "other-tag");
             }
             x => panic!(
-                r#"Expected `Err(EndEventMismatch("some-tag", "other-tag"))`, but found {:?}"#,
+                "Expected `Err(EndEventMismatch {{ expected = 'some-tag', found = 'other-tag' }})`, but got `{:?}`",
                 x
             ),
         }
@@ -174,7 +174,7 @@ mod issue604 {
         match reader.read_event_into(&mut buf) {
             Err(Error::UnexpectedEof(reason)) => assert_eq!(reason, "Comment"),
             x => panic!(
-                r#"Expected `Err(UnexpectedEof("Comment"))`, but found {:?}"#,
+                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                 x
             ),
         }
@@ -193,7 +193,7 @@ mod issue604 {
         match reader.read_event_into(&mut buf) {
             Err(Error::UnexpectedEof(reason)) => assert_eq!(reason, "Comment"),
             x => panic!(
-                r#"Expected `Err(UnexpectedEof("Comment"))`, but found {:?}"#,
+                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
                 x
             ),
         }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -4,6 +4,7 @@
 
 use std::sync::mpsc;
 
+use quick_xml::errors::SyntaxError;
 use quick_xml::events::{BytesDecl, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 use quick_xml::reader::Reader;
@@ -172,11 +173,8 @@ mod issue604 {
             Event::Decl(BytesDecl::new("1.0", None, None))
         );
         match reader.read_event_into(&mut buf) {
-            Err(Error::UnexpectedEof(reason)) => assert_eq!(reason, "Comment"),
-            x => panic!(
-                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
-                x
-            ),
+            Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
+            x => panic!("Expected `Err(Syntax(UnclosedComment))`, but got `{:?}`", x),
         }
         assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
     }
@@ -191,11 +189,8 @@ mod issue604 {
             Event::Decl(BytesDecl::new("1.0", None, None))
         );
         match reader.read_event_into(&mut buf) {
-            Err(Error::UnexpectedEof(reason)) => assert_eq!(reason, "Comment"),
-            x => panic!(
-                r#"Expected `Err(UnexpectedEof("Comment"))`, but got `{:?}`"#,
-                x
-            ),
+            Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
+            x => panic!("Expected `Err(Syntax(UnclosedComment))`, but got `{:?}`", x),
         }
         assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
     }

--- a/tests/serde-de-enum.rs
+++ b/tests/serde-de-enum.rs
@@ -320,6 +320,7 @@ mod externally_tagged {
         /// Struct variant cannot be directly deserialized from `Text` / `CData` events
         mod struct_ {
             use super::*;
+            use pretty_assertions::assert_eq;
 
             #[derive(Debug, Deserialize, PartialEq)]
             enum Text {
@@ -330,24 +331,42 @@ mod externally_tagged {
             #[test]
             fn text() {
                 match from_str::<Text>(" text ") {
-                    Err(DeError::Unsupported(_)) => {}
-                    x => panic!("Expected `Err(Unsupported(_))`, but got `{:?}`", x),
+                    Err(DeError::Custom(reason)) => assert_eq!(
+                        reason,
+                        "invalid type: string \"text\", expected struct variant Text::Struct"
+                    ),
+                    x => panic!(
+                        r#"Expected `Err(Custom("invalid type: string \"text\", expected struct variant Text::Struct"))`, but got `{:?}`"#,
+                        x
+                    ),
                 }
             }
 
             #[test]
             fn cdata() {
                 match from_str::<Text>("<![CDATA[ cdata ]]>") {
-                    Err(DeError::Unsupported(_)) => {}
-                    x => panic!("Expected `Err(Unsupported(_))`, but got `{:?}`", x),
+                    Err(DeError::Custom(reason)) => assert_eq!(
+                        reason,
+                        "invalid type: string \" cdata \", expected struct variant Text::Struct"
+                    ),
+                    x => panic!(
+                        r#"Expected `Err(Custom("invalid type: string \" cdata \", expected struct variant Text::Struct"))`, but got `{:?}`"#,
+                        x
+                    ),
                 }
             }
 
             #[test]
             fn mixed() {
                 match from_str::<Text>(" te <![CDATA[ cdata ]]> xt ") {
-                    Err(DeError::Unsupported(_)) => {}
-                    x => panic!("Expected `Err(Unsupported(_))`, but got `{:?}`", x),
+                    Err(DeError::Custom(reason)) => assert_eq!(
+                        reason,
+                        "invalid type: string \"te  cdata  xt\", expected struct variant Text::Struct"
+                    ),
+                    x => panic!(
+                        r#"Expected `Err(Custom("invalid type: string \"te  cdata  xt\", expected struct variant Text::Struct"))`, but got `{:?}`"#,
+                        x
+                    ),
                 }
             }
         }

--- a/tests/serde-de-enum.rs
+++ b/tests/serde-de-enum.rs
@@ -331,7 +331,7 @@ mod externally_tagged {
             fn text() {
                 match from_str::<Text>(" text ") {
                     Err(DeError::Unsupported(_)) => {}
-                    x => panic!("Expected `Err(Unsupported(_))`, but found {:?}", x),
+                    x => panic!("Expected `Err(Unsupported(_))`, but got `{:?}`", x),
                 }
             }
 
@@ -339,7 +339,7 @@ mod externally_tagged {
             fn cdata() {
                 match from_str::<Text>("<![CDATA[ cdata ]]>") {
                     Err(DeError::Unsupported(_)) => {}
-                    x => panic!("Expected `Err(Unsupported(_))`, but found {:?}", x),
+                    x => panic!("Expected `Err(Unsupported(_))`, but got `{:?}`", x),
                 }
             }
 
@@ -347,7 +347,7 @@ mod externally_tagged {
             fn mixed() {
                 match from_str::<Text>(" te <![CDATA[ cdata ]]> xt ") {
                     Err(DeError::Unsupported(_)) => {}
-                    x => panic!("Expected `Err(Unsupported(_))`, but found {:?}", x),
+                    x => panic!("Expected `Err(Unsupported(_))`, but got `{:?}`", x),
                 }
             }
         }

--- a/tests/serde-de-seq.rs
+++ b/tests/serde-de-seq.rs
@@ -236,7 +236,7 @@ mod fixed_name {
                     assert_eq!(e, "invalid length 2, expected an array of length 3")
                 }
                 e => panic!(
-                    r#"Expected `Err(Custom("invalid length 2, expected an array of length 3"))`, but found {:?}"#,
+                    r#"Expected `Err(Custom("invalid length 2, expected an array of length 3"))`, but got `{:?}`"#,
                     e
                 ),
             }
@@ -262,7 +262,7 @@ mod fixed_name {
             match data {
                 Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `item`"),
                 e => panic!(
-                    r#"Expected `Err(Custom("duplicate field `item`"))`, but found {:?}"#,
+                    r#"Expected `Err(Custom("duplicate field `item`"))`, but got `{:?}`"#,
                     e
                 ),
             }
@@ -286,7 +286,7 @@ mod fixed_name {
             match data {
                 Err(DeError::Custom(e)) => assert_eq!(e, "missing field `item`"),
                 e => panic!(
-                    r#"Expected `Err(Custom("missing field `item`"))`, but found {:?}"#,
+                    r#"Expected `Err(Custom("missing field `item`"))`, but got `{:?}`"#,
                     e
                 ),
             }
@@ -352,7 +352,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -386,7 +386,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -460,7 +460,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -495,7 +495,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -569,7 +569,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -604,7 +604,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -663,7 +663,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -699,7 +699,7 @@ mod fixed_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1042,7 +1042,7 @@ mod fixed_name {
             match data {
                 Err(DeError::Custom(e)) => assert_eq!(e, "missing field `item`"),
                 e => panic!(
-                    r#"Expected `Err(Custom("missing field `item`"))`, but found {:?}"#,
+                    r#"Expected `Err(Custom("missing field `item`"))`, but got `{:?}`"#,
                     e
                 ),
             }
@@ -1124,7 +1124,7 @@ mod fixed_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `item`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `item`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1165,7 +1165,7 @@ mod fixed_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `outer`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1260,7 +1260,7 @@ mod fixed_name {
                         assert_eq!(e, "duplicate field `item`")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `item`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1303,7 +1303,7 @@ mod fixed_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `outer`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1398,7 +1398,7 @@ mod fixed_name {
                         assert_eq!(e, "duplicate field `item`")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `item`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1441,7 +1441,7 @@ mod fixed_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `outer`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1511,7 +1511,7 @@ mod fixed_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `item`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `item`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `item`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -1553,7 +1553,7 @@ mod fixed_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `outer`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `outer`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `outer`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -2128,7 +2128,7 @@ mod variable_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -2174,7 +2174,7 @@ mod variable_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -2270,7 +2270,7 @@ mod variable_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -2316,7 +2316,7 @@ mod variable_name {
                         assert_eq!(e, "invalid length 1, expected an array of length 3")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                        r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -2435,7 +2435,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 2")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 2"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2472,7 +2472,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 3")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2512,7 +2512,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 2")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 2"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2552,7 +2552,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 3")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2667,7 +2667,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 2")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 2"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2704,7 +2704,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 3")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2744,7 +2744,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 2")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 2")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 2"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2784,7 +2784,7 @@ mod variable_name {
                                 assert_eq!(e, "invalid length 1, expected an array of length 3")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                                r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -2863,7 +2863,7 @@ mod variable_name {
                             assert_eq!(e, "invalid length 1, expected an array of length 3")
                         }
                         e => panic!(
-                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                             e
                         ),
                     }
@@ -3270,7 +3270,7 @@ mod variable_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -3316,7 +3316,7 @@ mod variable_name {
                         assert_eq!(e, "duplicate field `$value`")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -3410,7 +3410,7 @@ mod variable_name {
                 match data {
                     Err(DeError::Custom(e)) => assert_eq!(e, "duplicate field `$value`"),
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -3456,7 +3456,7 @@ mod variable_name {
                         assert_eq!(e, "duplicate field `$value`")
                     }
                     e => panic!(
-                        r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                        r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                         e
                     ),
                 }
@@ -3575,7 +3575,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `element`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `element`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -3612,7 +3612,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `$value`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -3652,7 +3652,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `element`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `element`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -3692,7 +3692,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `$value`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -3807,7 +3807,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `element`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `element`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -3844,7 +3844,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `$value`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -3884,7 +3884,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `element`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `element`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `element`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -3924,7 +3924,7 @@ mod variable_name {
                                 assert_eq!(e, "duplicate field `$value`")
                             }
                             e => panic!(
-                                r#"Expected Err(Custom("duplicate field `$value`")), got {:?}"#,
+                                r#"Expected `Err(Custom("duplicate field `$value`"))`, but got `{:?}`"#,
                                 e
                             ),
                         }
@@ -4003,7 +4003,7 @@ mod variable_name {
                             assert_eq!(e, "invalid length 1, expected an array of length 3")
                         }
                         e => panic!(
-                            r#"Expected Err(Custom("invalid length 1, expected an array of length 3")), got {:?}"#,
+                            r#"Expected `Err(Custom("invalid length 1, expected an array of length 3"))`, but got `{:?}`"#,
                             e
                         ),
                     }

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -556,6 +556,8 @@ macro_rules! maplike_errors {
     ) => {
         mod non_closed {
             use super::*;
+            use pretty_assertions::assert_eq;
+            use quick_xml::errors::{Error, IllFormedError};
 
             /// For struct we expect that error about not closed tag appears
             /// earlier than error about missing fields
@@ -594,8 +596,13 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root float="42"><string>answer"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => {}
-                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                        assert_eq!(cause, IllFormedError::MissedEnd("string".into()))
+                    }
+                    x => panic!(
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
         }

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -130,11 +130,9 @@ mod trivial {
             #[test]
             fn byte_buf() {
                 match from_str::<ByteBuf>($value) {
-                    Err(DeError::Unsupported(msg)) => {
-                        assert_eq!(msg, "binary data content is not supported by XML format")
-                    }
+                    Err(DeError::UnexpectedEof) => {}
                     x => panic!(
-                        r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                        r#"Expected `Err(UnexpectedEof)`, but got `{:?}`"#,
                         x
                     ),
                 }
@@ -144,11 +142,9 @@ mod trivial {
             #[test]
             fn bytes() {
                 match from_str::<Bytes>($value) {
-                    Err(DeError::Unsupported(msg)) => {
-                        assert_eq!(msg, "binary data content is not supported by XML format")
-                    }
+                    Err(DeError::UnexpectedEof) => {}
                     x => panic!(
-                        r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                        r#"Expected `Err(UnexpectedEof)`, but got `{:?}`"#,
                         x
                     ),
                 }
@@ -170,7 +166,6 @@ mod trivial {
     /// Empty document should considered invalid no matter what type we try to deserialize
     mod empty_doc {
         use super::*;
-        use pretty_assertions::assert_eq;
 
         eof!("");
     }
@@ -178,7 +173,6 @@ mod trivial {
     /// Document that contains only comment should be handled as if it is empty
     mod only_comment {
         use super::*;
-        use pretty_assertions::assert_eq;
 
         eof!("<!--comment-->");
     }

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -566,8 +566,13 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root>"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => {}
-                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                        assert_eq!(cause, IllFormedError::MissedEnd("root".into()))
+                    }
+                    x => panic!(
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
 
@@ -576,8 +581,13 @@ macro_rules! maplike_errors {
                 let data = from_str::<$attributes>(r#"<root float="42" string="answer">"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => {}
-                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                        assert_eq!(cause, IllFormedError::MissedEnd("root".into()))
+                    }
+                    x => panic!(
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
 
@@ -586,8 +596,13 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root float="42"><string>answer</string>"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => {}
-                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                        assert_eq!(cause, IllFormedError::MissedEnd("root".into()))
+                    }
+                    x => panic!(
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
 

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -354,11 +354,11 @@ mod trivial {
         #[test]
         fn byte_buf() {
             match from_str::<Trivial<ByteBuf>>("<root>escaped&#x20;byte_buf</root>") {
-                Err(DeError::Unsupported(msg)) => {
-                    assert_eq!(msg, "binary data content is not supported by XML format")
+                Err(DeError::Custom(msg)) => {
+                    assert_eq!(msg, "invalid type: string \"escaped byte_buf\", expected byte data")
                 }
                 x => panic!(
-                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Custom("invalid type: string \"escaped byte_buf\", expected byte data"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -368,11 +368,11 @@ mod trivial {
         #[test]
         fn bytes() {
             match from_str::<Trivial<Bytes>>("<root>escaped&#x20;byte_buf</root>") {
-                Err(DeError::Unsupported(msg)) => {
-                    assert_eq!(msg, "binary data content is not supported by XML format")
+                Err(DeError::Custom(msg)) => {
+                    assert_eq!(msg, "invalid type: string \"escaped byte_buf\", expected borrowed bytes")
                 }
                 x => panic!(
-                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Custom("invalid type: string \"escaped byte_buf\", expected borrowed bytes"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -417,11 +417,11 @@ mod trivial {
         #[test]
         fn byte_buf() {
             match from_str::<Trivial<ByteBuf>>("<root><![CDATA[escaped&#x20;byte_buf]]></root>") {
-                Err(DeError::Unsupported(msg)) => {
-                    assert_eq!(msg, "binary data content is not supported by XML format")
+                Err(DeError::Custom(msg)) => {
+                    assert_eq!(msg, "invalid type: string \"escaped&#x20;byte_buf\", expected byte data")
                 }
                 x => panic!(
-                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Custom("invalid type: string \"escaped&#x20;byte_buf\", expected byte data"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -431,11 +431,11 @@ mod trivial {
         #[test]
         fn bytes() {
             match from_str::<Trivial<Bytes>>("<root><![CDATA[escaped&#x20;byte_buf]]></root>") {
-                Err(DeError::Unsupported(msg)) => {
-                    assert_eq!(msg, "binary data content is not supported by XML format")
+                Err(DeError::Custom(msg)) => {
+                    assert_eq!(msg, "invalid type: string \"escaped&#x20;byte_buf\", expected borrowed bytes")
                 }
                 x => panic!(
-                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Custom("invalid type: string \"escaped&#x20;byte_buf\", expected borrowed bytes"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -1158,7 +1158,7 @@ mod xml_schema_lists {
             "third 3".to_string(),
         ]);
         err!(byte_buf: ByteBuf = r#"<root list="first second  third&#x20;3"/>"#
-                => Unsupported("byte arrays are not supported as `xs:list` items"));
+            => Custom("invalid type: string \"first\", expected byte data"));
 
         list!(unit: () = r#"<root list="1 second  false"/>"# => vec![(), (), ()]);
     }
@@ -1209,7 +1209,7 @@ mod xml_schema_lists {
                 "3".to_string(),
             ]);
             err!(byte_buf: ByteBuf = "<root>first second  third&#x20;3</root>"
-                => Unsupported("byte arrays are not supported as `xs:list` items"));
+                => Custom("invalid type: string \"first\", expected byte data"));
 
             list!(unit: () = "<root>1 second  false</root>" => vec![(), (), ()]);
         }
@@ -1248,7 +1248,7 @@ mod xml_schema_lists {
                 "third&#x20;3".to_string(),
             ]);
             err!(byte_buf: ByteBuf = "<root>first second  third&#x20;3</root>"
-                => Unsupported("byte arrays are not supported as `xs:list` items"));
+                => Custom("invalid type: string \"first\", expected byte data"));
 
             list!(unit: () = "<root>1 second  false</root>" => vec![(), (), ()]);
         }

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -890,8 +890,14 @@ mod struct_ {
             match from_str::<Elements>(
                 "\nexcess text\t<root><float>42</float><string>answer</string></root>",
             ) {
-                Err(DeError::ExpectedStart) => {}
-                x => panic!("Expected `Err(ExpectedStart)`, but got `{:?}`", x),
+                Err(DeError::Custom(reason)) => assert_eq!(
+                    reason,
+                    "invalid type: string \"excess text\", expected struct Elements",
+                ),
+                x => panic!(
+                    r#"Expected `Err(Custom("invalid type: string \"excess text\", expected struct Elements"))`, but got `{:?}`"#,
+                    x
+                ),
             };
         }
 
@@ -901,8 +907,14 @@ mod struct_ {
             match from_str::<Elements>(
                 "<![CDATA[excess cdata]]><root><float>42</float><string>answer</string></root>",
             ) {
-                Err(DeError::ExpectedStart) => {}
-                x => panic!("Expected `Err(ExpectedStart)`, but got `{:?}`", x),
+                Err(DeError::Custom(reason)) => assert_eq!(
+                    reason,
+                    "invalid type: string \"excess cdata\", expected struct Elements",
+                ),
+                x => panic!(
+                    r#"Expected `Err(Custom("invalid type: string \"excess cdata\", expected struct Elements"))`, but got `{:?}`"#,
+                    x
+                ),
             };
         }
 

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -225,10 +225,14 @@ mod trivial {
 
                 #[test]
                 fn field() {
-                    let item: Field<$type> = from_str(&format!("<root><value>{}</value></root>", $value)).unwrap();
+                    let item: Field<$type> =
+                        from_str(&format!("<root><value>{}</value></root>", $value)).unwrap();
                     assert_eq!(item, Field { value: $expected });
 
-                    match from_str::<Field<$type>>(&format!("<root><value><nested>{}</nested></value></root>", $value)) {
+                    match from_str::<Field<$type>>(&format!(
+                        "<root><value><nested>{}</nested></value></root>",
+                        $value
+                    )) {
                         // Expected unexpected start element `<nested>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"nested"),
                         x => panic!(
@@ -237,7 +241,10 @@ mod trivial {
                         ),
                     }
 
-                    match from_str::<Field<$type>>(&format!("<root><value>{}<something-else/></value></root>", $value)) {
+                    match from_str::<Field<$type>>(&format!(
+                        "<root><value>{}<something-else/></value></root>",
+                        $value
+                    )) {
                         // Expected unexpected start element `<something-else>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"something-else"),
                         x => panic!(
@@ -246,7 +253,10 @@ mod trivial {
                         ),
                     }
 
-                    match from_str::<Field<$type>>(&format!("<root><value><something-else/>{}</value></root>", $value)) {
+                    match from_str::<Field<$type>>(&format!(
+                        "<root><value><something-else/>{}</value></root>",
+                        $value
+                    )) {
                         // Expected unexpected start element `<something-else>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"something-else"),
                         x => panic!(
@@ -259,20 +269,26 @@ mod trivial {
                 /// Tests deserialization from top-level tag content: `<root>...content...</root>`
                 #[test]
                 fn text() {
-                    let item: Trivial<$type> = from_str(&format!("<root>{}</root>", $value)).unwrap();
+                    let item: Trivial<$type> =
+                        from_str(&format!("<root>{}</root>", $value)).unwrap();
                     assert_eq!(item, Trivial { value: $expected });
 
                     // Unlike `naked` test, here we have a struct that is serialized to XML with
                     // an implicit field `$text` and some other field "something-else" which not interested
                     // for us in the Trivial structure. If you want the same behavior as for naked primitive,
                     // use `$value` field which would consume all data, unless a dedicated field would present
-                    let item: Trivial<$type> = from_str(&format!("<root>{}<something-else/></root>", $value)).unwrap();
+                    let item: Trivial<$type> =
+                        from_str(&format!("<root>{}<something-else/></root>", $value)).unwrap();
                     assert_eq!(item, Trivial { value: $expected });
 
-                    let item: Trivial<$type> = from_str(&format!("<root><something-else/>{}</root>", $value)).unwrap();
+                    let item: Trivial<$type> =
+                        from_str(&format!("<root><something-else/>{}</root>", $value)).unwrap();
                     assert_eq!(item, Trivial { value: $expected });
 
-                    match from_str::<Trivial<$type>>(&format!("<root><nested>{}</nested></root>", $value)) {
+                    match from_str::<Trivial<$type>>(&format!(
+                        "<root><nested>{}</nested></root>",
+                        $value
+                    )) {
                         // Expected unexpected start element `<nested>`
                         Err(DeError::Custom(reason)) => assert_eq!(reason, "missing field `$text`"),
                         x => panic!(
@@ -602,7 +618,10 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
-                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
+                    x => panic!(
+                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
 
@@ -615,7 +634,10 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
-                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
+                    x => panic!(
+                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
 
@@ -628,7 +650,10 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
-                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
+                    x => panic!(
+                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
 
@@ -641,7 +666,10 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
-                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
+                    x => panic!(
+                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        x
+                    ),
                 }
             }
         }
@@ -1315,9 +1343,7 @@ mod borrow {
 
         #[test]
         fn top_level() {
-            match from_str::<&str>(
-                r#"<root>with escape sequence: &lt;</root>"#,
-            ) {
+            match from_str::<&str>(r#"<root>with escape sequence: &lt;</root>"#) {
                 Err(DeError::Custom(reason)) => assert_eq!(
                     reason,
                     "invalid type: string \"with escape sequence: <\", expected a borrowed string"

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -593,6 +593,20 @@ macro_rules! maplike_errors {
 
             #[test]
             fn elements_child() {
+                // Reaches `Deserializer::read_text` when text is not present
+                let data = from_str::<$mixed>(r#"<root float="42"><string>"#);
+
+                match data {
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
+                        assert_eq!(cause, IllFormedError::MissedEnd("string".into()))
+                    }
+                    x => panic!(
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
+                        x
+                    ),
+                }
+
+                // Reaches `Deserializer::read_text` when text is present
                 let data = from_str::<$mixed>(r#"<root float="42"><string>answer"#);
 
                 match data {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -70,7 +70,7 @@ fn ignored_any() {
     let err = from_str::<IgnoredAny>("");
     match err {
         Err(DeError::UnexpectedEof) => {}
-        other => panic!("Expected `UnexpectedEof`, found {:?}", other),
+        x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
     }
 
     from_str::<IgnoredAny>(r#"<empty/>"#).unwrap();
@@ -91,9 +91,9 @@ mod trivial {
             #[test]
             fn $name() {
                 match from_str::<$type>($value) {
-                    Err(DeError::UnexpectedEof) => (),
+                    Err(DeError::UnexpectedEof) => {}
                     x => panic!(
-                        r#"Expected `Err(DeError::UnexpectedEof)`, but got `{:?}`"#,
+                        r#"Expected `Err(UnexpectedEof)`, but got `{:?}`"#,
                         x
                     ),
                 }
@@ -134,7 +134,7 @@ mod trivial {
                         assert_eq!(msg, "binary data content is not supported by XML format")
                     }
                     x => panic!(
-                        r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                        r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
                         x
                     ),
                 }
@@ -148,7 +148,7 @@ mod trivial {
                         assert_eq!(msg, "binary data content is not supported by XML format")
                     }
                     x => panic!(
-                        r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                        r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
                         x
                     ),
                 }
@@ -157,9 +157,9 @@ mod trivial {
             #[test]
             fn unit() {
                 match from_str::<()>($value) {
-                    Err(DeError::UnexpectedEof) => (),
+                    Err(DeError::UnexpectedEof) => {}
                     x => panic!(
-                        r#"Expected `Err(DeError::UnexpectedEof)`, but got `{:?}`"#,
+                        r#"Expected `Err(UnexpectedEof)`, but got `{:?}`"#,
                         x
                     ),
                 }
@@ -199,7 +199,7 @@ mod trivial {
                         // Expected unexpected start element `<nested>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"nested"),
                         x => panic!(
-                            r#"Expected `Err(DeError::UnexpectedStart("nested"))`, but got `{:?}`"#,
+                            r#"Expected `Err(UnexpectedStart("nested"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -208,7 +208,7 @@ mod trivial {
                         // Expected unexpected start element `<something-else>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"something-else"),
                         x => panic!(
-                            r#"Expected `Err(DeError::UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -217,7 +217,7 @@ mod trivial {
                         // Expected unexpected start element `<something-else>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"something-else"),
                         x => panic!(
-                            r#"Expected `Err(DeError::UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -232,7 +232,7 @@ mod trivial {
                         // Expected unexpected start element `<nested>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"nested"),
                         x => panic!(
-                            r#"Expected `Err(DeError::UnexpectedStart("nested"))`, but got `{:?}`"#,
+                            r#"Expected `Err(UnexpectedStart("nested"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -241,7 +241,7 @@ mod trivial {
                         // Expected unexpected start element `<something-else>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"something-else"),
                         x => panic!(
-                            r#"Expected `Err(DeError::UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -250,7 +250,7 @@ mod trivial {
                         // Expected unexpected start element `<something-else>`
                         Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, b"something-else"),
                         x => panic!(
-                            r#"Expected `Err(DeError::UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -276,7 +276,7 @@ mod trivial {
                         // Expected unexpected start element `<nested>`
                         Err(DeError::Custom(reason)) => assert_eq!(reason, "missing field `$text`"),
                         x => panic!(
-                            r#"Expected `Err(DeError::Custom("missing field `$text`"))`, but got `{:?}`"#,
+                            r#"Expected `Err(Custom("missing field `$text`"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -342,7 +342,7 @@ mod trivial {
                     assert_eq!(msg, "binary data content is not supported by XML format")
                 }
                 x => panic!(
-                    r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -356,7 +356,7 @@ mod trivial {
                     assert_eq!(msg, "binary data content is not supported by XML format")
                 }
                 x => panic!(
-                    r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -405,7 +405,7 @@ mod trivial {
                     assert_eq!(msg, "binary data content is not supported by XML format")
                 }
                 x => panic!(
-                    r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -419,7 +419,7 @@ mod trivial {
                     assert_eq!(msg, "binary data content is not supported by XML format")
                 }
                 x => panic!(
-                    r#"Expected `Err(DeError::Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Unsupported("binary data content is not supported by XML format"))`, but got `{:?}`"#,
                     x
                 ),
             }
@@ -554,8 +554,8 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root>"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => (),
-                    _ => panic!("Expected `UnexpectedEof`, found {:?}", data),
+                    Err(DeError::UnexpectedEof) => {}
+                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
                 }
             }
 
@@ -564,8 +564,8 @@ macro_rules! maplike_errors {
                 let data = from_str::<$attributes>(r#"<root float="42" string="answer">"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => (),
-                    _ => panic!("Expected `UnexpectedEof`, found {:?}", data),
+                    Err(DeError::UnexpectedEof) => {}
+                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
                 }
             }
 
@@ -574,8 +574,8 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root float="42"><string>answer</string>"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => (),
-                    _ => panic!("Expected `UnexpectedEof`, found {:?}", data),
+                    Err(DeError::UnexpectedEof) => {}
+                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
                 }
             }
 
@@ -584,8 +584,8 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root float="42"><string>answer"#);
 
                 match data {
-                    Err(DeError::UnexpectedEof) => (),
-                    _ => panic!("Expected `UnexpectedEof`, found {:?}", data),
+                    Err(DeError::UnexpectedEof) => {}
+                    x => panic!("Expected `Err(UnexpectedEof)`, but got `{:?}`", x),
                 }
             }
         }
@@ -601,8 +601,8 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root></mismatched>"#);
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => (),
-                    _ => panic!("Expected `InvalidXml(EndEventMismatch)`, found {:?}", data),
+                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
                 }
             }
 
@@ -614,8 +614,8 @@ macro_rules! maplike_errors {
                 );
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => (),
-                    _ => panic!("Expected `InvalidXml(EndEventMismatch)`, found {:?}", data),
+                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
                 }
             }
 
@@ -627,8 +627,8 @@ macro_rules! maplike_errors {
                 );
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => (),
-                    _ => panic!("Expected `InvalidXml(EndEventMismatch)`, found {:?}", data),
+                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
                 }
             }
 
@@ -640,8 +640,8 @@ macro_rules! maplike_errors {
                 );
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => (),
-                    _ => panic!("Expected `InvalidXml(EndEventMismatch)`, found {:?}", data),
+                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    x => panic!("Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`", x),
                 }
             }
         }
@@ -862,8 +862,8 @@ mod struct_ {
             match from_str::<Elements>(
                 "\nexcess text\t<root><float>42</float><string>answer</string></root>",
             ) {
-                Err(DeError::ExpectedStart) => (),
-                x => panic!("Expected Err(ExpectedStart), but got {:?}", x),
+                Err(DeError::ExpectedStart) => {}
+                x => panic!("Expected `Err(ExpectedStart)`, but got `{:?}`", x),
             };
         }
 
@@ -873,8 +873,8 @@ mod struct_ {
             match from_str::<Elements>(
                 "<![CDATA[excess cdata]]><root><float>42</float><string>answer</string></root>",
             ) {
-                Err(DeError::ExpectedStart) => (),
-                x => panic!("Expected Err(ExpectedStart), but got {:?}", x),
+                Err(DeError::ExpectedStart) => {}
+                x => panic!("Expected `Err(ExpectedStart)`, but got `{:?}`", x),
             };
         }
 
@@ -1069,7 +1069,7 @@ mod xml_schema_lists {
                 match err {
                     DeError::$kind(e) => assert_eq!(e, $err),
                     _ => panic!(
-                        "Expected `{}({})`, found `{:?}`",
+                        "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),
                         $err,
                         err
@@ -1323,7 +1323,7 @@ mod borrow {
                     "invalid type: string \"with escape sequence: <\", expected a borrowed string"
                 ),
                 e => panic!(
-                    "Expected `Err(Custom(invalid type: string \"with escape sequence: <\", expected a borrowed string))`, but found {:?}",
+                    r#"Expected `Err(Custom("invalid type: string \"with escape sequence: <\", expected a borrowed string"))`, but got `{:?}`"#,
                     e
                 ),
             }
@@ -1342,7 +1342,7 @@ mod borrow {
                     "invalid type: string \"with escape sequence: <\", expected a borrowed string"
                 ),
                 e => panic!(
-                    "Expected `Err(Custom(invalid type: string \"with escape sequence: <\", expected a borrowed string))`, but found {:?}",
+                    r#"Expected `Err(Custom("invalid type: string \"with escape sequence: <\", expected a borrowed string"))`, but got `{:?}`"#,
                     e
                 ),
             }
@@ -1356,7 +1356,7 @@ mod borrow {
                     "invalid type: string \"with \\\"escape\\\" sequences\", expected a borrowed string"
                 ),
                 e => panic!(
-                    "Expected `Err(Custom(invalid type: string \"with \"escape\" sequences\", expected a borrowed string))`, but found {:?}",
+                    r#"Expected `Err(Custom("invalid type: string \"with \"escape\" sequences\", expected a borrowed string"))`, but got `{:?}`"#,
                     e
                 ),
             }

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -652,7 +652,8 @@ macro_rules! maplike_errors {
 
         mod mismatched_end {
             use super::*;
-            use quick_xml::Error::EndEventMismatch;
+            use pretty_assertions::assert_eq;
+            use quick_xml::errors::{Error, IllFormedError};
 
             /// For struct we expect that error about mismatched tag appears
             /// earlier than error about missing fields
@@ -661,9 +662,15 @@ macro_rules! maplike_errors {
                 let data = from_str::<$mixed>(r#"<root></mismatched>"#);
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
+                        cause,
+                        IllFormedError::MismatchedEnd {
+                            expected: "root".into(),
+                            found: "mismatched".into(),
+                        }
+                    ),
                     x => panic!(
-                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
                         x
                     ),
                 }
@@ -677,9 +684,15 @@ macro_rules! maplike_errors {
                 );
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
+                        cause,
+                        IllFormedError::MismatchedEnd {
+                            expected: "root".into(),
+                            found: "mismatched".into(),
+                        }
+                    ),
                     x => panic!(
-                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
                         x
                     ),
                 }
@@ -693,9 +706,15 @@ macro_rules! maplike_errors {
                 );
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
+                        cause,
+                        IllFormedError::MismatchedEnd {
+                            expected: "root".into(),
+                            found: "mismatched".into(),
+                        }
+                    ),
                     x => panic!(
-                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
                         x
                     ),
                 }
@@ -709,9 +728,15 @@ macro_rules! maplike_errors {
                 );
 
                 match data {
-                    Err(DeError::InvalidXml(EndEventMismatch { .. })) => {}
+                    Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
+                        cause,
+                        IllFormedError::MismatchedEnd {
+                            expected: "string".into(),
+                            found: "mismatched".into(),
+                        }
+                    ),
                     x => panic!(
-                        "Expected `Err(InvalidXml(EndEventMismatch {{ .. }}))`, but got `{:?}`",
+                        "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
                         x
                     ),
                 }

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -255,7 +255,7 @@ mod without_root {
                 match $data.serialize(ser) {
                     Err(DeError::$kind(e)) => assert_eq!(e, $reason),
                     e => panic!(
-                        "Expected `{}({})`, found `{:?}`",
+                        "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),
                         $reason,
                         e
@@ -1301,7 +1301,7 @@ mod without_root {
                     match $data.serialize(ser) {
                         Err(DeError::$kind(e)) => assert_eq!(e, $reason),
                         e => panic!(
-                            "Expected `{}({})`, found `{:?}`",
+                            "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
                             $reason,
                             e
@@ -1768,7 +1768,7 @@ mod with_root {
                 match $data.serialize(ser) {
                     Err(DeError::$kind(e)) => assert_eq!(e, $reason),
                     e => panic!(
-                        "Expected `{}({})`, found `{:?}`",
+                        "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),
                         $reason,
                         e

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -404,9 +404,9 @@ fn test_offset_err_end_element() {
     r.trim_text(true);
 
     match r.read_event() {
-        Err(_) if r.buffer_position() == 2 => (), // error at char 2: no opening tag
+        Err(_) if r.buffer_position() == 0 => (), // error at char 0: no opening tag
         Err(e) => panic!(
-            "expecting buf_pos = 2, found {}, err: {:?}",
+            "expecting buf_pos = 0, found {}, err: {:?}",
             r.buffer_position(),
             e
         ),

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -201,7 +201,7 @@ fn dashes_in_comments() {
     test(
         r#"<!-- comment -- --><hello/>"#,
         r#"
-        |Error: Unexpected token '--'
+        |Error: ill-formed document: forbidden string `--` was found in a comment
         "#,
         true,
     );
@@ -209,7 +209,7 @@ fn dashes_in_comments() {
     test(
         r#"<!-- comment ---><hello/>"#,
         r#"
-        |Error: Unexpected token '--'
+        |Error: ill-formed document: forbidden string `--` was found in a comment
         "#,
         true,
     );

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -182,7 +182,7 @@ fn sample_ns_short() {
 fn eof_1() {
     test(
         r#"<?xml"#,
-        r#"Error: Unexpected EOF during reading XmlDecl"#,
+        r#"Error: syntax error: processing instruction or xml declaration not closed: `?>` not found before end of input"#,
         true,
     );
 }
@@ -191,7 +191,7 @@ fn eof_1() {
 fn bad_1() {
     test(
         r#"<?xml&.,"#,
-        r#"1:6 Error: Unexpected EOF during reading XmlDecl"#,
+        r#"1:6 Error: syntax error: processing instruction or xml declaration not closed: `?>` not found before end of input"#,
         true,
     );
 }


### PR DESCRIPTION
This PR does cleanup of our errors, making them more consistent. In particular, now syntax errors decoupled from other errors and this will allow us to have `no_std` XML parser in the future.

In addition, I also review the way how errors is reported by the serde deserializer. I already wrote my points about correct deserializer behavior [here](https://github.com/serde-rs/serde/pull/2639#issuecomment-1783793554) and in this PR I implement them -- I avoid to return errors if requested data does not match existing data. Instead deserializer will provide the data and the `Visitor` will return an error if it wish.