### PR TITLE
First attempt to add newlines between attributes. (#275)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 - [#629]: Added a default case to `impl_deserialize_for_internally_tagged_enum` macro so that
   it can handle every attribute that does not match existing cases within an enum variant.
 - [#722]: Allow to pass owned strings to `Writer::create_element`. This is breaking change!
+- [#275]: Added `ElementWriter::new_line()` which enables pretty printing elements with multiple attributes.
 
 ### Bug Fixes
 
@@ -67,6 +68,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 - [#738]: Add an example of how to deserialize XML elements into Rust enums using an
   intermediate custom deserializer.
 
+[#275]: https://github.com/tafia/quick-xml/issues/275
 [#362]: https://github.com/tafia/quick-xml/issues/362
 [#513]: https://github.com/tafia/quick-xml/issues/513
 [#622]: https://github.com/tafia/quick-xml/issues/622

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -242,13 +242,8 @@ impl<'a> BytesStart<'a> {
     where
         A: Into<Attribute<'b>>,
     {
-        let a = attr.into();
-        let bytes = self.buf.to_mut();
-        bytes.push(b' ');
-        bytes.extend_from_slice(a.key.as_ref());
-        bytes.extend_from_slice(b"=\"");
-        bytes.extend_from_slice(a.value.as_ref());
-        bytes.push(b'"');
+        self.buf.to_mut().push(b' ');
+        self.push_attr(attr.into());
     }
 
     /// Remove all attributes from the ByteStart
@@ -286,6 +281,26 @@ impl<'a> BytesStart<'a> {
             }
         }
         Ok(None)
+    }
+
+    /// Adds an attribute to this element.
+    pub(crate) fn push_attr<'b>(&mut self, attr: Attribute<'b>) {
+        let bytes = self.buf.to_mut();
+        bytes.extend_from_slice(attr.key.as_ref());
+        bytes.extend_from_slice(b"=\"");
+        // FIXME: need to escape attribute content
+        bytes.extend_from_slice(attr.value.as_ref());
+        bytes.push(b'"');
+    }
+
+    /// Adds new line in existing element
+    pub(crate) fn push_newline(&mut self) {
+        self.buf.to_mut().push(b'\n');
+    }
+
+    /// Adds indentation bytes in existing element
+    pub(crate) fn push_indent(&mut self, indent: &[u8]) {
+        self.buf.to_mut().extend_from_slice(indent);
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/tafia/quick-xml/issues/275 
This is an implementation of the suggestion here: https://github.com/tafia/quick-xml/issues/275#issuecomment-1322157730

It may be a little hacky, I am new to Rust so if I am doing some obvious mistake please tell me. 