### PR TITLE
Don't unnecessarily restrict create_element to borrowed names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,7 +30,9 @@ to get an offset of the error position. For `SyntaxError`s the range
 - [#362]: Added `BytesCData::minimal_escape()` which escapes only `&` and `<`.
 - [#362]: Added `Serializer::set_quote_level()` which allow to set desired level of escaping.
 - [#705]: Added `NsReader::prefixes()` to list all the prefixes currently declared.
-- [#629]: Added a default case to `impl_deserialize_for_internally_tagged_enum` macro so that it can handle every attribute that does not match existing cases within an enum variant.
+- [#629]: Added a default case to `impl_deserialize_for_internally_tagged_enum` macro so that
+  it can handle every attribute that does not match existing cases within an enum variant.
+- [#722]: Allow to pass owned strings to `Writer::create_element`. This is breaking change!
 
 ### Bug Fixes
 
@@ -74,6 +76,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 [#689]: https://github.com/tafia/quick-xml/pull/689
 [#704]: https://github.com/tafia/quick-xml/pull/704
 [#705]: https://github.com/tafia/quick-xml/pull/705
+[#722]: https://github.com/tafia/quick-xml/pull/722
 [#738]: https://github.com/tafia/quick-xml/pull/738
 
 

--- a/fuzz/fuzz_targets/structured_roundtrip.rs
+++ b/fuzz/fuzz_targets/structured_roundtrip.rs
@@ -60,7 +60,7 @@ fn fuzz_round_trip(driver: Driver) -> quick_xml::Result<()> {
                 attributes,
             } => {
                 let element_writer = writer
-                    .create_element(&name)
+                    .create_element(name)
                     .with_attributes(attributes.into_iter().copied());
                 use ElementWriterFunc::*;
                 match func {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,6 @@
 //! Contains high-level interface for an events-based XML emitter.
 
+use std::borrow::Cow;
 use std::io::Write;
 use std::result::Result as StdResult;
 
@@ -143,13 +144,13 @@ impl<W> Writer<W> {
     /// # }
     /// ```
     #[must_use]
-    pub fn create_element<'a, N>(&'a mut self, name: &'a N) -> ElementWriter<W>
+    pub fn create_element<'a, N>(&'a mut self, name: N) -> ElementWriter<W>
     where
-        N: 'a + AsRef<str> + ?Sized,
+        N: Into<Cow<'a, str>>,
     {
         ElementWriter {
             writer: self,
-            start_tag: BytesStart::new(name.as_ref()),
+            start_tag: BytesStart::new(name),
         }
     }
 }


### PR DESCRIPTION
This allows passing owned strings to create_element by making the bounds for the name the same as in the parameter for BytesStart::new.