### PR TITLE
Add Deserializer.into_inner destructor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@ to get an offset of the error position. For `SyntaxError`s the range
   it can handle every attribute that does not match existing cases within an enum variant.
 - [#722]: Allow to pass owned strings to `Writer::create_element`. This is breaking change!
 - [#275]: Added `ElementWriter::new_line()` which enables pretty printing elements with multiple attributes.
+- [#743]: Add `Deserializer::get_ref()` to get XML Reader from serde Deserializer
 
 ### Bug Fixes
 
@@ -83,6 +84,7 @@ to get an offset of the error position. For `SyntaxError`s the range
 [#705]: https://github.com/tafia/quick-xml/pull/705
 [#722]: https://github.com/tafia/quick-xml/pull/722
 [#738]: https://github.com/tafia/quick-xml/pull/738
+[#743]: https://github.com/tafia/quick-xml/pull/743
 [#748]: https://github.com/tafia/quick-xml/pull/748
 [`DeEvent`]: https://docs.rs/quick-xml/latest/quick_xml/de/enum.DeEvent.html
 [`PayloadEvent`]: https://docs.rs/quick-xml/latest/quick_xml/de/enum.PayloadEvent.html

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2436,6 +2436,38 @@ where
         false
     }
 
+    /// Returns the underlying XML reader.
+    ///
+    /// ```
+    /// # use pretty_assertions::assert_eq;
+    /// use serde::Deserialize;
+    /// use quick_xml::de::Deserializer;
+    /// use quick_xml::Reader;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct SomeStruct {
+    ///     field1: String,
+    ///     field2: String,
+    /// }
+    ///
+    /// // Try to deserialize from broken XML
+    /// let mut de = Deserializer::from_str(
+    ///     "<SomeStruct><field1><field2></SomeStruct>"
+    /// //   0                           ^= 28        ^= 41
+    /// );
+    ///
+    /// let err = SomeStruct::deserialize(&mut de);
+    /// assert!(err.is_err());
+    ///
+    /// let reader: &Reader<_> = de.get_ref().get_ref();
+    ///
+    /// assert_eq!(reader.error_position(), 28);
+    /// assert_eq!(reader.buffer_position(), 41);
+    /// ```
+    pub fn get_ref(&self) -> &R {
+        &self.reader.reader
+    }
+
     /// Set the maximum number of events that could be skipped during deserialization
     /// of sequences.
     ///
@@ -3065,6 +3097,41 @@ pub struct IoReader<R: BufRead> {
     buf: Vec<u8>,
 }
 
+impl<R: BufRead> IoReader<R> {
+    /// Returns the underlying XML reader.
+    ///
+    /// ```
+    /// # use pretty_assertions::assert_eq;
+    /// use serde::Deserialize;
+    /// use std::io::Cursor;
+    /// use quick_xml::de::Deserializer;
+    /// use quick_xml::Reader;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct SomeStruct {
+    ///     field1: String,
+    ///     field2: String,
+    /// }
+    ///
+    /// // Try to deserialize from broken XML
+    /// let mut de = Deserializer::from_reader(Cursor::new(
+    ///     "<SomeStruct><field1><field2></SomeStruct>"
+    /// //   0                           ^= 28        ^= 41
+    /// ));
+    ///
+    /// let err = SomeStruct::deserialize(&mut de);
+    /// assert!(err.is_err());
+    ///
+    /// let reader: &Reader<Cursor<&str>> = de.get_ref().get_ref();
+    ///
+    /// assert_eq!(reader.error_position(), 28);
+    /// assert_eq!(reader.buffer_position(), 41);
+    /// ```
+    pub fn get_ref(&self) -> &Reader<R> {
+        &self.reader
+    }
+}
+
 impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
     fn next(&mut self) -> Result<PayloadEvent<'static>, DeError> {
         loop {
@@ -3096,6 +3163,40 @@ impl<'i, R: BufRead> XmlRead<'i> for IoReader<R> {
 pub struct SliceReader<'de> {
     reader: Reader<&'de [u8]>,
     start_trimmer: StartTrimmer,
+}
+
+impl<'de> SliceReader<'de> {
+    /// Returns the underlying XML reader.
+    ///
+    /// ```
+    /// # use pretty_assertions::assert_eq;
+    /// use serde::Deserialize;
+    /// use quick_xml::de::Deserializer;
+    /// use quick_xml::Reader;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct SomeStruct {
+    ///     field1: String,
+    ///     field2: String,
+    /// }
+    ///
+    /// // Try to deserialize from broken XML
+    /// let mut de = Deserializer::from_str(
+    ///     "<SomeStruct><field1><field2></SomeStruct>"
+    /// //   0                           ^= 28        ^= 41
+    /// );
+    ///
+    /// let err = SomeStruct::deserialize(&mut de);
+    /// assert!(err.is_err());
+    ///
+    /// let reader: &Reader<&[u8]> = de.get_ref().get_ref();
+    ///
+    /// assert_eq!(reader.error_position(), 28);
+    /// assert_eq!(reader.buffer_position(), 41);
+    /// ```
+    pub fn get_ref(&self) -> &Reader<&'de [u8]> {
+        &self.reader
+    }
 }
 
 impl<'de> XmlRead<'de> for SliceReader<'de> {


### PR DESCRIPTION
It's useful to extract position from Deserializer when error occurs.
Line and column can be extracted from inner reader without the need for RefCell inside a custom Cursor.

Other serde crate `rmp_serde` supports `.into_inner()`
https://docs.rs/rmp-serde/latest/rmp_serde/decode/struct.Deserializer.html#method.into_inner


```rust
pub fn from_str_xml<'de, T>(source: &'de str) -> eyre::Result<T>
where
    T: Deserialize<'de>,
{
    use quick_xml::de::Deserializer;
    let cur = Cursor::new(source);

    let mut de = Deserializer::from_reader(cur);
    let result = T::deserialize(&mut de);

    let cur: Cursor<&str> = de.into_inner().into_inner().into_inner();
    let object: T = result.wrap_err_with(|| format!("position: {}", cur.position()))?;

    Ok(object)
}
```

or even better:
```rust
    .wrap_err_with(|| {
        if let Some(before) = source.as_bytes().get(..cur.position() as usize) {
            let line_num = before.iter().filter(|&c| *c == b'\n').count() + 1;
            let line: &[u8] = before.rsplit(|e| *e == b'\n').next().unwrap_or(before);
            let col_num = line.len();
            format!("Ln {}, Col {}", line_num, col_num)
        }else{
            format!("position: {}", cur.position())
        }
        
    })?;
```

