### PR TITLE
enhancement: return bytes written from `write_event`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,7 +20,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 
 ### New Features
 
-- [#721]: Report bytes from `Writer::write_event`
+- [#721]: Report the number of bytes from `Writer::write_event`
 - [#513]: Allow to continue parsing after getting new `Error::IllFormed`.
 - [#677]: Added methods `config()` and `config_mut()` to inspect and change the parser
   configuration. Previous builder methods on `Reader` / `NsReader` was replaced by
@@ -62,7 +62,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 - [#689]: `buffer_position()` now always report the position the parser last seen.
   To get an error position use `error_position()`.
 
-[#721]: https://github.com/tafia/quick-xml/pull/721
+[#721]: 
 [#362]: https://github.com/tafia/quick-xml/issues/362
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 
 ### New Features
 
+- [#721]: Report bytes from `Writer::write_event`
 - [#513]: Allow to continue parsing after getting new `Error::IllFormed`.
 - [#677]: Added methods `config()` and `config_mut()` to inspect and change the parser
   configuration. Previous builder methods on `Reader` / `NsReader` was replaced by

--- a/Changelog.md
+++ b/Changelog.md
@@ -62,6 +62,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 - [#689]: `buffer_position()` now always report the position the parser last seen.
   To get an error position use `error_position()`.
 
+[#721]: https://github.com/tafia/quick-xml/pull/721
 [#362]: https://github.com/tafia/quick-xml/issues/362
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/fuzz/fuzz_targets/structured_roundtrip.rs
+++ b/fuzz/fuzz_targets/structured_roundtrip.rs
@@ -51,9 +51,15 @@ fn fuzz_round_trip(driver: Driver) -> quick_xml::Result<()> {
         // TODO: Handle error cases.
         use WriterFunc::*;
         match writer_func {
-            WriteEvent(event) => writer.write_event(event)?,
-            WriteBom => writer.write_bom()?,
-            WriteIndent => writer.write_indent()?,
+            WriteEvent(event) => {
+                writer.write_event(event)?;
+            },
+            WriteBom => { 
+                writer.write_bom()?;
+            },
+            WriteIndent => { 
+                writer.write_indent()?;
+            },
             CreateElement {
                 name,
                 func,
@@ -78,8 +84,8 @@ fn fuzz_round_trip(driver: Driver) -> quick_xml::Result<()> {
                     }
                 }
             }
-        }
-    }
+        };
+    };
     let xml = writer.into_inner().into_inner();
     // The str should be valid as we just generated it, unwrapping **should** be safe.
     let mut reader = Reader::from_str(std::str::from_utf8(&xml).unwrap());

--- a/fuzz/fuzz_targets/structured_roundtrip.rs
+++ b/fuzz/fuzz_targets/structured_roundtrip.rs
@@ -53,13 +53,13 @@ fn fuzz_round_trip(driver: Driver) -> quick_xml::Result<()> {
         match writer_func {
             WriteEvent(event) => {
                 writer.write_event(event)?;
-            },
-            WriteBom => { 
+            }
+            WriteBom => {
                 writer.write_bom()?;
-            },
-            WriteIndent => { 
+            }
+            WriteIndent => {
                 writer.write_indent()?;
-            },
+            }
             CreateElement {
                 name,
                 func,

--- a/fuzz/fuzz_targets/structured_roundtrip.rs
+++ b/fuzz/fuzz_targets/structured_roundtrip.rs
@@ -84,8 +84,8 @@ fn fuzz_round_trip(driver: Driver) -> quick_xml::Result<()> {
                     }
                 }
             }
-        };
-    };
+        }
+    }
     let xml = writer.into_inner().into_inner();
     // The str should be valid as we just generated it, unwrapping **should** be safe.
     let mut reader = Reader::from_str(std::str::from_utf8(&xml).unwrap());

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -246,10 +246,10 @@ impl<W: Write> Writer<W> {
                 n += i.current().len();
             }
         }
-        self.write(before)?;
-        self.write(value)?;
-        self.write(after)?;
-        Ok(before.len() + value.len() + after.len() + n)
+        n += self.write(before)?;
+        n += self.write(value)?;
+        n += self.write(after)?;
+        Ok(n)
     }
 
     /// Manually write a newline and indentation at the proper level.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -243,7 +243,7 @@ impl<W: Write> Writer<W> {
             if i.should_line_break {
                 self.writer.write_all(b"\n")?;
                 self.writer.write_all(i.current())?;
-                n += i.current().len();
+                n += i.current().len() + 1;
             }
         }
         n += self.write(before)?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -263,12 +263,14 @@ impl<W: Write> Writer<W> {
     /// [`Text`]: Event::Text
     /// [`Start`]: Event::Start
     /// [`new_with_indent`]: Self::new_with_indent
-    pub fn write_indent(&mut self) -> Result<()> {
+    pub fn write_indent(&mut self) -> Result<usize> {
+        let mut n = 0;
         if let Some(ref i) = self.indent {
             self.writer.write_all(b"\n")?;
             self.writer.write_all(i.current())?;
+            n += i.current().len() + 1;
         }
-        Ok(())
+        Ok(n)
     }
 
     /// Write an arbitrary serializable type

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -185,12 +185,12 @@ impl<W: Write> Writer<W> {
     /// # }
     /// ```
     /// [Byte-Order-Mark]: https://unicode.org/faq/utf_bom.html#BOM
-    pub fn write_bom(&mut self) -> Result<()> {
+    pub fn write_bom(&mut self) -> Result<usize> {
         self.write(UTF8_BOM)
     }
 
     /// Writes the given event to the underlying writer.
-    pub fn write_event<'a, E: AsRef<Event<'a>>>(&mut self, event: E) -> Result<()> {
+    pub fn write_event<'a, E: AsRef<Event<'a>>>(&mut self, event: E) -> Result<usize> {
         let mut next_should_line_break = true;
         let result = match *event.as_ref() {
             Event::Start(ref e) => {
@@ -221,7 +221,7 @@ impl<W: Write> Writer<W> {
             Event::Decl(ref e) => self.write_wrapped(b"<?", e, b"?>"),
             Event::PI(ref e) => self.write_wrapped(b"<?", e, b"?>"),
             Event::DocType(ref e) => self.write_wrapped(b"<!DOCTYPE ", e, b">"),
-            Event::Eof => Ok(()),
+            Event::Eof => Ok(0),
         };
         if let Some(i) = self.indent.as_mut() {
             i.should_line_break = next_should_line_break;
@@ -231,22 +231,25 @@ impl<W: Write> Writer<W> {
 
     /// Writes bytes
     #[inline]
-    pub(crate) fn write(&mut self, value: &[u8]) -> Result<()> {
-        self.writer.write_all(value).map_err(Into::into)
+    pub(crate) fn write(&mut self, value: &[u8]) -> Result<usize> {
+        self.writer.write_all(value)?;
+        Ok(value.len())
     }
 
     #[inline]
-    fn write_wrapped(&mut self, before: &[u8], value: &[u8], after: &[u8]) -> Result<()> {
+    fn write_wrapped(&mut self, before: &[u8], value: &[u8], after: &[u8]) -> Result<usize> {
+        let mut n = 0;
         if let Some(ref i) = self.indent {
             if i.should_line_break {
                 self.writer.write_all(b"\n")?;
                 self.writer.write_all(i.current())?;
+                n += i.current().len();
             }
         }
         self.write(before)?;
         self.write(value)?;
         self.write(after)?;
-        Ok(())
+        Ok(before.len() + value.len() + after.len() + n)
     }
 
     /// Manually write a newline and indentation at the proper level.

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -600,7 +600,6 @@ fn write_event_reports_bytes_written() {
     loop {
         match reader.read_event() {
             Ok(Start(e)) if e.name().as_ref() == b"this_tag" => {
-
                 // crates a new element ... alternatively we could reuse `e` by calling
                 // `e.into_owned()`
                 let mut elem = BytesStart::new("my_elem");
@@ -614,23 +613,23 @@ fn write_event_reports_bytes_written() {
                 // writes the event to the writer
                 n += match writer.write_event(Start(elem)) {
                     Ok(b) => b,
-                    Err(_) => panic!("Unexpected error in sample code")
+                    Err(_) => panic!("Unexpected error in sample code"),
                 }
-            },
+            }
             Ok(End(e)) if e.name().as_ref() == b"this_tag" => {
                 n += match writer.write_event(End(BytesEnd::new("my_elem"))) {
                     Ok(b) => b,
-                    Err(_) => panic!("Unexpected error in sample code")
+                    Err(_) => panic!("Unexpected error in sample code"),
                 }
-            },
+            }
             Ok(Eof) => break,
             // we can either move or borrow the event to write, depending on your use-case
-            Ok(e) => { 
-                n += match  writer.write_event(e) {
+            Ok(e) => {
+                n += match writer.write_event(e) {
                     Ok(b) => b,
-                    Err(_) => panic!("Unexpected error in sample code")
+                    Err(_) => panic!("Unexpected error in sample code"),
                 }
-            },
+            }
             Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
         }
     }


### PR DESCRIPTION
`Writer` now reports the number of bytes written by the underlying `Write`. My use case is that I need to send a prelude over TCP reporting how long serialized XML messages will be before I send the actual message.