### PR TITLE
Update maybe_xml in `compare` project to the latest version and add quick-xml borrowed to compare table

### DIFF
--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-maybe_xml = "0.6"
+maybe_xml = "0.10.1"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
 rusty_xml = { version = "0.3", package = "RustyXML" }

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -100,13 +100,13 @@ fn low_level_comparison(c: &mut Criterion) {
             *data,
             |b, input| {
                 use maybe_xml::token::Ty;
-                use maybe_xml::Lexer;
+                use maybe_xml::Reader;
 
                 b.iter(|| {
-                    let lexer = Lexer::from_slice(input.as_bytes());
+                    let reader = Reader::from_str(input);
 
                     let mut count = criterion::black_box(0);
-                    for token in lexer.into_iter() {
+                    for token in reader.into_iter() {
                         match token.ty() {
                             Ty::StartTag(_) | Ty::EmptyElementTag(_) => count += 1,
                             _ => (),

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -58,12 +58,12 @@ fn low_level_comparison(c: &mut Criterion) {
             *data,
             |b, input| {
                 b.iter(|| {
-                    let mut r = Reader::from_reader(input.as_bytes());
-                    r.config_mut().check_end_names = false;
+                    let mut reader = Reader::from_reader(input.as_bytes());
+                    reader.config_mut().check_end_names = false;
                     let mut count = criterion::black_box(0);
                     let mut buf = Vec::new();
                     loop {
-                        match r.read_event_into(&mut buf) {
+                        match reader.read_event_into(&mut buf) {
                             Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
                             Ok(Event::Eof) => break,
                             _ => (),
@@ -79,8 +79,8 @@ fn low_level_comparison(c: &mut Criterion) {
             BenchmarkId::new("maybe_xml", filename),
             *data,
             |b, input| {
-                use maybe_xml::Lexer;
                 use maybe_xml::token::Ty;
+                use maybe_xml::Lexer;
 
                 b.iter(|| {
                     let lexer = Lexer::from_slice(input.as_bytes());
@@ -272,7 +272,8 @@ fn serde_comparison(c: &mut Criterion) {
             }
 
             b.iter(|| {
-                let rss: Rss<Enclosure> = criterion::black_box(quick_xml::de::from_str(input).unwrap());
+                let rss: Rss<Enclosure> =
+                    criterion::black_box(quick_xml::de::from_str(input).unwrap());
                 assert_eq!(rss.channel.items.len(), 99);
             })
         },
@@ -307,7 +308,8 @@ fn serde_comparison(c: &mut Criterion) {
             }
 
             b.iter(|| {
-                let rss: Rss<Enclosure> = criterion::black_box(serde_xml_rs::from_str(input).unwrap());
+                let rss: Rss<Enclosure> =
+                    criterion::black_box(serde_xml_rs::from_str(input).unwrap());
                 assert_eq!(rss.channel.items.len(), 99);
             })
         },


### PR DESCRIPTION
I found, that at least part of our slowdown against maybe_xml is because we benchmarked in buffered mode, while maybe_xml completely allocation-free. Add the same variant for quick-xml