### PR TITLE
Fix wrong disregarding of not closed markup, such as lone `<`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ configuration is serializable.
 
 ### Bug Fixes
 
+- [#622]: Fix wrong disregarding of not closed markup, such as lone `<`.
+
 ### Misc Changes
 
 - [#675]: Minimum supported version of serde raised to 1.0.139
@@ -36,6 +38,7 @@ configuration is serializable.
   - `Error::UnexpectedToken` replaced by `IllFormedError::DoubleHyphenInComment`
 
 [#513]: https://github.com/tafia/quick-xml/issues/513
+[#622]: https://github.com/tafia/quick-xml/issues/622
 [#675]: https://github.com/tafia/quick-xml/pull/675
 [#677]: https://github.com/tafia/quick-xml/pull/677
 

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -4,13 +4,13 @@
 
 use tokio::io::{self, AsyncBufRead, AsyncBufReadExt};
 
+use crate::errors::{Error, Result, SyntaxError};
 use crate::events::Event;
 use crate::name::{QName, ResolveResult};
 use crate::reader::buffered_reader::impl_buffered_source;
 use crate::reader::{
     is_whitespace, BangType, NsReader, ParseState, ReadElementState, Reader, Span,
 };
-use crate::{Error, Result};
 
 /// A struct for read XML asynchronously from an [`AsyncBufRead`].
 ///

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -54,7 +54,7 @@ macro_rules! impl_buffered_source {
             byte: u8,
             buf: &'b mut Vec<u8>,
             position: &mut usize,
-        ) -> Result<Option<&'b [u8]>> {
+        ) -> Result<(&'b [u8], bool)> {
             // search byte must be within the ascii range
             debug_assert!(byte.is_ascii());
 
@@ -90,11 +90,7 @@ macro_rules! impl_buffered_source {
             }
             *position += read;
 
-            if read == 0 {
-                Ok(None)
-            } else {
-                Ok(Some(&buf[start..]))
-            }
+            Ok((&buf[start..], done))
         }
 
         $($async)? fn read_bang_element $(<$lf>)? (

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -97,7 +97,7 @@ macro_rules! impl_buffered_source {
             &mut self,
             buf: &'b mut Vec<u8>,
             position: &mut usize,
-        ) -> Result<Option<(BangType, &'b [u8])>> {
+        ) -> Result<(BangType, &'b [u8])> {
             // Peeked one bang ('!') before being called, so it's guaranteed to
             // start with it.
             let start = buf.len();
@@ -140,9 +140,9 @@ macro_rules! impl_buffered_source {
             }
 
             if read == 0 {
-                Ok(None)
+                Err(bang_type.to_err())
             } else {
-                Ok(Some((bang_type, &buf[start..])))
+                Ok((bang_type, &buf[start..]))
             }
         }
 

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use memchr;
 
-use crate::errors::{Error, Result};
+use crate::errors::{Error, Result, SyntaxError};
 use crate::events::Event;
 use crate::name::QName;
 use crate::reader::{is_whitespace, BangType, ReadElementState, Reader, Span, XmlSource};
@@ -151,7 +151,7 @@ macro_rules! impl_buffered_source {
             &mut self,
             buf: &'b mut Vec<u8>,
             position: &mut usize,
-        ) -> Result<Option<&'b [u8]>> {
+        ) -> Result<&'b [u8]> {
             let mut state = ReadElementState::Elem;
             let mut read = 0;
 
@@ -187,9 +187,9 @@ macro_rules! impl_buffered_source {
             }
 
             if read == 0 {
-                Ok(None)
+                Err(Error::Syntax(SyntaxError::UnclosedTag))
             } else {
-                Ok(Some(&buf[start..]))
+                Ok(&buf[start..])
             }
         }
 

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -260,24 +260,21 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         byte: u8,
         _buf: (),
         position: &mut usize,
-    ) -> Result<Option<&'a [u8]>> {
+    ) -> Result<(&'a [u8], bool)> {
         // search byte must be within the ascii range
         debug_assert!(byte.is_ascii());
-        if self.is_empty() {
-            return Ok(None);
-        }
 
-        Ok(Some(if let Some(i) = memchr::memchr(byte, self) {
+        if let Some(i) = memchr::memchr(byte, self) {
             *position += i + 1;
             let bytes = &self[..i];
             *self = &self[i + 1..];
-            bytes
+            Ok((bytes, true))
         } else {
             *position += self.len();
             let bytes = &self[..];
             *self = &[];
-            bytes
-        }))
+            Ok((bytes, false))
+        }
     }
 
     fn read_bang_element(

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -299,18 +299,14 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         Err(bang_type.to_err())
     }
 
-    fn read_element(&mut self, _buf: (), position: &mut usize) -> Result<Option<&'a [u8]>> {
-        if self.is_empty() {
-            return Ok(None);
-        }
-
+    fn read_element(&mut self, _buf: (), position: &mut usize) -> Result<&'a [u8]> {
         let mut state = ReadElementState::Elem;
 
         if let Some((bytes, i)) = state.change(self) {
             // Position now just after the `>` symbol
             *position += i;
             *self = &self[i..];
-            return Ok(Some(bytes));
+            return Ok(bytes);
         }
 
         // Note: Do not update position, so the error points to a sane place

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -281,7 +281,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         &mut self,
         _buf: (),
         position: &mut usize,
-    ) -> Result<Option<(BangType, &'a [u8])>> {
+    ) -> Result<(BangType, &'a [u8])> {
         // Peeked one bang ('!') before being called, so it's guaranteed to
         // start with it.
         debug_assert_eq!(self[0], b'!');
@@ -291,7 +291,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         if let Some((bytes, i)) = bang_type.parse(&[], self) {
             *position += i;
             *self = &self[i..];
-            return Ok(Some((bang_type, bytes)));
+            return Ok((bang_type, bytes));
         }
 
         // Note: Do not update position, so the error points to

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -49,12 +49,14 @@ pub(super) struct ReaderState {
 }
 
 impl ReaderState {
-    /// Trims whitespaces from `bytes`, if required, and returns a [`Text`] event.
+    /// Trims end whitespaces from `bytes`, if required, and returns a [`Text`]
+    /// event or an [`Eof`] event, if text after trimming is empty.
     ///
     /// # Parameters
     /// - `bytes`: data from the start of stream to the first `<` or from `>` to `<`
     ///
     /// [`Text`]: Event::Text
+    /// [`Eof`]: Event::Eof
     pub fn emit_text<'b>(&mut self, bytes: &'b [u8]) -> Result<Event<'b>> {
         let mut content = bytes;
 
@@ -67,7 +69,11 @@ impl ReaderState {
             content = &bytes[..len];
         }
 
-        Ok(Event::Text(BytesText::wrap(content, self.decoder())))
+        if content.is_empty() {
+            Ok(Event::Eof)
+        } else {
+            Ok(Event::Text(BytesText::wrap(content, self.decoder())))
+        }
     }
 
     /// reads `BytesElement` starting with a `!`,


### PR DESCRIPTION
The 1st commit is a preparation step.
The 2nd adds a regression test.
The 3rd commit fixes #622.

The bug was in two parts:
- the first one is incorrect returning of `Event::Eof` in `read_until_close!` macro. We are inside a markup at this moment, so we cannot return EOF event.
- the second is an incorrect transition to `OpenedTag` state from `ClosedTag` state. It is assumed that in `OpenedTag` we already have seen and have consumed the `<` character, but because `read_byte_until` could return bytes without seeing the searched byte we could go to `OpenedTag` state when `<` was not seen. In that case the first part of a bug have masked problem in most cases.

I also noticed other problems near to fixed code, so the commits 4 and 5 fixes them: `read_element` and `read_bang_element` are called inside of a tag or bang markup (i. e. after seeing `<` character), so they must return a corresponding event or an error. The last commit just a refactoring of that fixes, that also removes dead code arised due to a typo.