### PR TITLE
Allow `&#0;` character references

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -80,6 +80,7 @@ resolve predefined entities.
 - [#734]: No longer resolve predefined entities (`lt`, `gt`, `apos`, `quot`, `amp`)
   in `unescape_with` family of methods. You should do that by yourself using the methods
   listed above.
+- [#750]: Remove `EscapeError::EntityWithNull` and allow `&#0;` character reference.
 
 [#275]: https://github.com/tafia/quick-xml/issues/275
 [#362]: https://github.com/tafia/quick-xml/issues/362
@@ -98,6 +99,7 @@ resolve predefined entities.
 [#738]: https://github.com/tafia/quick-xml/pull/738
 [#743]: https://github.com/tafia/quick-xml/pull/743
 [#748]: https://github.com/tafia/quick-xml/pull/748
+[#750]: https://github.com/tafia/quick-xml/pull/750
 [`DeEvent`]: https://docs.rs/quick-xml/latest/quick_xml/de/enum.DeEvent.html
 [`PayloadEvent`]: https://docs.rs/quick-xml/latest/quick_xml/de/enum.PayloadEvent.html
 [`Text`]: https://docs.rs/quick-xml/latest/quick_xml/de/struct.Text.html


### PR DESCRIPTION
We should either restrict all invalid characters both in literal form and as character references, or none of them. Disallowing only the one character is inconsistently. Because checking literal forms means that we should decode and check all the input, this will influence performance. We are not ready to get that performance lost for now. Users of the Reader API could do their own checks themselves.

Ironically, this is what firstly was proposed in #496. After trying to finish that PR I found that we have some unanswered questions (above) which we should work out before we will be create a consistent solution. I think, it will be tight linked with #749.

I think, the best what we can do now is to not check validity of any characters and allow users to that themselves.

cc @sashka