### PR TITLE
Fix `buffer_position()` after resuming parsing after `IllFormed` errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,10 @@ The way to configure parser is changed. Now all configuration is contained in th
 `Config` struct and can be applied at once. When `serde-types` feature is enabled,
 configuration is serializable.
 
+The method of reporting positions of errors has changed - use `error_position()`
+to get an offset of the error position. For `SyntaxError`s the range
+`error_position()..buffer_position()` also will represent a span of error.
+
 ### New Features
 
 - [#513]: Allow to continue parsing after getting new `Error::IllFormed`.
@@ -46,11 +50,14 @@ configuration is serializable.
   - `Error::XmlDeclWithoutVersion` replaced by `IllFormedError::MissingDeclVersion` (in [#684])
   - `Error::EmptyDocType` replaced by `IllFormedError::MissingDoctypeName` (in [#684])
 - [#684]: Changed positions reported for `SyntaxError`s: now they are always points
-  to the start of markup (i. e. to the `<` character) with error.
+  to the start of markup (i. e. to the `<` character) with error. Use `error_position()`
+  for that.
 - [#684]: Now `<??>` parsed as `Event::PI` with empty content instead of raising
   syntax error.
 - [#684]: Now `<?xml?>` parsed as `Event::Decl` instead of `Event::PI`.
 - [#362]: Now default quote level is `QuoteLevel::Partial` when using serde serializer.
+- [#689]: `buffer_position()` now always report the position the parser last seen.
+  To get an error position use `error_position()`.
 
 [#362]: https://github.com/tafia/quick-xml/issues/362
 [#513]: https://github.com/tafia/quick-xml/issues/513
@@ -58,6 +65,7 @@ configuration is serializable.
 [#675]: https://github.com/tafia/quick-xml/pull/675
 [#677]: https://github.com/tafia/quick-xml/pull/677
 [#684]: https://github.com/tafia/quick-xml/pull/684
+[#689]: https://github.com/tafia/quick-xml/pull/689
 
 
 ## 0.31.0 -- 2023-10-22

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -105,7 +105,7 @@ macro_rules! impl_buffered_source {
             buf.push(b'!');
             self $(.$reader)? .consume(1);
 
-            let bang_type = BangType::new(self.peek_one() $(.$await)? ?, position)?;
+            let bang_type = BangType::new(self.peek_one() $(.$await)? ?)?;
 
             loop {
                 match self $(.$reader)? .fill_buf() $(.$await)? {
@@ -139,10 +139,7 @@ macro_rules! impl_buffered_source {
                 }
             }
 
-            // <!....EOF
-            //  ^^^^^ - `buf` does not contains `<`, but we want to report error at `<`,
-            //          so we move offset to it (+1 for `<`)
-            *position -= 1;
+            *position += read;
             Err(bang_type.to_err())
         }
 
@@ -186,10 +183,7 @@ macro_rules! impl_buffered_source {
                 };
             }
 
-            // <.....EOF
-            //  ^^^^^ - `buf` does not contains `<`, but we want to report error at `<`,
-            //          so we move offset to it (+1 for `<`)
-            *position -= 1;
+            *position += read;
             Err(Error::Syntax(SyntaxError::UnclosedTag))
         }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -449,7 +449,7 @@ pub type Span = Range<usize>;
 ///   Empty     -- End                   --> ClosedTag
 ///   _ -. Eof .-> Exit
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum ParseState {
     /// Initial state in which reader stay after creation. Transition from that
     /// state could produce a `Text`, `Decl`, `Comment` or `Start` event. The next
@@ -490,7 +490,7 @@ enum ParseState {
 ///   BomDetected -- "encoding=..." --> XmlDetected
 /// ```
 #[cfg(feature = "encoding")]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum EncodingRef {
     /// Encoding was implicitly assumed to have a specified value. It can be refined
     /// using BOM or by the XML declaration event (`<?xml encoding=... ?>`)

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -331,6 +331,7 @@ macro_rules! read_until_close {
     ) => {{
         $self.state.state = ParseState::ClosedTag;
 
+        let start = $self.state.offset;
         match $reader.peek_one() $(.$await)? {
             // `<!` - comment, CDATA or DOCTYPE declaration
             Ok(Some(b'!')) => match $reader
@@ -338,7 +339,13 @@ macro_rules! read_until_close {
                 $(.$await)?
             {
                 Ok((bang_type, bytes)) => $self.state.emit_bang(bang_type, bytes),
-                Err(e) => Err(e),
+                Err(e) => {
+                    // <!....EOF
+                    //  ^^^^^ - `buf` does not contains `<`, but we want to report error at `<`,
+                    //          so we move offset to it (-1 for `<`)
+                    $self.state.last_error_offset = start - 1;
+                    Err(e)
+                }
             },
             // `</` - closing tag
             Ok(Some(b'/')) => match $reader
@@ -346,10 +353,10 @@ macro_rules! read_until_close {
                 $(.$await)?
             {
                 Ok((bytes, true)) => $self.state.emit_end(bytes),
-                Ok((bytes, false)) => {
+                Ok((_, false)) => {
                     // We want to report error at `<`, but offset was increased,
-                    // so return it back (+1 for `<`)
-                    $self.state.offset -= bytes.len() + 1;
+                    // so return it back (-1 for `<`)
+                    $self.state.last_error_offset = start - 1;
                     Err(Error::Syntax(SyntaxError::UnclosedTag))
                 }
                 Err(e) => Err(e),
@@ -360,10 +367,10 @@ macro_rules! read_until_close {
                 $(.$await)?
             {
                 Ok((bytes, true)) => $self.state.emit_question_mark(bytes),
-                Ok((bytes, false)) => {
+                Ok((_, false)) => {
                     // We want to report error at `<`, but offset was increased,
-                    // so return it back (+1 for `<`)
-                    $self.state.offset -= bytes.len() + 1;
+                    // so return it back (-1 for `<`)
+                    $self.state.last_error_offset = start - 1;
                     Err(Error::Syntax(SyntaxError::UnclosedPIOrXmlDecl))
                 }
                 Err(e) => Err(e),
@@ -379,8 +386,8 @@ macro_rules! read_until_close {
             // `<` - syntax error, tag not closed
             Ok(None) => {
                 // We want to report error at `<`, but offset was increased,
-                // so return it back (+1 for `<`)
-                $self.state.offset -= 1;
+                // so return it back (-1 for `<`)
+                $self.state.last_error_offset = start - 1;
                 Err(Error::Syntax(SyntaxError::UnclosedTag))
             }
             Err(e) => Err(e),
@@ -680,8 +687,6 @@ impl<R> Reader<R> {
     }
 
     /// Gets the current byte position in the input data.
-    ///
-    /// Useful when debugging errors.
     pub fn buffer_position(&self) -> usize {
         // when internal state is OpenedTag, we have actually read until '<',
         // which we don't want to show
@@ -690,6 +695,21 @@ impl<R> Reader<R> {
         } else {
             self.state.offset
         }
+    }
+
+    /// Gets the last error byte position in the input data. If there is no errors
+    /// yet, returns `0`.
+    ///
+    /// Unlike `buffer_position` it will point to the place where it is rational
+    /// to report error to the end user. For example, all [`SyntaxError`]s are
+    /// reported when the parser sees EOF inside of some kind of markup. The
+    /// `buffer_position()` will point to the last byte of input which is not
+    /// very useful. `error_position()` will point to the start of corresponding
+    /// markup element (i. e. to the `<` character).
+    ///
+    /// This position is always `<= buffer_position()`.
+    pub fn error_position(&self) -> usize {
+        self.state.last_error_offset
     }
 
     /// Get the decoder, used to decode bytes, read by this reader, to the strings.
@@ -870,17 +890,12 @@ enum BangType {
 }
 impl BangType {
     #[inline(always)]
-    fn new(byte: Option<u8>, position: &mut usize) -> Result<Self> {
+    fn new(byte: Option<u8>) -> Result<Self> {
         Ok(match byte {
             Some(b'[') => Self::CData,
             Some(b'-') => Self::Comment,
             Some(b'D') | Some(b'd') => Self::DocType,
-            _ => {
-                // <!EOF
-                //  ^ - we want to report error at `<`, so we move offset to it (+1 for `<`)
-                *position -= 1;
-                return Err(Error::Syntax(SyntaxError::InvalidBangMarkup));
-            }
+            _ => return Err(Error::Syntax(SyntaxError::InvalidBangMarkup)),
         })
     }
 
@@ -1148,8 +1163,7 @@ mod test {
                                 x
                             ),
                         }
-                        // We want to report error at `<`
-                        assert_eq!(position, 0);
+                        assert_eq!(position, 1);
                     }
 
                     /// Checks that if CDATA startup sequence was matched, but an end sequence
@@ -1159,7 +1173,7 @@ mod test {
                         let buf = $buf;
                         let mut position = 1;
                         let mut input = b"![CDATA[other content".as_ref();
-                        //                ^= 1
+                        //                ^= 1                 ^= 22
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::Syntax(SyntaxError::UnclosedCData)) => {}
@@ -1168,8 +1182,7 @@ mod test {
                                 x
                             ),
                         }
-                        // We want to report error at `<`
-                        assert_eq!(position, 0);
+                        assert_eq!(position, 22);
                     }
 
                     /// Checks that CDATA element without content inside parsed successfully
@@ -1248,8 +1261,7 @@ mod test {
                                 x
                             ),
                         }
-                        // We want to report error at `<`
-                        assert_eq!(position, 0);
+                        assert_eq!(position, 1);
                     }
 
                     #[$test]
@@ -1257,7 +1269,7 @@ mod test {
                         let buf = $buf;
                         let mut position = 1;
                         let mut input = b"!->other content".as_ref();
-                        //                ^= 1
+                        //                ^= 1            ^= 17
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
@@ -1266,8 +1278,7 @@ mod test {
                                 x
                             ),
                         }
-                        // We want to report error at `<`
-                        assert_eq!(position, 0);
+                        assert_eq!(position, 17);
                     }
 
                     #[$test]
@@ -1275,7 +1286,7 @@ mod test {
                         let buf = $buf;
                         let mut position = 1;
                         let mut input = b"!--other content".as_ref();
-                        //                ^= 1
+                        //                ^= 1            ^= 17
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
@@ -1284,8 +1295,7 @@ mod test {
                                 x
                             ),
                         }
-                        // We want to report error at `<`
-                        assert_eq!(position, 0);
+                        assert_eq!(position, 17);
                     }
 
                     #[$test]
@@ -1293,7 +1303,7 @@ mod test {
                         let buf = $buf;
                         let mut position = 1;
                         let mut input = b"!-->other content".as_ref();
-                        //                ^= 1
+                        //                ^= 1             ^= 18
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
@@ -1302,8 +1312,7 @@ mod test {
                                 x
                             ),
                         }
-                        // We want to report error at `<`
-                        assert_eq!(position, 0);
+                        assert_eq!(position, 18);
                     }
 
                     #[$test]
@@ -1311,7 +1320,7 @@ mod test {
                         let buf = $buf;
                         let mut position = 1;
                         let mut input = b"!--->other content".as_ref();
-                        //                ^= 1
+                        //                ^= 1              ^= 19
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                             Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
@@ -1320,8 +1329,7 @@ mod test {
                                 x
                             ),
                         }
-                        // We want to report error at `<`
-                        assert_eq!(position, 0);
+                        assert_eq!(position, 19);
                     }
 
                     #[$test]
@@ -1374,7 +1382,7 @@ mod test {
                             let buf = $buf;
                             let mut position = 1;
                             let mut input = b"!D other content".as_ref();
-                            //                ^= 1
+                            //                ^= 1            ^= 17
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
@@ -1383,8 +1391,7 @@ mod test {
                                     x
                                 ),
                             }
-                            // We want to report error at `<`
-                            assert_eq!(position, 0);
+                            assert_eq!(position, 17);
                         }
 
                         #[$test]
@@ -1392,7 +1399,7 @@ mod test {
                             let buf = $buf;
                             let mut position = 1;
                             let mut input = b"!DOCTYPEother content".as_ref();
-                            //                ^= 1
+                            //                ^= 1                 ^= 22
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
@@ -1401,8 +1408,7 @@ mod test {
                                     x
                                 ),
                             }
-                            // We want to report error at `<`
-                            assert_eq!(position, 0);
+                            assert_eq!(position, 22);
                         }
 
                         #[$test]
@@ -1428,7 +1434,7 @@ mod test {
                             let buf = $buf;
                             let mut position = 1;
                             let mut input = b"!DOCTYPE other content".as_ref();
-                            //                ^= 1
+                            //                ^= 1                  ^23
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
@@ -1437,8 +1443,7 @@ mod test {
                                     x
                                 ),
                             }
-                            // We want to report error at `<`
-                            assert_eq!(position, 0);
+                            assert_eq!(position, 23);
                         }
                     }
 
@@ -1451,7 +1456,7 @@ mod test {
                             let buf = $buf;
                             let mut position = 1;
                             let mut input = b"!d other content".as_ref();
-                            //                ^= 1
+                            //                ^= 1            ^= 17
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
@@ -1460,8 +1465,7 @@ mod test {
                                     x
                                 ),
                             }
-                            // We want to report error at `<`
-                            assert_eq!(position, 0);
+                            assert_eq!(position, 17);
                         }
 
                         #[$test]
@@ -1469,7 +1473,7 @@ mod test {
                             let buf = $buf;
                             let mut position = 1;
                             let mut input = b"!doctypeother content".as_ref();
-                            //                ^= 1
+                            //                ^= 1                 ^= 22
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
@@ -1478,8 +1482,7 @@ mod test {
                                     x
                                 ),
                             }
-                            // We want to report error at `<`
-                            assert_eq!(position, 0);
+                            assert_eq!(position, 22);
                         }
 
                         #[$test]
@@ -1505,7 +1508,7 @@ mod test {
                             let buf = $buf;
                             let mut position = 1;
                             let mut input = b"!doctype other content".as_ref();
-                            //                ^= 1
+                            //                ^= 1                  ^= 23
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
                                 Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
@@ -1514,8 +1517,7 @@ mod test {
                                     x
                                 ),
                             }
-                            // We want to report error at `<`
-                            assert_eq!(position, 0);
+                            assert_eq!(position, 23);
                         }
                     }
                 }
@@ -1542,8 +1544,7 @@ mod test {
                             x
                         ),
                     }
-                    // We want to report error at `<`
-                    assert_eq!(position, 0);
+                    assert_eq!(position, 1);
                 }
 
                 mod open {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1697,63 +1697,6 @@ mod test {
                 }
             }
 
-            mod issue_344 {
-                use crate::errors::{Error, SyntaxError};
-                use crate::reader::Reader;
-
-                #[$test]
-                $($async)? fn cdata() {
-                    let mut reader = Reader::from_str("![]]>");
-
-                    match reader.$read_until_close($buf) $(.$await)? {
-                        Err(Error::Syntax(SyntaxError::UnclosedCData)) => {}
-                        x => panic!(
-                            "Expected `Err(Syntax(UnclosedCData))`, but got `{:?}`",
-                            x
-                        ),
-                    }
-                }
-
-                #[$test]
-                $($async)? fn comment() {
-                    let mut reader = Reader::from_str("!- -->");
-
-                    match reader.$read_until_close($buf) $(.$await)? {
-                        Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
-                        x => panic!(
-                            "Expected `Err(Syntax(UnclosedComment)`, but got `{:?}`",
-                            x
-                        ),
-                    }
-                }
-
-                #[$test]
-                $($async)? fn doctype_uppercase() {
-                    let mut reader = Reader::from_str("!D>");
-
-                    match reader.$read_until_close($buf) $(.$await)? {
-                        Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
-                        x => panic!(
-                            "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
-                            x
-                        ),
-                    }
-                }
-
-                #[$test]
-                $($async)? fn doctype_lowercase() {
-                    let mut reader = Reader::from_str("!d>");
-
-                    match reader.$read_until_close($buf) $(.$await)? {
-                        Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
-                        x => panic!(
-                            "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
-                            x
-                        ),
-                    }
-                }
-            }
-
             /// Ensures, that no empty `Text` events are generated
             mod $read_event {
                 use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -286,7 +286,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         // start with it.
         debug_assert_eq!(self[0], b'!');
 
-        let bang_type = BangType::new(self[1..].first().copied(), position)?;
+        let bang_type = BangType::new(self[1..].first().copied())?;
 
         if let Some((bytes, i)) = bang_type.parse(&[], self) {
             *position += i;
@@ -294,10 +294,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
             return Ok((bang_type, bytes));
         }
 
-        // <!....EOF
-        //  ^^^^^ - `self` does not contains `<`, but we want to report error at `<`,
-        //          so we move offset to it (+1 for `<`)
-        *position -= 1;
+        *position += self.len();
         Err(bang_type.to_err())
     }
 
@@ -311,10 +308,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
             return Ok(bytes);
         }
 
-        // <.....EOF
-        //  ^^^^^ - `self` does not contains `<`, but we want to report error at `<`,
-        //          so we move offset to it (+1 for `<`)
-        *position -= 1;
+        *position += self.len();
         Err(Error::Syntax(SyntaxError::UnclosedTag))
     }
 

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -13,7 +13,7 @@ use memchr;
 /// A struct that holds a current reader state and a parser configuration.
 /// It is independent on a way of reading data: the reader feed data into it and
 /// get back produced [`Event`]s.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) struct ReaderState {
     /// Number of bytes read from the source of data since the reader was created
     pub offset: usize,

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -129,10 +129,10 @@ impl ReaderState {
                 }
             }
             _ => {
-                // <!....
-                //  ^^^^^ - `buf` does not contains `<`, but we want to report error at `<`,
-                //          so we move offset to it (+1 for `<`)
-                self.offset -= 1;
+                // <!....>
+                //  ^^^^^ - `buf` does not contain `<` and `>`, but `self.offset` is after `>`.
+                // ^------- We report error at that position, so we need to subtract 2 and buf len
+                self.offset -= len + 2;
                 Err(bang_type.to_err())
             }
         }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -73,6 +73,15 @@ fn issue299() -> Result<(), Error> {
     Ok(())
 }
 
+/// Regression test for https://github.com/tafia/quick-xml/issues/344
+#[test]
+fn issue344() {
+    let mut reader = Reader::from_str("<!D>");
+    let mut buf = Vec::new();
+    let _ = reader.read_event_into(&mut buf);
+    let _ = reader.read_event_into(&mut buf);
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/360
 #[test]
 fn issue360() {

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -610,9 +610,9 @@ mod ill_formed {
     // IllFormedError::MissingDeclVersion is generated lazily when you call `BytesDecl::version()`
 
     err!(missing_doctype_name1("<!DOCTYPE>") => 9: IllFormedError::MissingDoctypeName);
-    //                                  ^= 9
+    //                                   ^= 9
     err!(missing_doctype_name2("<!DOCTYPE \t\r\n>") => 13: IllFormedError::MissingDoctypeName);
-    //                                         ^= 13
+    //                                          ^= 13
     ok!(missing_doctype_name3("<!DOCTYPE \t\r\nx>") => Event::DocType(BytesText::new("x")));
 
     err!(unmatched_end_tag1("</>") => 0: IllFormedError::UnmatchedEndTag("".to_string()));
@@ -621,17 +621,17 @@ mod ill_formed {
 
     ok!(mismatched_end_tag1("<start></start>") => Event::Start(BytesStart::new("start")));
     err2!(mismatched_end_tag2("<start></>") => 7: IllFormedError::MismatchedEndTag {
-        //                        ^= 7
+        //                            ^= 7
         expected: "start".to_string(),
         found: "".to_string(),
     });
     err2!(mismatched_end_tag3("<start></end>") => 7: IllFormedError::MismatchedEndTag {
-        //                        ^= 7
+        //                            ^= 7
         expected: "start".to_string(),
         found: "end".to_string(),
     });
     err2!(mismatched_end_tag4("<start></end >") => 7: IllFormedError::MismatchedEndTag {
-        //                        ^= 7
+        //                            ^= 7
         expected: "start".to_string(),
         found: "end".to_string(),
     });

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -230,6 +230,7 @@ mod syntax {
         err!(unclosed5("<\t") => SyntaxError::UnclosedTag);
         err!(unclosed6("<\r") => SyntaxError::UnclosedTag);
         err!(unclosed7("<\n") => SyntaxError::UnclosedTag);
+        err!(unclosed8("< \t\r\nx") => SyntaxError::UnclosedTag);
 
         /// Closed tags can be tested only in pair with open tags, because otherwise
         /// `IllFormedError::UnmatchedEndTag` will be raised
@@ -278,20 +279,25 @@ mod syntax {
         }
     }
 
-    err!(unclosed_bang1("<!")  => SyntaxError::InvalidBangMarkup);
-    err!(unclosed_bang2("<!>") => SyntaxError::InvalidBangMarkup);
+    err!(unclosed_bang1("<!")   => SyntaxError::InvalidBangMarkup);
+    err!(unclosed_bang2("<!>")  => SyntaxError::InvalidBangMarkup);
+    err!(unclosed_bang3("<!a")  => SyntaxError::InvalidBangMarkup);
+    err!(unclosed_bang4("<!a>") => SyntaxError::InvalidBangMarkup);
 
     /// https://www.w3.org/TR/xml11/#NT-Comment
     mod comment {
         use super::*;
 
-        err!(unclosed1("<!-")    => SyntaxError::UnclosedComment);
-        err!(unclosed2("<!--")   => SyntaxError::UnclosedComment);
-        err!(unclosed3("<!->")   => SyntaxError::UnclosedComment);
-        err!(unclosed4("<!---")  => SyntaxError::UnclosedComment);
-        err!(unclosed5("<!-->")  => SyntaxError::UnclosedComment);
-        err!(unclosed6("<!----") => SyntaxError::UnclosedComment);
-        err!(unclosed7("<!--->") => SyntaxError::UnclosedComment);
+        err!(unclosed01("<!-")    => SyntaxError::UnclosedComment);
+        err!(unclosed02("<!--")   => SyntaxError::UnclosedComment);
+        err!(unclosed03("<!->")   => SyntaxError::UnclosedComment);
+        err!(unclosed04("<!-a")   => SyntaxError::UnclosedComment);
+        err!(unclosed05("<!---")  => SyntaxError::UnclosedComment);
+        err!(unclosed06("<!-->")  => SyntaxError::UnclosedComment);
+        err!(unclosed07("<!--b")  => SyntaxError::UnclosedComment);
+        err!(unclosed08("<!----") => SyntaxError::UnclosedComment);
+        err!(unclosed09("<!--->") => SyntaxError::UnclosedComment);
+        err!(unclosed10("<!---c") => SyntaxError::UnclosedComment);
 
         ok!(normal("<!---->") => Event::Comment(BytesText::new("")));
     }
@@ -300,15 +306,31 @@ mod syntax {
     mod cdata {
         use super::*;
 
-        err!(unclosed1("<![")         => SyntaxError::UnclosedCData);
-        err!(unclosed2("<![C")        => SyntaxError::UnclosedCData);
-        err!(unclosed3("<![CD")       => SyntaxError::UnclosedCData);
-        err!(unclosed4("<![CDA")      => SyntaxError::UnclosedCData);
-        err!(unclosed5("<![CDAT")     => SyntaxError::UnclosedCData);
-        err!(unclosed6("<![CDATA")    => SyntaxError::UnclosedCData);
-        err!(unclosed7("<![CDATA[")   => SyntaxError::UnclosedCData);
-        err!(unclosed8("<![CDATA[]")  => SyntaxError::UnclosedCData);
-        err!(unclosed9("<![CDATA[]]") => SyntaxError::UnclosedCData);
+        err!(unclosed01("<![")         => SyntaxError::UnclosedCData);
+        err!(unclosed02("<![C")        => SyntaxError::UnclosedCData);
+        err!(unclosed03("<![a")        => SyntaxError::UnclosedCData);
+        err!(unclosed04("<![>")        => SyntaxError::UnclosedCData);
+        err!(unclosed05("<![CD")       => SyntaxError::UnclosedCData);
+        err!(unclosed06("<![Cb")       => SyntaxError::UnclosedCData);
+        err!(unclosed07("<![C>")       => SyntaxError::UnclosedCData);
+        err!(unclosed08("<![CDA")      => SyntaxError::UnclosedCData);
+        err!(unclosed09("<![CDc")      => SyntaxError::UnclosedCData);
+        err!(unclosed10("<![CD>")      => SyntaxError::UnclosedCData);
+        err!(unclosed11("<![CDAT")     => SyntaxError::UnclosedCData);
+        err!(unclosed12("<![CDAd")     => SyntaxError::UnclosedCData);
+        err!(unclosed13("<![CDA>")     => SyntaxError::UnclosedCData);
+        err!(unclosed14("<![CDATA")    => SyntaxError::UnclosedCData);
+        err!(unclosed15("<![CDATe")    => SyntaxError::UnclosedCData);
+        err!(unclosed16("<![CDAT>")    => SyntaxError::UnclosedCData);
+        err!(unclosed17("<![CDATA[")   => SyntaxError::UnclosedCData);
+        err!(unclosed18("<![CDATAf")   => SyntaxError::UnclosedCData);
+        err!(unclosed19("<![CDATA>")   => SyntaxError::UnclosedCData);
+        err!(unclosed20("<![CDATA[]")  => SyntaxError::UnclosedCData);
+        err!(unclosed21("<![CDATA[g")  => SyntaxError::UnclosedCData);
+        err!(unclosed22("<![CDATA[>")  => SyntaxError::UnclosedCData);
+        err!(unclosed23("<![CDATA[]]") => SyntaxError::UnclosedCData);
+        err!(unclosed24("<![CDATA[]h") => SyntaxError::UnclosedCData);
+        err!(unclosed25("<![CDATA[]>") => SyntaxError::UnclosedCData);
 
         ok!(normal("<![CDATA[]]>") => Event::CData(BytesCData::new("")));
     }
@@ -319,15 +341,29 @@ mod syntax {
     mod doctype {
         use super::*;
 
-        err!(unclosed1("<!D")         => SyntaxError::UnclosedDoctype);
-        err!(unclosed2("<!DO")        => SyntaxError::UnclosedDoctype);
-        err!(unclosed3("<!DOC")       => SyntaxError::UnclosedDoctype);
-        err!(unclosed4("<!DOCT")      => SyntaxError::UnclosedDoctype);
-        err!(unclosed5("<!DOCTY")     => SyntaxError::UnclosedDoctype);
-        err!(unclosed6("<!DOCTYP")    => SyntaxError::UnclosedDoctype);
-        err!(unclosed7("<!DOCTYPE")   => SyntaxError::UnclosedDoctype);
-        err!(unclosed8("<!DOCTYPE ")  => SyntaxError::UnclosedDoctype);
-        err!(unclosed9("<!DOCTYPE e") => SyntaxError::UnclosedDoctype);
+        err!(unclosed01("<!D")         => SyntaxError::UnclosedDoctype);
+        err!(unclosed02("<!DO")        => SyntaxError::UnclosedDoctype);
+        err!(unclosed03("<!Da")        => SyntaxError::UnclosedDoctype);
+        err!(unclosed04("<!D>")        => SyntaxError::UnclosedDoctype);
+        err!(unclosed05("<!DOC")       => SyntaxError::UnclosedDoctype);
+        err!(unclosed06("<!DOb")       => SyntaxError::UnclosedDoctype);
+        err!(unclosed07("<!DO>")       => SyntaxError::UnclosedDoctype);
+        err!(unclosed08("<!DOCT")      => SyntaxError::UnclosedDoctype);
+        err!(unclosed09("<!DOCc")      => SyntaxError::UnclosedDoctype);
+        err!(unclosed10("<!DOC>")      => SyntaxError::UnclosedDoctype);
+        err!(unclosed11("<!DOCTY")     => SyntaxError::UnclosedDoctype);
+        err!(unclosed12("<!DOCTd")     => SyntaxError::UnclosedDoctype);
+        err!(unclosed13("<!DOCT>")     => SyntaxError::UnclosedDoctype);
+        err!(unclosed14("<!DOCTYP")    => SyntaxError::UnclosedDoctype);
+        err!(unclosed15("<!DOCTYe")    => SyntaxError::UnclosedDoctype);
+        err!(unclosed16("<!DOCTY>")    => SyntaxError::UnclosedDoctype);
+        err!(unclosed17("<!DOCTYPE")   => SyntaxError::UnclosedDoctype);
+        err!(unclosed18("<!DOCTYPf")   => SyntaxError::UnclosedDoctype);
+        err!(unclosed19("<!DOCTYP>")   => SyntaxError::UnclosedDoctype);
+        err!(unclosed20("<!DOCTYPE ")  => SyntaxError::UnclosedDoctype);
+        err!(unclosed21("<!DOCTYPEg")  => SyntaxError::UnclosedDoctype);
+        // <!DOCTYPE> results in IllFormed(MissingDoctypeName), checked below
+        err!(unclosed22("<!DOCTYPE e") => SyntaxError::UnclosedDoctype);
 
         // According to the grammar, XML declaration MUST contain at least one space
         // and an element name, but we do not consider this as a _syntax_ error.

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -72,10 +72,10 @@ mod syntax {
                 fn borrowed() {
                     let mut reader = Reader::from_str($xml);
                     match reader.read_event() {
-                        Err(Error::Syntax(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), 0);
-                        }
+                        Err(Error::Syntax(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, 0),
+                        ),
                         x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -87,10 +87,10 @@ mod syntax {
 
                     let mut reader = NsReader::from_str($xml);
                     match reader.read_resolved_event() {
-                        Err(Error::Syntax(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), 0);
-                        }
+                        Err(Error::Syntax(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, 0),
+                        ),
                         x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -107,10 +107,10 @@ mod syntax {
                     let mut buf = Vec::new();
                     let mut reader = Reader::from_str($xml);
                     match reader.read_event_into(&mut buf) {
-                        Err(Error::Syntax(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), 0);
-                        }
+                        Err(Error::Syntax(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, 0),
+                        ),
                         x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -122,10 +122,10 @@ mod syntax {
 
                     let mut reader = NsReader::from_str($xml);
                     match reader.read_resolved_event_into(&mut buf) {
-                        Err(Error::Syntax(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), 0);
-                        }
+                        Err(Error::Syntax(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, 0),
+                        ),
                         x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -143,10 +143,10 @@ mod syntax {
                     let mut buf = Vec::new();
                     let mut reader = Reader::from_str($xml);
                     match reader.read_event_into_async(&mut buf).await {
-                        Err(Error::Syntax(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), 0);
-                        }
+                        Err(Error::Syntax(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, 0),
+                        ),
                         x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -159,10 +159,10 @@ mod syntax {
 
                     let mut reader = NsReader::from_str($xml);
                     match reader.read_resolved_event_into_async(&mut buf).await {
-                        Err(Error::Syntax(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), 0);
-                        }
+                        Err(Error::Syntax(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, 0),
+                        ),
                         x => panic!("Expected `Err(Syntax(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -347,10 +347,10 @@ mod ill_formed {
                     let mut reader = Reader::from_str(concat!($xml, "<x/>"));
                     reader.config_mut().enable_all_checks(true);
                     match reader.read_event() {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -363,10 +363,10 @@ mod ill_formed {
                     let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
                     reader.config_mut().enable_all_checks(true);
                     match reader.read_resolved_event() {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -386,10 +386,10 @@ mod ill_formed {
                     let mut reader = Reader::from_str(concat!($xml, "<x/>"));
                     reader.config_mut().enable_all_checks(true);
                     match reader.read_event_into(&mut buf) {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -402,10 +402,10 @@ mod ill_formed {
                     let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
                     reader.config_mut().enable_all_checks(true);
                     match reader.read_resolved_event_into(&mut buf) {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -426,10 +426,10 @@ mod ill_formed {
                     let mut reader = Reader::from_str(concat!($xml, "<x/>"));
                     reader.config_mut().enable_all_checks(true);
                     match reader.read_event_into_async(&mut buf).await {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -442,10 +442,10 @@ mod ill_formed {
                     let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
                     reader.config_mut().enable_all_checks(true);
                     match reader.read_resolved_event_into_async(&mut buf).await {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -476,10 +476,10 @@ mod ill_formed {
                     reader.config_mut().enable_all_checks(true);
                     reader.read_event().expect("first .read_event()");
                     match reader.read_event() {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -493,10 +493,10 @@ mod ill_formed {
                     reader.config_mut().enable_all_checks(true);
                     reader.read_event().expect("first .read_resolved_event()");
                     match reader.read_resolved_event() {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -519,10 +519,10 @@ mod ill_formed {
                         .read_event_into(&mut buf)
                         .expect("first .read_event_into()");
                     match reader.read_event_into(&mut buf) {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -538,10 +538,10 @@ mod ill_formed {
                         .read_resolved_event_into(&mut buf)
                         .expect("first .read_resolved_event_into()");
                     match reader.read_resolved_event_into(&mut buf) {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -566,10 +566,10 @@ mod ill_formed {
                         .await
                         .expect("first .read_event_into_async()");
                     match reader.read_event_into_async(&mut buf).await {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(
@@ -586,10 +586,10 @@ mod ill_formed {
                         .await
                         .expect("first .read_resolved_event_into_async()");
                     match reader.read_resolved_event_into_async(&mut buf).await {
-                        Err(Error::IllFormed(cause)) => {
-                            assert_eq!(cause, $cause);
-                            assert_eq!(reader.buffer_position(), $pos);
-                        }
+                        Err(Error::IllFormed(cause)) => assert_eq!(
+                            (cause, reader.buffer_position()),
+                            ($cause, $pos),
+                        ),
                         x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                     }
                     assert_eq!(

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -425,7 +425,8 @@ mod ill_formed {
 
                     #[test]
                     fn borrowed() {
-                        let mut reader = Reader::from_str(concat!($xml, "<x/>"));
+                        let xml = concat!($xml, "<x/>");
+                        let mut reader = Reader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         match reader.read_event() {
                             Err(Error::IllFormed(cause)) => assert_eq!(
@@ -440,12 +441,18 @@ mod ill_formed {
                             ),
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[test]
                     fn buffered() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = Reader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = Reader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         match reader.read_event_into(&mut buf) {
                             Err(Error::IllFormed(cause)) => assert_eq!(
@@ -460,13 +467,19 @@ mod ill_formed {
                             ),
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[cfg(feature = "async-tokio")]
                     #[tokio::test]
                     async fn async_tokio() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = Reader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = Reader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         match reader.read_event_into_async(&mut buf).await {
                             Err(Error::IllFormed(cause)) => assert_eq!(
@@ -481,6 +494,11 @@ mod ill_formed {
                             ),
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
                 }
 
@@ -490,7 +508,8 @@ mod ill_formed {
 
                     #[test]
                     fn borrowed() {
-                        let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
+                        let xml = concat!($xml, "<x/>");
+                        let mut reader = NsReader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         match reader.read_resolved_event() {
                             Err(Error::IllFormed(cause)) => assert_eq!(
@@ -508,12 +527,18 @@ mod ill_formed {
                                 .1,
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[test]
                     fn buffered() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = NsReader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         match reader.read_resolved_event_into(&mut buf) {
                             Err(Error::IllFormed(cause)) => assert_eq!(
@@ -531,13 +556,19 @@ mod ill_formed {
                                 .1,
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[cfg(feature = "async-tokio")]
                     #[tokio::test]
                     async fn async_tokio() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = NsReader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         match reader.read_resolved_event_into_async(&mut buf).await {
                             Err(Error::IllFormed(cause)) => assert_eq!(
@@ -555,6 +586,11 @@ mod ill_formed {
                                 )
                                 .1,
                             Event::Empty(BytesStart::new("x"))
+                        );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
                         );
                     }
                 }
@@ -574,7 +610,8 @@ mod ill_formed {
 
                     #[test]
                     fn borrowed() {
-                        let mut reader = Reader::from_str(concat!($xml, "<x/>"));
+                        let xml = concat!($xml, "<x/>");
+                        let mut reader = Reader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         reader.read_event().expect("first .read_event()");
                         match reader.read_event() {
@@ -590,12 +627,18 @@ mod ill_formed {
                             ),
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[test]
                     fn buffered() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = Reader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = Reader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         reader
                             .read_event_into(&mut buf)
@@ -613,13 +656,19 @@ mod ill_formed {
                             ),
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[cfg(feature = "async-tokio")]
                     #[tokio::test]
                     async fn async_tokio() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = Reader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = Reader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         reader
                             .read_event_into_async(&mut buf)
@@ -638,6 +687,11 @@ mod ill_formed {
                             ),
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
                 }
 
@@ -647,7 +701,8 @@ mod ill_formed {
 
                     #[test]
                     fn borrowed() {
-                        let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
+                        let xml = concat!($xml, "<x/>");
+                        let mut reader = NsReader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         reader.read_event().expect("first .read_resolved_event()");
                         match reader.read_resolved_event() {
@@ -666,12 +721,18 @@ mod ill_formed {
                                 .1,
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[test]
                     fn buffered() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = NsReader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         reader
                             .read_resolved_event_into(&mut buf)
@@ -692,13 +753,19 @@ mod ill_formed {
                                 .1,
                             Event::Empty(BytesStart::new("x"))
                         );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
+                        );
                     }
 
                     #[cfg(feature = "async-tokio")]
                     #[tokio::test]
                     async fn async_tokio() {
+                        let xml = concat!($xml, "<x/>");
                         let mut buf = Vec::new();
-                        let mut reader = NsReader::from_str(concat!($xml, "<x/>"));
+                        let mut reader = NsReader::from_str(xml);
                         reader.config_mut().enable_all_checks(true);
                         reader
                             .read_resolved_event_into_async(&mut buf)
@@ -720,6 +787,11 @@ mod ill_formed {
                                 )
                                 .1,
                             Event::Empty(BytesStart::new("x"))
+                        );
+                        assert_eq!(
+                            reader.buffer_position(),
+                            xml.len(),
+                            ".buffer_position() is incorrect in the end"
                         );
                     }
                 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -367,22 +367,6 @@ fn test_new_xml_decl_empty() {
 }
 
 #[test]
-fn test_offset_err_end_element() {
-    let mut r = Reader::from_str("</a>");
-    r.config_mut().trim_text(true);
-
-    match r.read_event() {
-        Err(_) if r.buffer_position() == 0 => (), // error at char 0: no opening tag
-        Err(e) => panic!(
-            "expecting buf_pos = 0, found {}, err: {:?}",
-            r.buffer_position(),
-            e
-        ),
-        e => panic!("expecting error, found {:?}", e),
-    }
-}
-
-#[test]
 fn test_escaped_content() {
     let mut r = Reader::from_str("<a>&lt;test&gt;</a>");
     r.config_mut().trim_text(true);


### PR DESCRIPTION
Because since #677 we can continue parsing after `Error::IllFormed` we no longer can change `buffer_position()` so that it points to useful position of error. The best solution would be to add position to the `Error` itself, in form of:
```rust
struct Error {
  kind: ErrorKind, // former Error enum
  offset: usize,
}
```
but that would require massive changes, also in the code that I plan to remove soon during rewrite. To keep changes relative small and do not touch that code I decided to add a new `error_position()` getter which would report position of the error. After rewrite I'll try to implement the best solution.

`reader-error.rs` tests was updated to check `buffer_position()` result after resuming parsing after error. Also a couple of new cases was added, which also allowed me to find a bug in one case.