### PR TITLE
Exclude namespace from tag name when comparing against field names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 - [#684]: Fix incorrect position reported for `Error::IllFormed(DoubleHyphenInComment)`.
 - [#684]: Fix incorrect position reported for `Error::IllFormed(MissingDoctypeName)`.
 - [#704]: Fix empty tags with attributes not being expanded when `expand_empty_elements` is set to true.
+- [#683]: Use local tag name when check tag name against possible names for field.
 
 ### Misc Changes
 
@@ -72,6 +73,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 [#629]: https://github.com/tafia/quick-xml/issues/629
 [#675]: https://github.com/tafia/quick-xml/pull/675
 [#677]: https://github.com/tafia/quick-xml/pull/677
+[#683]: https://github.com/tafia/quick-xml/issues/683
 [#684]: https://github.com/tafia/quick-xml/pull/684
 [#689]: https://github.com/tafia/quick-xml/pull/689
 [#704]: https://github.com/tafia/quick-xml/pull/704

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -1181,6 +1181,8 @@ where
 
 #[test]
 fn test_not_in() {
+    use pretty_assertions::assert_eq;
+
     let tag = BytesStart::new("tag");
 
     assert_eq!(not_in(&[], &tag, Decoder::utf8()).unwrap(), true);
@@ -1191,5 +1193,19 @@ fn test_not_in() {
     assert_eq!(
         not_in(&["some", "tag", "included"], &tag, Decoder::utf8()).unwrap(),
         false
+    );
+
+    let tag_ns = BytesStart::new("ns1:tag");
+    assert_eq!(
+        not_in(&["no", "such", "tags"], &tag_ns, Decoder::utf8()).unwrap(),
+        true
+    );
+    assert_eq!(
+        not_in(&["some", "tag", "included"], &tag_ns, Decoder::utf8()).unwrap(),
+        false
+    );
+    assert_eq!(
+        not_in(&["some", "namespace", "ns1:tag"], &tag_ns, Decoder::utf8()).unwrap(),
+        true
     );
 }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -789,7 +789,7 @@ fn not_in(
     start: &BytesStart,
     decoder: Decoder,
 ) -> Result<bool, DeError> {
-    let tag = decoder.decode(start.name().into_inner())?;
+    let tag = decoder.decode(start.local_name().into_inner())?;
 
     Ok(fields.iter().all(|&field| field != tag.as_ref()))
 }

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -462,3 +462,35 @@ fn issue580() {
         }
     );
 }
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/683.
+#[test]
+fn issue683() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    enum ScheduleLocation {
+        #[serde(rename = "DT")]
+        Destination,
+    }
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    #[allow(non_snake_case)]
+    struct Schedule {
+        cancelReason: Option<u32>,
+        #[serde(rename = "$value")]
+        locations: Vec<ScheduleLocation>,
+    }
+    let xml = r#"
+        <schedule xmlns:ns2="http://www.thalesgroup.com/rtti/PushPort/Schedules/v3">
+            <ns2:DT/>
+            <ns2:cancelReason>918</ns2:cancelReason>
+        </schedule>"#;
+    let result = quick_xml::de::from_str::<Schedule>(xml);
+    dbg!(&result);
+    assert_eq!(
+        result.unwrap(),
+        Schedule {
+            cancelReason: Some(918),
+            locations: vec![ScheduleLocation::Destination],
+        }
+    );
+}


### PR DESCRIPTION
Attempting to deserialize the following snippet to the following struct fails with "missing field `$value`" due to `not_in()` depending on the full name of the tag rather than the local name. This makes it impossible (or at least very difficult) to deserialize `xs:choice` values when they have a namespace prefix. Relying on local name addresses this without causing any noticeable complications.

```xml
              <t:FolderId Id="Zm9vYmFyCg==" ChangeKey="AQAAAA=="/>
              <t:ParentFolderId Id="Zm9vCg==" ChangeKey="AQAAAA=="/>
              <t:FolderClass>IPF.Note</t:FolderClass>
              <t:DisplayName>Inbox</t:DisplayName>
              <t:TotalCount>48</t:TotalCount>
              <t:ChildFolderCount>0</t:ChildFolderCount>
              <t:UnreadCount>46</t:UnreadCount>
```

```rs
#[derive(Debug, Deserialize)]
#[serde(rename_all = "PascalCase")]
pub struct FolderInner {
    pub folder_id: BaseFolderId,
    pub parent_folder_id: Option<ParentFolderId>,
    pub folder_class: Option<String>,
    pub display_name: Option<String>,
    total_count: Option<u32>,
    child_folder_count: Option<u32>,
    unread_count: Option<u32>,
}

#[derive(Debug, Deserialize)]
pub enum BaseFolderId {
    FolderId(FolderId),

    ...
}

#[derive(Debug, Deserialize)]
pub struct FolderId {
    #[serde(rename = "@Id")]
    pub id: String,

    #[serde(rename = "@ChangeKey")]
    pub change_key: Option<String>,
}
```
