### PR TITLE
de: consider local name only for namespaced tags in structs with `$value`

### DIFF
--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -23,7 +23,7 @@ macro_rules! deserialize_num {
 /// The method will borrow if encoding is UTF-8 compatible and `name` contains
 /// only UTF-8 compatible characters (usually only ASCII characters).
 #[inline]
-fn decode_name<'n>(name: QName<'n>, decoder: Decoder) -> Result<Cow<'n, str>, DeError> {
+pub(super) fn decode_name<'n>(name: QName<'n>, decoder: Decoder) -> Result<Cow<'n, str>, DeError> {
     let local = name.local_name();
     Ok(decoder.decode(local.into_inner())?)
 }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -1192,4 +1192,18 @@ fn test_not_in() {
         not_in(&["some", "tag", "included"], &tag, Decoder::utf8()).unwrap(),
         false
     );
+
+    let tag_ns = BytesStart::new("ns1:tag");
+    assert_eq!(
+        not_in(&["no", "such", "tags"], &tag_ns, Decoder::utf8()).unwrap(),
+        true
+    );
+    assert_eq!(
+        not_in(&["some", "tag", "included"], &tag_ns, Decoder::utf8()).unwrap(),
+        false
+    );
+    assert_eq!(
+        not_in(&["some", "namespace", "ns1:tag"], &tag_ns, Decoder::utf8()).unwrap(),
+        true
+    );
 }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -789,7 +789,7 @@ fn not_in(
     start: &BytesStart,
     decoder: Decoder,
 ) -> Result<bool, DeError> {
-    let tag = decoder.decode(start.name().into_inner())?;
+    let tag = super::key::decode_name(start.name(), decoder)?;
 
     Ok(fields.iter().all(|&field| field != tag.as_ref()))
 }


### PR DESCRIPTION
This updates the "not_in" check that decides whether to pass a new start tag within a struct to a $value field, to only consider the local part of a QName. It now uses the same decode_name function as the QNameDeserializer that is used for keys/fields already to ensure they stay in sync.

Using the namespaced name in serde (i.e. `#[serde(rename = "ns1:tag")]`) fails with ``Custom("missing field `ns1:tag`")`` today, so this will not break existing code.

Might help with #347