### PR TITLE
Fix warnings from Rust 1.80 by rely on docsrs --cfg provided by docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,9 +186,6 @@ serialize = ["serde"] # "dep:" prefix only avalible from Rust 1.60
 [package.metadata.docs.rs]
 # document all features
 all-features = true
-# defines the configuration attribute `docs_rs` to enable feature requirements
-# See https://stackoverflow.com/questions/61417452
-rustdoc-args = ["--cfg", "docs_rs"]
 
 # Tests, benchmarks and examples doesn't included in package on crates.io,
 # so we need to specify a path, otherwise `cargo package` complains

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,8 @@
 #![recursion_limit = "1024"]
 // Enable feature requirements in the docs from 1.57
 // See https://stackoverflow.com/questions/61417452
-#![cfg_attr(docs_rs, feature(doc_auto_cfg))]
+// docs.rs defines `docsrs` when building documentation
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "serialize")]
 pub mod de;


### PR DESCRIPTION
Serde maintainer say that docs.rs defines `--cfg=docsrs` when building documentation: https://github.com/serde-rs/serde/pull/2745

Fixes new warning: https://blog.rust-lang.org/2024/05/06/check-cfg.html