### PR TITLE
Add new tests for syntax and ill-formed parser errors and fix... emm... errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,7 @@ configuration is serializable.
   - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases
   - `Error::UnexpectedEof` replaced by `IllFormedError` in some cases
   - `Error::UnexpectedToken` replaced by `IllFormedError::DoubleHyphenInComment`
+  - `Error::XmlDeclWithoutVersion` replaced by `IllFormedError::MissedVersion` (in [#684])
 
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ configuration is serializable.
 ### Bug Fixes
 
 - [#622]: Fix wrong disregarding of not closed markup, such as lone `<`.
+- [#684]: Fix incorrect position reported for `Error::IllFormed(DoubleHyphenInComment)`.
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,21 +27,21 @@ configuration is serializable.
 
 - [#622]: Fix wrong disregarding of not closed markup, such as lone `<`.
 - [#684]: Fix incorrect position reported for `Error::IllFormed(DoubleHyphenInComment)`.
-- [#684]: Fix incorrect position reported for `Error::IllFormed(MissedDoctypeName)`.
+- [#684]: Fix incorrect position reported for `Error::IllFormed(MissingDoctypeName)`.
 
 ### Misc Changes
 
 - [#675]: Minimum supported version of serde raised to 1.0.139
 - [#675]: Rework the `quick_xml::Error` type to provide more accurate information:
-  - `Error::EndEventMismatch` replaced by `IllFormedError::MismatchedEnd` in some cases
-  - `Error::EndEventMismatch` replaced by `IllFormedError::UnmatchedEnd` in some cases
+  - `Error::EndEventMismatch` replaced by `IllFormedError::MismatchedEndTag` in some cases
+  - `Error::EndEventMismatch` replaced by `IllFormedError::UnmatchedEndTag` in some cases
   - `Error::TextNotFound` was removed because not used
   - `Error::UnexpectedBang` replaced by `SyntaxError`
   - `Error::UnexpectedEof` replaced by `SyntaxError` in some cases
   - `Error::UnexpectedEof` replaced by `IllFormedError` in some cases
   - `Error::UnexpectedToken` replaced by `IllFormedError::DoubleHyphenInComment`
-  - `Error::XmlDeclWithoutVersion` replaced by `IllFormedError::MissedVersion` (in [#684])
-  - `Error::EmptyDocType` replaced by `IllFormedError::MissedDoctypeName` (in [#684])
+  - `Error::XmlDeclWithoutVersion` replaced by `IllFormedError::MissingDeclVersion` (in [#684])
+  - `Error::EmptyDocType` replaced by `IllFormedError::MissingDoctypeName` (in [#684])
 - [#684]: Changed positions reported for `SyntaxError`s: now they are always points
   to the start of markup (i. e. to the `<` character) with error.
 - [#684]: Now `<??>` parsed as `Event::PI` with empty content instead of raising

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ configuration is serializable.
 
 - [#622]: Fix wrong disregarding of not closed markup, such as lone `<`.
 - [#684]: Fix incorrect position reported for `Error::IllFormed(DoubleHyphenInComment)`.
+- [#684]: Fix incorrect position reported for `Error::IllFormed(MissedDoctypeName)`.
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -42,6 +42,8 @@ configuration is serializable.
   - `Error::EmptyDocType` replaced by `IllFormedError::MissedDoctypeName` (in [#684])
 - [#684]: Changed positions reported for `SyntaxError`s: now they are always points
   to the start of markup (i. e. to the `<` character) with error.
+- [#684]: Now `<??>` parsed as `Event::PI` with empty content instead of raising
+  syntax error.
 
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/Changelog.md
+++ b/Changelog.md
@@ -44,6 +44,7 @@ configuration is serializable.
   to the start of markup (i. e. to the `<` character) with error.
 - [#684]: Now `<??>` parsed as `Event::PI` with empty content instead of raising
   syntax error.
+- [#684]: Now `<?xml?>` parsed as `Event::Decl` instead of `Event::PI`.
 
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@ configuration is serializable.
 - [#677]: Added methods `config()` and `config_mut()` to inspect and change the parser
   configuration. Previous builder methods on `Reader` / `NsReader` was replaced by
   direct access to fields of config using `reader.config_mut().<...>`.
+- #[#684]: Added a method `Config::enable_all_checks` to turn on or off all
+  well-formedness checks.
 
 ### Bug Fixes
 
@@ -41,6 +43,7 @@ configuration is serializable.
 [#622]: https://github.com/tafia/quick-xml/issues/622
 [#675]: https://github.com/tafia/quick-xml/pull/675
 [#677]: https://github.com/tafia/quick-xml/pull/677
+[#684]: https://github.com/tafia/quick-xml/pull/684
 
 
 ## 0.31.0 -- 2023-10-22

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@ configuration is serializable.
   - `Error::UnexpectedToken` replaced by `IllFormedError::DoubleHyphenInComment`
   - `Error::XmlDeclWithoutVersion` replaced by `IllFormedError::MissedVersion` (in [#684])
   - `Error::EmptyDocType` replaced by `IllFormedError::MissedDoctypeName` (in [#684])
+- [#684]: Changed positions reported for `SyntaxError`s: now they are always points
+  to the start of markup (i. e. to the `<` character) with error.
 
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@ configuration is serializable.
   - `Error::UnexpectedEof` replaced by `IllFormedError` in some cases
   - `Error::UnexpectedToken` replaced by `IllFormedError::DoubleHyphenInComment`
   - `Error::XmlDeclWithoutVersion` replaced by `IllFormedError::MissedVersion` (in [#684])
+  - `Error::EmptyDocType` replaced by `IllFormedError::MissedDoctypeName` (in [#684])
 
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2649,7 +2649,7 @@ where
     /// |[`DeEvent::Start`]|`<any-tag>...</any-tag>`   |Emits [`UnexpectedStart("any-tag")`](DeError::UnexpectedStart)
     /// |[`DeEvent::End`]  |`</tag>`                   |Returns an empty slice. The reader guarantee that tag will match the open one
     /// |[`DeEvent::Text`] |`text content` or `<![CDATA[cdata content]]>` (probably mixed)|Returns event content unchanged, expects the `</tag>` after that
-    /// |[`DeEvent::Eof`]  |                           |Emits [`InvalidXml(IllFormed(MissedEnd))`](DeError::InvalidXml)
+    /// |[`DeEvent::Eof`]  |                           |Emits [`InvalidXml(IllFormed(MissingEndTag))`](DeError::InvalidXml)
     ///
     /// [`Text`]: Event::Text
     /// [`CData`]: Event::CData
@@ -3642,7 +3642,7 @@ mod tests {
 
             match de.read_to_end(QName(b"tag")) {
                 Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                    assert_eq!(cause, IllFormedError::MissedEnd("tag".into()))
+                    assert_eq!(cause, IllFormedError::MissingEndTag("tag".into()))
                 }
                 x => panic!(
                     "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -3661,7 +3661,7 @@ mod tests {
 
             match de.read_to_end(QName(b"tag")) {
                 Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                    assert_eq!(cause, IllFormedError::MissedEnd("tag".into()))
+                    assert_eq!(cause, IllFormedError::MissingEndTag("tag".into()))
                 }
                 x => panic!(
                     "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -3756,7 +3756,7 @@ mod tests {
     fn read_string() {
         match from_str::<String>(r#"</root>"#) {
             Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                assert_eq!(cause, IllFormedError::UnmatchedEnd("root".into()));
+                assert_eq!(cause, IllFormedError::UnmatchedEndTag("root".into()));
             }
             x => panic!(
                 "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -3770,7 +3770,7 @@ mod tests {
         match from_str::<String>(r#"<root></other>"#) {
             Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
                 cause,
-                IllFormedError::MismatchedEnd {
+                IllFormedError::MismatchedEndTag {
                     expected: "root".into(),
                     found: "other".into(),
                 }
@@ -4098,7 +4098,7 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
                     match de.next() {
                         Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag2".into()));
+                            assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag2".into()));
                         }
                         x => panic!(
                             "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -4241,7 +4241,7 @@ mod tests {
             let mut de = make_de("</tag>");
             match de.next() {
                 Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                    assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
+                    assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
                 }
                 x => panic!(
                     "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -4320,7 +4320,7 @@ mod tests {
                 assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
                 match de.next() {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
+                        assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -4352,7 +4352,7 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Text("text  cdata ".into()));
                     match de.next() {
                         Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
+                            assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
                         }
                         x => panic!(
                             "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -4458,7 +4458,7 @@ mod tests {
                 assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata ".into()));
                 match de.next() {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
+                        assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -4488,7 +4488,7 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text".into()));
                     match de.next() {
                         Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
+                            assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
                         }
                         x => panic!(
                             "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -4538,7 +4538,7 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  cdata2 ".into()));
                     match de.next() {
                         Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                            assert_eq!(cause, IllFormedError::UnmatchedEnd("tag".into()));
+                            assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
                         }
                         x => panic!(
                             "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -82,6 +82,14 @@ pub enum IllFormedError {
     ///
     /// [specification]: https://www.w3.org/TR/xml11/#sec-prolog-dtd
     MissedVersion(Option<String>),
+    /// A document type definition (DTD) does not contain a name of a root element.
+    ///
+    /// According to the [specification], document type definition (`<!DOCTYPE foo>`)
+    /// MUST contain a name which defines a document type (`foo`). If that name
+    /// is missed, this error is returned.
+    ///
+    /// [specification]: https://www.w3.org/TR/xml11/#NT-doctypedecl
+    MissedDoctypeName,
     /// The end tag was not found during reading of a sub-tree of elements due to
     /// encountering an EOF from the underlying reader. This error is returned from
     /// [`Reader::read_to_end`].
@@ -120,6 +128,10 @@ impl fmt::Display for IllFormedError {
             Self::MissedVersion(Some(attr)) => {
                 write!(f, "an XML declaration must start with `version` attribute, but in starts with `{}`", attr)
             }
+            Self::MissedDoctypeName => write!(
+                f,
+                "`<!DOCTYPE>` declaration does not contain a name of a document type"
+            ),
             Self::MissedEnd(tag) => write!(
                 f,
                 "start tag not closed: `</{}>` not found before end of input",
@@ -160,14 +172,6 @@ pub enum Error {
     ///
     /// [`encoding`]: index.html#encoding
     NonDecodable(Option<Utf8Error>),
-    /// A document type definition (DTD) does not contain a name of a root element.
-    ///
-    /// According to the [specification], document type definition (`<!doctype foo>`)
-    /// MUST contain a name which defines a document type. If that name is missed,
-    /// this error is returned.
-    ///
-    /// [specification]: https://www.w3.org/TR/xml11/#NT-doctypedecl
-    EmptyDocType,
     /// Attribute parsing error
     InvalidAttr(AttrError),
     /// Escape error
@@ -267,10 +271,6 @@ impl fmt::Display for Error {
             Error::IllFormed(e) => write!(f, "ill-formed document: {}", e),
             Error::NonDecodable(None) => write!(f, "Malformed input, decoding impossible"),
             Error::NonDecodable(Some(e)) => write!(f, "Malformed UTF-8 input: {}", e),
-            Error::EmptyDocType => write!(
-                f,
-                "`<!DOCTYPE>` declaration does not contain a name of a document type"
-            ),
             Error::InvalidAttr(e) => write!(f, "error while parsing attribute: {}", e),
             Error::EscapeError(e) => write!(f, "{}", e),
             Error::UnknownPrefix(prefix) => {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -81,7 +81,7 @@ pub enum IllFormedError {
     /// the declaration. In the last case it contains the name of the found attribute.
     ///
     /// [specification]: https://www.w3.org/TR/xml11/#sec-prolog-dtd
-    MissedVersion(Option<String>),
+    MissingDeclVersion(Option<String>),
     /// A document type definition (DTD) does not contain a name of a root element.
     ///
     /// According to the [specification], document type definition (`<!DOCTYPE foo>`)
@@ -89,18 +89,18 @@ pub enum IllFormedError {
     /// is missed, this error is returned.
     ///
     /// [specification]: https://www.w3.org/TR/xml11/#NT-doctypedecl
-    MissedDoctypeName,
+    MissingDoctypeName,
     /// The end tag was not found during reading of a sub-tree of elements due to
     /// encountering an EOF from the underlying reader. This error is returned from
     /// [`Reader::read_to_end`].
     ///
     /// [`Reader::read_to_end`]: crate::reader::Reader::read_to_end
-    MissedEnd(String),
+    MissingEndTag(String),
     /// The specified end tag was encountered without corresponding open tag at the
     /// same level of hierarchy
-    UnmatchedEnd(String),
+    UnmatchedEndTag(String),
     /// The specified end tag does not match the start tag at that nesting level.
-    MismatchedEnd {
+    MismatchedEndTag {
         /// Name of open tag, that is expected to be closed
         expected: String,
         /// Name of actually closed tag
@@ -122,25 +122,25 @@ pub enum IllFormedError {
 impl fmt::Display for IllFormedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::MissedVersion(None) => {
+            Self::MissingDeclVersion(None) => {
                 write!(f, "an XML declaration does not contain `version` attribute")
             }
-            Self::MissedVersion(Some(attr)) => {
+            Self::MissingDeclVersion(Some(attr)) => {
                 write!(f, "an XML declaration must start with `version` attribute, but in starts with `{}`", attr)
             }
-            Self::MissedDoctypeName => write!(
+            Self::MissingDoctypeName => write!(
                 f,
                 "`<!DOCTYPE>` declaration does not contain a name of a document type"
             ),
-            Self::MissedEnd(tag) => write!(
+            Self::MissingEndTag(tag) => write!(
                 f,
                 "start tag not closed: `</{}>` not found before end of input",
                 tag,
             ),
-            Self::UnmatchedEnd(tag) => {
+            Self::UnmatchedEndTag(tag) => {
                 write!(f, "close tag `</{}>` does not match any open tag", tag)
             }
-            Self::MismatchedEnd { expected, found } => write!(
+            Self::MismatchedEndTag { expected, found } => write!(
                 f,
                 "expected `</{}>`, but `</{}>` was found",
                 expected, found,
@@ -199,7 +199,7 @@ pub enum Error {
 impl Error {
     pub(crate) fn missed_end(name: QName, decoder: Decoder) -> Self {
         match decoder.decode(name.as_ref()) {
-            Ok(name) => IllFormedError::MissedEnd(name.into()).into(),
+            Ok(name) => IllFormedError::MissingEndTag(name.into()).into(),
             Err(err) => err.into(),
         }
     }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -391,7 +391,7 @@ impl<'a> BytesDecl<'a> {
     /// In case of multiple attributes value of the first one is returned.
     ///
     /// If version is missed in the declaration, or the first thing is not a version,
-    /// [`IllFormedError::MissedVersion`] will be returned.
+    /// [`IllFormedError::MissingDeclVersion`] will be returned.
     ///
     /// # Examples
     ///
@@ -410,21 +410,21 @@ impl<'a> BytesDecl<'a> {
     /// // <?xml encoding='utf-8'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" encoding='utf-8'", 0));
     /// match decl.version() {
-    ///     Err(Error::IllFormed(IllFormedError::MissedVersion(Some(key)))) => assert_eq!(key, "encoding"),
+    ///     Err(Error::IllFormed(IllFormedError::MissingDeclVersion(Some(key)))) => assert_eq!(key, "encoding"),
     ///     _ => assert!(false),
     /// }
     ///
     /// // <?xml encoding='utf-8' version='1.1'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" encoding='utf-8' version='1.1'", 0));
     /// match decl.version() {
-    ///     Err(Error::IllFormed(IllFormedError::MissedVersion(Some(key)))) => assert_eq!(key, "encoding"),
+    ///     Err(Error::IllFormed(IllFormedError::MissingDeclVersion(Some(key)))) => assert_eq!(key, "encoding"),
     ///     _ => assert!(false),
     /// }
     ///
     /// // <?xml?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content("", 0));
     /// match decl.version() {
-    ///     Err(Error::IllFormed(IllFormedError::MissedVersion(None))) => {},
+    ///     Err(Error::IllFormed(IllFormedError::MissingDeclVersion(None))) => {},
     ///     _ => assert!(false),
     /// }
     /// ```
@@ -437,12 +437,14 @@ impl<'a> BytesDecl<'a> {
             // first attribute was not "version"
             Some(Ok(a)) => {
                 let found = from_utf8(a.key.as_ref())?.to_string();
-                Err(Error::IllFormed(IllFormedError::MissedVersion(Some(found))))
+                Err(Error::IllFormed(IllFormedError::MissingDeclVersion(Some(
+                    found,
+                ))))
             }
             // error parsing attributes
             Some(Err(e)) => Err(e.into()),
             // no attributes
-            None => Err(Error::IllFormed(IllFormedError::MissedVersion(None))),
+            None => Err(Error::IllFormed(IllFormedError::MissingDeclVersion(None))),
         }
     }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -40,7 +40,7 @@ pub struct Config {
     pub check_comments: bool,
 
     /// Whether mismatched closing tag names should be detected. If enabled, in
-    /// case of mismatch the [`Error::IllFormed(MismatchedEnd)`] is returned from
+    /// case of mismatch the [`Error::IllFormed(MismatchedEndTag)`] is returned from
     /// read methods.
     ///
     /// Note, that start and end tags [should match literally][spec], they cannot
@@ -71,7 +71,7 @@ pub struct Config {
     ///
     /// Default: `true`
     ///
-    /// [`Error::IllFormed(MismatchedEnd)`]: crate::errors::IllFormedError::MismatchedEnd
+    /// [`Error::IllFormed(MismatchedEndTag)`]: crate::errors::IllFormedError::MismatchedEndTag
     /// [spec]: https://www.w3.org/TR/xml11/#dt-etag
     /// [`End`]: crate::events::Event::End
     /// [`expand_empty_elements`]: Self::expand_empty_elements

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -177,6 +177,15 @@ impl Config {
         self.trim_text_start = trim;
         self.trim_text_end = trim;
     }
+
+    /// Turn on or off all checks for well-formedness. Currently it is that settings:
+    /// - [`check_comments`](Self::check_comments)
+    /// - [`check_end_names`](Self::check_end_names)
+    #[inline]
+    pub fn enable_all_checks(&mut self, enable: bool) {
+        self.check_comments = enable;
+        self.check_end_names = enable;
+    }
 }
 
 impl Default for Config {

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -114,7 +114,7 @@ impl ReaderState {
                     .position(|b| !is_whitespace(*b))
                     .unwrap_or(len - 8);
                 if start + 8 >= len {
-                    return Err(Error::EmptyDocType);
+                    return Err(Error::IllFormed(IllFormedError::MissedDoctypeName));
                 }
                 Ok(Event::DocType(BytesText::wrap(
                     &buf[8 + start..],

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -190,8 +190,13 @@ impl ReaderState {
     ///
     /// Returns `Decl` or `PI` event
     pub fn emit_question_mark<'b>(&mut self, buf: &'b [u8]) -> Result<Event<'b>> {
+        debug_assert!(buf.len() > 0);
+        debug_assert_eq!(buf[0], b'?');
+
         let len = buf.len();
-        if len > 2 && buf[len - 1] == b'?' {
+        // We accept at least <??>
+        //                     ~~ - len = 2
+        if len > 1 && buf[len - 1] == b'?' {
             if len > 5 && &buf[1..4] == b"xml" && is_whitespace(buf[4]) {
                 let event = BytesDecl::from_start(BytesStart::wrap(&buf[1..len - 1], 3));
 

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -119,6 +119,10 @@ impl ReaderState {
                     .position(|b| !is_whitespace(*b))
                     .unwrap_or(len - 8);
                 if start + 8 >= len {
+                    // Because we here, we at least read `<!DOCTYPE>` and offset after `>`.
+                    // We want report error at place where name is expected - this is just
+                    // before `>`
+                    self.offset -= 1;
                     return Err(Error::IllFormed(IllFormedError::MissedDoctypeName));
                 }
                 Ok(Event::DocType(BytesText::wrap(

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -197,8 +197,11 @@ impl ReaderState {
         // We accept at least <??>
         //                     ~~ - len = 2
         if len > 1 && buf[len - 1] == b'?' {
-            if len > 5 && &buf[1..4] == b"xml" && is_whitespace(buf[4]) {
-                let event = BytesDecl::from_start(BytesStart::wrap(&buf[1..len - 1], 3));
+            let content = &buf[1..len - 1];
+            let len = content.len();
+
+            if content.starts_with(b"xml") && (len == 3 || is_whitespace(content[3])) {
+                let event = BytesDecl::from_start(BytesStart::wrap(content, 3));
 
                 // Try getting encoding from the declaration event
                 #[cfg(feature = "encoding")]
@@ -210,7 +213,7 @@ impl ReaderState {
 
                 Ok(Event::Decl(event))
             } else {
-                Ok(Event::PI(BytesText::wrap(&buf[1..len - 1], self.decoder())))
+                Ok(Event::PI(BytesText::wrap(content, self.decoder())))
             }
         } else {
             // <?....EOF

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -124,7 +124,7 @@ impl ReaderState {
                         // We want report error at place where name is expected - this is just
                         // before `>`
                         self.offset -= 1;
-                        return Err(Error::IllFormed(IllFormedError::MissedDoctypeName));
+                        return Err(Error::IllFormed(IllFormedError::MissingDoctypeName));
                     }
                 }
             }
@@ -170,7 +170,7 @@ impl ReaderState {
                         // Report error at start of the end tag at `<` character
                         // +2 for `<` and `>`
                         self.offset -= buf.len() + 2;
-                        return Err(Error::IllFormed(IllFormedError::MismatchedEnd {
+                        return Err(Error::IllFormed(IllFormedError::MismatchedEndTag {
                             expected,
                             found: decoder.decode(name).unwrap_or_default().into_owned(),
                         }));
@@ -183,7 +183,7 @@ impl ReaderState {
                 // Report error at start of the end tag at `<` character
                 // +2 for `<` and `>`
                 self.offset -= buf.len() + 2;
-                return Err(Error::IllFormed(IllFormedError::UnmatchedEnd(
+                return Err(Error::IllFormed(IllFormedError::UnmatchedEndTag(
                     decoder.decode(name).unwrap_or_default().into_owned(),
                 )));
             }

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -1,8 +1,8 @@
 //! Cases that was found by fuzzing
 
+use quick_xml::errors::{Error, IllFormedError};
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
-use quick_xml::Error;
 
 #[test]
 fn fuzz_53() {
@@ -56,7 +56,7 @@ fn fuzz_empty_doctype() {
     let mut buf = Vec::new();
     assert!(matches!(
         reader.read_event_into(&mut buf).unwrap_err(),
-        Error::EmptyDocType
+        Error::IllFormed(IllFormedError::MissedDoctypeName)
     ));
     assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
 }

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -56,7 +56,7 @@ fn fuzz_empty_doctype() {
     let mut buf = Vec::new();
     assert!(matches!(
         reader.read_event_into(&mut buf).unwrap_err(),
-        Error::IllFormed(IllFormedError::MissedDoctypeName)
+        Error::IllFormed(IllFormedError::MissingDoctypeName)
     ));
     assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -146,7 +146,7 @@ mod issue514 {
         match reader.read_event() {
             Err(Error::IllFormed(cause)) => assert_eq!(
                 cause,
-                IllFormedError::MismatchedEnd {
+                IllFormedError::MismatchedEndTag {
                     expected: "some-tag".into(),
                     found: "other-tag".into(),
                 }

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -330,7 +330,7 @@ mod check_end_names {
             match reader.read_event() {
                 Err(Error::IllFormed(cause)) => assert_eq!(
                     cause,
-                    IllFormedError::MismatchedEnd {
+                    IllFormedError::MismatchedEndTag {
                         expected: "tag".into(),
                         found: "mismatched".into(),
                     }
@@ -421,7 +421,7 @@ mod trim_markup_names_in_closing_tags {
             match reader.read_event() {
                 Err(Error::IllFormed(cause)) => assert_eq!(
                     cause,
-                    IllFormedError::MismatchedEnd {
+                    IllFormedError::MismatchedEndTag {
                         expected: "root".into(),
                         found: "root \t\r\n".into(),
                     }

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -1,0 +1,327 @@
+//! Contains tests that produces errors during parsing XML.
+
+use quick_xml::errors::{Error, SyntaxError};
+use quick_xml::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::reader::{NsReader, Reader};
+
+macro_rules! ok {
+    ($test:ident($xml:literal) => $event:expr) => {
+        mod $test {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[test]
+            fn borrowed() {
+                let mut reader = Reader::from_str($xml);
+                assert_eq!(reader.read_event().unwrap(), $event);
+
+                let mut reader = NsReader::from_str($xml);
+                assert_eq!(reader.read_resolved_event().unwrap().1, $event);
+            }
+
+            #[test]
+            fn buffered() {
+                let mut buf = Vec::new();
+                let mut reader = Reader::from_str($xml);
+                assert_eq!(reader.read_event_into(&mut buf).unwrap(), $event);
+
+                let mut reader = NsReader::from_str($xml);
+                assert_eq!(reader.read_resolved_event_into(&mut buf).unwrap().1, $event);
+            }
+
+            #[cfg(feature = "async-tokio")]
+            #[tokio::test]
+            async fn async_tokio() {
+                let mut buf = Vec::new();
+                let mut reader = Reader::from_str($xml);
+                assert_eq!(
+                    reader.read_event_into_async(&mut buf).await.unwrap(),
+                    $event
+                );
+
+                let mut reader = NsReader::from_str($xml);
+                assert_eq!(
+                    reader
+                        .read_resolved_event_into_async(&mut buf)
+                        .await
+                        .unwrap()
+                        .1,
+                    $event
+                );
+            }
+        }
+    };
+}
+
+mod syntax {
+    use super::*;
+
+    macro_rules! err {
+        ($test:ident($xml:literal) => $cause:expr) => {
+            mod $test {
+                use super::*;
+                use pretty_assertions::assert_eq;
+
+                #[test]
+                fn borrowed() {
+                    let mut reader = Reader::from_str($xml);
+                    match reader.read_event() {
+                        Err(Error::Syntax(cause)) => {
+                            assert_eq!(cause, $cause);
+                            assert_eq!(reader.buffer_position(), 0);
+                        }
+                        x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
+                    }
+                    assert_eq!(
+                        reader
+                            .read_event()
+                            .expect("parser should return `Event::Eof` after error"),
+                        Event::Eof
+                    );
+
+                    let mut reader = NsReader::from_str($xml);
+                    match reader.read_resolved_event() {
+                        Err(Error::Syntax(cause)) => {
+                            assert_eq!(cause, $cause);
+                            assert_eq!(reader.buffer_position(), 0);
+                        }
+                        x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
+                    }
+                    assert_eq!(
+                        reader
+                            .read_resolved_event()
+                            .expect("parser should return `Event::Eof` after error")
+                            .1,
+                        Event::Eof
+                    );
+                }
+
+                #[test]
+                fn buffered() {
+                    let mut buf = Vec::new();
+                    let mut reader = Reader::from_str($xml);
+                    match reader.read_event_into(&mut buf) {
+                        Err(Error::Syntax(cause)) => {
+                            assert_eq!(cause, $cause);
+                            assert_eq!(reader.buffer_position(), 0);
+                        }
+                        x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
+                    }
+                    assert_eq!(
+                        reader
+                            .read_event_into(&mut buf)
+                            .expect("parser should return `Event::Eof` after error"),
+                        Event::Eof
+                    );
+
+                    let mut reader = NsReader::from_str($xml);
+                    match reader.read_resolved_event_into(&mut buf) {
+                        Err(Error::Syntax(cause)) => {
+                            assert_eq!(cause, $cause);
+                            assert_eq!(reader.buffer_position(), 0);
+                        }
+                        x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
+                    }
+                    assert_eq!(
+                        reader
+                            .read_resolved_event_into(&mut buf)
+                            .expect("parser should return `Event::Eof` after error")
+                            .1,
+                        Event::Eof
+                    );
+                }
+
+                #[cfg(feature = "async-tokio")]
+                #[tokio::test]
+                async fn async_tokio() {
+                    let mut buf = Vec::new();
+                    let mut reader = Reader::from_str($xml);
+                    match reader.read_event_into_async(&mut buf).await {
+                        Err(Error::Syntax(cause)) => {
+                            assert_eq!(cause, $cause);
+                            assert_eq!(reader.buffer_position(), 0);
+                        }
+                        x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
+                    }
+                    assert_eq!(
+                        reader
+                            .read_event_into_async(&mut buf)
+                            .await
+                            .expect("parser should return `Event::Eof` after error"),
+                        Event::Eof
+                    );
+
+                    let mut reader = NsReader::from_str($xml);
+                    match reader.read_resolved_event_into_async(&mut buf).await {
+                        Err(Error::Syntax(cause)) => {
+                            assert_eq!(cause, $cause);
+                            assert_eq!(reader.buffer_position(), 0);
+                        }
+                        x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
+                    }
+                    assert_eq!(
+                        reader
+                            .read_resolved_event_into_async(&mut buf)
+                            .await
+                            .expect("parser should return `Event::Eof` after error")
+                            .1,
+                        Event::Eof
+                    );
+                }
+            }
+        };
+    }
+
+    mod tag {
+        use super::*;
+
+        err!(unclosed1("<")   => SyntaxError::UnclosedTag);
+        err!(unclosed2("</")  => SyntaxError::UnclosedTag);
+        err!(unclosed3("<x")  => SyntaxError::UnclosedTag);
+        err!(unclosed4("< ")  => SyntaxError::UnclosedTag);
+        err!(unclosed5("<\t") => SyntaxError::UnclosedTag);
+        err!(unclosed6("<\r") => SyntaxError::UnclosedTag);
+        err!(unclosed7("<\n") => SyntaxError::UnclosedTag);
+
+        /// Closed tags can be tested only in pair with open tags, because otherwise
+        /// `IllFormedError::UnmatchedEnd` will be raised
+        mod normal {
+            use super::*;
+            use pretty_assertions::assert_eq;
+
+            #[test]
+            fn borrowed() {
+                let mut reader = Reader::from_str("<></>");
+                assert_eq!(
+                    reader.read_event().unwrap(),
+                    Event::Start(BytesStart::new(""))
+                );
+                assert_eq!(reader.read_event().unwrap(), Event::End(BytesEnd::new("")));
+            }
+
+            #[test]
+            fn buffered() {
+                let mut buf = Vec::new();
+                let mut reader = Reader::from_str("<></>");
+                assert_eq!(
+                    reader.read_event_into(&mut buf).unwrap(),
+                    Event::Start(BytesStart::new(""))
+                );
+                assert_eq!(
+                    reader.read_event_into(&mut buf).unwrap(),
+                    Event::End(BytesEnd::new(""))
+                );
+            }
+
+            #[cfg(feature = "async-tokio")]
+            #[tokio::test]
+            async fn async_tokio() {
+                let mut buf = Vec::new();
+                let mut reader = Reader::from_str("<></>");
+                assert_eq!(
+                    reader.read_event_into_async(&mut buf).await.unwrap(),
+                    Event::Start(BytesStart::new(""))
+                );
+                assert_eq!(
+                    reader.read_event_into_async(&mut buf).await.unwrap(),
+                    Event::End(BytesEnd::new(""))
+                );
+            }
+        }
+    }
+
+    err!(unclosed_bang1("<!")  => SyntaxError::InvalidBangMarkup);
+    err!(unclosed_bang2("<!>") => SyntaxError::InvalidBangMarkup);
+
+    /// https://www.w3.org/TR/xml11/#NT-Comment
+    mod comment {
+        use super::*;
+
+        err!(unclosed1("<!-")    => SyntaxError::UnclosedComment);
+        err!(unclosed2("<!--")   => SyntaxError::UnclosedComment);
+        err!(unclosed3("<!->")   => SyntaxError::UnclosedComment);
+        err!(unclosed4("<!---")  => SyntaxError::UnclosedComment);
+        err!(unclosed5("<!-->")  => SyntaxError::UnclosedComment);
+        err!(unclosed6("<!----") => SyntaxError::UnclosedComment);
+        err!(unclosed7("<!--->") => SyntaxError::UnclosedComment);
+
+        ok!(normal("<!---->") => Event::Comment(BytesText::new("")));
+    }
+
+    /// https://www.w3.org/TR/xml11/#NT-CDSect
+    mod cdata {
+        use super::*;
+
+        err!(unclosed1("<![")         => SyntaxError::UnclosedCData);
+        err!(unclosed2("<![C")        => SyntaxError::UnclosedCData);
+        err!(unclosed3("<![CD")       => SyntaxError::UnclosedCData);
+        err!(unclosed4("<![CDA")      => SyntaxError::UnclosedCData);
+        err!(unclosed5("<![CDAT")     => SyntaxError::UnclosedCData);
+        err!(unclosed6("<![CDATA")    => SyntaxError::UnclosedCData);
+        err!(unclosed7("<![CDATA[")   => SyntaxError::UnclosedCData);
+        err!(unclosed8("<![CDATA[]")  => SyntaxError::UnclosedCData);
+        err!(unclosed9("<![CDATA[]]") => SyntaxError::UnclosedCData);
+
+        ok!(normal("<![CDATA[]]>") => Event::CData(BytesCData::new("")));
+    }
+
+    /// According to the grammar, only upper-case letters allowed for DOCTYPE writing.
+    ///
+    /// https://www.w3.org/TR/xml11/#NT-doctypedecl
+    mod doctype {
+        use super::*;
+
+        err!(unclosed1("<!D")         => SyntaxError::UnclosedDoctype);
+        err!(unclosed2("<!DO")        => SyntaxError::UnclosedDoctype);
+        err!(unclosed3("<!DOC")       => SyntaxError::UnclosedDoctype);
+        err!(unclosed4("<!DOCT")      => SyntaxError::UnclosedDoctype);
+        err!(unclosed5("<!DOCTY")     => SyntaxError::UnclosedDoctype);
+        err!(unclosed6("<!DOCTYP")    => SyntaxError::UnclosedDoctype);
+        err!(unclosed7("<!DOCTYPE")   => SyntaxError::UnclosedDoctype);
+        err!(unclosed8("<!DOCTYPE ")  => SyntaxError::UnclosedDoctype);
+        err!(unclosed9("<!DOCTYPE e") => SyntaxError::UnclosedDoctype);
+
+        // According to the grammar, XML declaration MUST contain at least one space
+        // and an element name, but we do not consider this as a _syntax_ error.
+        ok!(normal("<!DOCTYPE e>") => Event::DocType(BytesText::new("e")));
+    }
+
+    /// https://www.w3.org/TR/xml11/#NT-PI
+    mod pi {
+        use super::*;
+
+        err!(unclosed1("<?")    => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed2("<??")   => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed3("<?>")   => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed4("<?<")   => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed5("<?&")   => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed6("<?p")   => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed7("<? ")   => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed8("<?\t")  => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed9("<?\r")  => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed10("<?\n") => SyntaxError::UnclosedPIOrXmlDecl);
+
+        // According to the grammar, processing instruction MUST contain a non-empty
+        // target name, but we do not consider this as a _syntax_ error.
+        ok!(normal_empty("<??>")    => Event::PI(BytesText::new("")));
+        ok!(normal_xmlx("<?xmlx?>") => Event::PI(BytesText::new("xmlx")));
+    }
+
+    /// https://www.w3.org/TR/xml11/#NT-prolog
+    mod decl {
+        use super::*;
+
+        err!(unclosed1("<?x")    => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed2("<?xm")   => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed3("<?xml")  => SyntaxError::UnclosedPIOrXmlDecl);
+        err!(unclosed4("<?xml?") => SyntaxError::UnclosedPIOrXmlDecl);
+
+        // According to the grammar, XML declaration MUST contain at least one space
+        // and `version` attribute, but we do not consider this as a _syntax_ error.
+        ok!(normal1("<?xml?>")   => Event::Decl(BytesDecl::from_start(BytesStart::new("xml"))));
+        ok!(normal2("<?xml ?>")  => Event::Decl(BytesDecl::from_start(BytesStart::from_content("xml ", 3))));
+        ok!(normal3("<?xml\t?>") => Event::Decl(BytesDecl::from_start(BytesStart::from_content("xml\t", 3))));
+        ok!(normal4("<?xml\r?>") => Event::Decl(BytesDecl::from_start(BytesStart::from_content("xml\r", 3))));
+        ok!(normal5("<?xml\n?>") => Event::Decl(BytesDecl::from_start(BytesStart::from_content("xml\n", 3))));
+    }
+}

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -190,7 +190,7 @@ mod syntax {
         err!(unclosed7("<\n") => SyntaxError::UnclosedTag);
 
         /// Closed tags can be tested only in pair with open tags, because otherwise
-        /// `IllFormedError::UnmatchedEnd` will be raised
+        /// `IllFormedError::UnmatchedEndTag` will be raised
         mod normal {
             use super::*;
             use pretty_assertions::assert_eq;
@@ -607,30 +607,30 @@ mod ill_formed {
         };
     }
 
-    // IllFormedError::MissedVersion is generated lazily when you call `BytesDecl::version()`
+    // IllFormedError::MissingDeclVersion is generated lazily when you call `BytesDecl::version()`
 
-    err!(missed_doctype_name1("<!DOCTYPE>") => 9: IllFormedError::MissedDoctypeName);
+    err!(missing_doctype_name1("<!DOCTYPE>") => 9: IllFormedError::MissingDoctypeName);
     //                                  ^= 9
-    err!(missed_doctype_name2("<!DOCTYPE \t\r\n>") => 13: IllFormedError::MissedDoctypeName);
+    err!(missing_doctype_name2("<!DOCTYPE \t\r\n>") => 13: IllFormedError::MissingDoctypeName);
     //                                         ^= 13
-    ok!(missed_doctype_name3("<!DOCTYPE \t\r\nx>") => Event::DocType(BytesText::new("x")));
+    ok!(missing_doctype_name3("<!DOCTYPE \t\r\nx>") => Event::DocType(BytesText::new("x")));
 
-    err!(unmatched_end1("</>") => 0: IllFormedError::UnmatchedEnd("".to_string()));
-    err!(unmatched_end2("</end>") => 0: IllFormedError::UnmatchedEnd("end".to_string()));
-    err!(unmatched_end3("</end >") => 0: IllFormedError::UnmatchedEnd("end".to_string()));
+    err!(unmatched_end_tag1("</>") => 0: IllFormedError::UnmatchedEndTag("".to_string()));
+    err!(unmatched_end_tag2("</end>") => 0: IllFormedError::UnmatchedEndTag("end".to_string()));
+    err!(unmatched_end_tag3("</end >") => 0: IllFormedError::UnmatchedEndTag("end".to_string()));
 
-    ok!(mismatched_end1("<start></start>") => Event::Start(BytesStart::new("start")));
-    err2!(mismatched_end2("<start></>") => 7: IllFormedError::MismatchedEnd {
+    ok!(mismatched_end_tag1("<start></start>") => Event::Start(BytesStart::new("start")));
+    err2!(mismatched_end_tag2("<start></>") => 7: IllFormedError::MismatchedEndTag {
         //                        ^= 7
         expected: "start".to_string(),
         found: "".to_string(),
     });
-    err2!(mismatched_end3("<start></end>") => 7: IllFormedError::MismatchedEnd {
+    err2!(mismatched_end_tag3("<start></end>") => 7: IllFormedError::MismatchedEndTag {
         //                        ^= 7
         expected: "start".to_string(),
         found: "end".to_string(),
     });
-    err2!(mismatched_end4("<start></end >") => 7: IllFormedError::MismatchedEnd {
+    err2!(mismatched_end_tag4("<start></end >") => 7: IllFormedError::MismatchedEndTag {
         //                        ^= 7
         expected: "start".to_string(),
         found: "end".to_string(),

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -568,7 +568,7 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::MissedEnd("root".into()))
+                        assert_eq!(cause, IllFormedError::MissingEndTag("root".into()))
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -583,7 +583,7 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::MissedEnd("root".into()))
+                        assert_eq!(cause, IllFormedError::MissingEndTag("root".into()))
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -598,7 +598,7 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::MissedEnd("root".into()))
+                        assert_eq!(cause, IllFormedError::MissingEndTag("root".into()))
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -611,7 +611,7 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::MissedEnd("root".into()))
+                        assert_eq!(cause, IllFormedError::MissingEndTag("root".into()))
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -627,7 +627,7 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::MissedEnd("string".into()))
+                        assert_eq!(cause, IllFormedError::MissingEndTag("string".into()))
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -640,7 +640,7 @@ macro_rules! maplike_errors {
 
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
-                        assert_eq!(cause, IllFormedError::MissedEnd("string".into()))
+                        assert_eq!(cause, IllFormedError::MissingEndTag("string".into()))
                     }
                     x => panic!(
                         "Expected `Err(InvalidXml(IllFormed(_)))`, but got `{:?}`",
@@ -664,7 +664,7 @@ macro_rules! maplike_errors {
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
                         cause,
-                        IllFormedError::MismatchedEnd {
+                        IllFormedError::MismatchedEndTag {
                             expected: "root".into(),
                             found: "mismatched".into(),
                         }
@@ -686,7 +686,7 @@ macro_rules! maplike_errors {
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
                         cause,
-                        IllFormedError::MismatchedEnd {
+                        IllFormedError::MismatchedEndTag {
                             expected: "root".into(),
                             found: "mismatched".into(),
                         }
@@ -708,7 +708,7 @@ macro_rules! maplike_errors {
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
                         cause,
-                        IllFormedError::MismatchedEnd {
+                        IllFormedError::MismatchedEndTag {
                             expected: "root".into(),
                             found: "mismatched".into(),
                         }
@@ -730,7 +730,7 @@ macro_rules! maplike_errors {
                 match data {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => assert_eq!(
                         cause,
-                        IllFormedError::MismatchedEnd {
+                        IllFormedError::MismatchedEndTag {
                             expected: "string".into(),
                             found: "mismatched".into(),
                         }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -54,13 +54,6 @@ macro_rules! next_eq {
 }
 
 #[test]
-fn test_start() {
-    let mut r = Reader::from_str("<a>");
-    r.config_mut().trim_text(true);
-    next_eq!(r, Start, b"a");
-}
-
-#[test]
 fn test_start_end() {
     let mut r = Reader::from_str("<a></a>");
     r.config_mut().trim_text(true);
@@ -382,48 +375,6 @@ fn test_offset_err_end_element() {
         Err(_) if r.buffer_position() == 0 => (), // error at char 0: no opening tag
         Err(e) => panic!(
             "expecting buf_pos = 0, found {}, err: {:?}",
-            r.buffer_position(),
-            e
-        ),
-        e => panic!("expecting error, found {:?}", e),
-    }
-}
-
-#[test]
-fn test_offset_err_comment() {
-    let mut r = Reader::from_str("<a><!--b>");
-    r.config_mut().trim_text(true);
-
-    next_eq!(r, Start, b"a");
-    assert_eq!(r.buffer_position(), 3);
-
-    match r.read_event() {
-        // error at char 4: no closing --> tag found
-        Err(e) => assert_eq!(
-            r.buffer_position(),
-            4,
-            "expecting buf_pos = 4, found {}, err {:?}",
-            r.buffer_position(),
-            e
-        ),
-        e => panic!("expecting error, found {:?}", e),
-    }
-}
-
-#[test]
-fn test_offset_err_comment_trim_text() {
-    let mut r = Reader::from_str("<a>\r\n <!--b>");
-    r.config_mut().trim_text(true);
-
-    next_eq!(r, Start, b"a");
-    assert_eq!(r.buffer_position(), 3);
-
-    match r.read_event() {
-        // error at char 7: no closing --> tag found
-        Err(e) => assert_eq!(
-            r.buffer_position(),
-            7,
-            "expecting buf_pos = 7, found {}, err {:?}",
             r.buffer_position(),
             e
         ),

--- a/tests/xmlrs_reader_tests.rs
+++ b/tests/xmlrs_reader_tests.rs
@@ -179,24 +179,6 @@ fn sample_ns_short() {
 }
 
 #[test]
-fn eof_1() {
-    test(
-        r#"<?xml"#,
-        r#"Error: syntax error: processing instruction or xml declaration not closed: `?>` not found before end of input"#,
-        true,
-    );
-}
-
-#[test]
-fn bad_1() {
-    test(
-        r#"<?xml&.,"#,
-        r#"1:6 Error: syntax error: processing instruction or xml declaration not closed: `?>` not found before end of input"#,
-        true,
-    );
-}
-
-#[test]
 fn tabs_1() {
     test(
         "\t<a>\t<b/></a>",


### PR DESCRIPTION
This PR is a prepare step for rewriting parser from scratch. First of all I want to guarantee that behaviour will not be changed, especially conditions on which errors is returned and a final state after the error.

Thanks to that tests, I found several bugs related to result of `.buffer_position()` that should report error position.

This PR changes how some ill-formed XML constructs are processed:
- `<?xml?>` now will be threated as syntactically correct XML declaration, although it [is not well-formed](https://www.w3.org/TR/xml11/#NT-XMLDecl). Note, however, that some [online validators](https://codebeautify.org/xmlvalidator) allows such declaration. Previously it was reported as `Event::PI`. According to the specification, a `version` attribute is mandatory, but I follow the quick-xml ideology, that we do not do checks that could slow down parsing, but that checks are performed by demand. In that case when you call `BytesDecl::version()`. Maybe that is not the better way to do things, but this PR not about it.
- `<??>` now will be parsed as syntactically correct processing instruction, although it [is not well-formed](https://www.w3.org/TR/xml11/#NT-PI), previously error is returned. Again, some online validators allows that. Currently there is no way to enforce well-formedless check for PI, but I think, that could be done in #650