### PR TITLE
Add `ElementParser` and probably slightly increase performance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,7 @@ resolve predefined entities.
   - `quick_xml::escape::resolve_xml_entity`
   - `quick_xml::escape::resolve_html5_entity`
 - [#753]: Added parser for processing instructions: `quick_xml::reader::PiParser`.
+- [#754]: Added parser for elements: `quick_xml::reader::ElementParser`.
 
 ### Bug Fixes
 
@@ -101,6 +102,7 @@ resolve predefined entities.
 [#743]: https://github.com/tafia/quick-xml/pull/743
 [#748]: https://github.com/tafia/quick-xml/pull/748
 [#753]: https://github.com/tafia/quick-xml/pull/753
+[#754]: https://github.com/tafia/quick-xml/pull/754
 [`DeEvent`]: https://docs.rs/quick-xml/latest/quick_xml/de/enum.DeEvent.html
 [`PayloadEvent`]: https://docs.rs/quick-xml/latest/quick_xml/de/enum.PayloadEvent.html
 [`Text`]: https://docs.rs/quick-xml/latest/quick_xml/de/struct.Text.html

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -8,9 +8,7 @@ use crate::errors::{Error, Result, SyntaxError};
 use crate::events::Event;
 use crate::name::{QName, ResolveResult};
 use crate::reader::buffered_reader::impl_buffered_source;
-use crate::reader::{
-    is_whitespace, BangType, NsReader, ParseState, ReadElementState, Reader, Span,
-};
+use crate::reader::{is_whitespace, BangType, ElementParser, NsReader, ParseState, Reader, Span};
 
 /// A struct for read XML asynchronously from an [`AsyncBufRead`].
 ///

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -8,7 +8,9 @@ use crate::errors::{Error, Result, SyntaxError};
 use crate::events::Event;
 use crate::name::{QName, ResolveResult};
 use crate::reader::buffered_reader::impl_buffered_source;
-use crate::reader::{is_whitespace, BangType, ElementParser, NsReader, ParseState, Reader, Span};
+use crate::reader::{
+    is_whitespace, BangType, ElementParser, NsReader, ParseState, Parser, PiParser, Reader, Span,
+};
 
 /// A struct for read XML asynchronously from an [`AsyncBufRead`].
 ///

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -13,6 +13,7 @@ use crate::reader::{is_whitespace, BangType, Parser, Reader, Span, XmlSource};
 macro_rules! impl_buffered_source {
     ($($lf:lifetime, $reader:tt, $async:ident, $await:ident)?) => {
         #[cfg(not(feature = "encoding"))]
+        #[inline]
         $($async)? fn remove_utf8_bom(&mut self) -> Result<()> {
             use crate::encoding::UTF8_BOM;
 
@@ -31,6 +32,7 @@ macro_rules! impl_buffered_source {
         }
 
         #[cfg(feature = "encoding")]
+        #[inline]
         $($async)? fn detect_encoding(&mut self) -> Result<Option<&'static encoding_rs::Encoding>> {
             loop {
                 break match self $(.$reader)? .fill_buf() $(.$await)? {
@@ -91,6 +93,7 @@ macro_rules! impl_buffered_source {
             Ok((&buf[start..], done))
         }
 
+        #[inline]
         $($async)? fn read_with<$($lf,)? P: Parser>(
             &mut self,
             mut parser: P,
@@ -133,6 +136,7 @@ macro_rules! impl_buffered_source {
             Err(Error::Syntax(P::eof_error()))
         }
 
+        #[inline]
         $($async)? fn read_bang_element $(<$lf>)? (
             &mut self,
             buf: &'b mut Vec<u8>,
@@ -183,6 +187,7 @@ macro_rules! impl_buffered_source {
             Err(bang_type.to_err())
         }
 
+        #[inline]
         $($async)? fn skip_whitespace(&mut self, position: &mut usize) -> Result<()> {
             loop {
                 break match self $(.$reader)? .fill_buf() $(.$await)? {
@@ -202,6 +207,7 @@ macro_rules! impl_buffered_source {
             }
         }
 
+        #[inline]
         $($async)? fn skip_one(&mut self, byte: u8) -> Result<bool> {
             // search byte must be within the ascii range
             debug_assert!(byte.is_ascii());
@@ -215,6 +221,7 @@ macro_rules! impl_buffered_source {
             }
         }
 
+        #[inline]
         $($async)? fn peek_one(&mut self) -> Result<Option<u8>> {
             loop {
                 break match self $(.$reader)? .fill_buf() $(.$await)? {

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -115,10 +115,10 @@ macro_rules! impl_buffered_source {
 
                     match parser.feed(available) {
                         Some(i) => {
-                            // We does not include `>` in data
-                            buf.extend_from_slice(&available[..i - 1]);
+                            buf.extend_from_slice(&available[..i]);
                             done = true;
-                            i
+                            // +1 for `>` which we do not include
+                            i + 1
                         }
                         None => {
                             buf.extend_from_slice(available);

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -112,22 +112,19 @@ macro_rules! impl_buffered_source {
                         }
                     };
 
-                    match parser.feed(available) {
-                        Some(i) => {
-                            buf.extend_from_slice(&available[..i]);
+                    if let Some(i) = parser.feed(available) {
+                        buf.extend_from_slice(&available[..i]);
 
-                            // +1 for `>` which we do not include
-                            self $(.$reader)? .consume(i + 1);
-                            read += i + 1;
+                        // +1 for `>` which we do not include
+                        self $(.$reader)? .consume(i + 1);
+                        read += i + 1;
 
-                            *position += read;
-                            return Ok(&buf[start..]);
-                        }
-                        None => {
-                            buf.extend_from_slice(available);
-                            available.len()
-                        }
+                        *position += read;
+                        return Ok(&buf[start..]);
                     }
+
+                    buf.extend_from_slice(available);
+                    available.len()
                 };
                 self $(.$reader)? .consume(used);
                 read += used;

--- a/src/reader/element.rs
+++ b/src/reader/element.rs
@@ -1,0 +1,113 @@
+//! Contains a parser for an XML element.
+
+/// A parser that search a `>` symbol in the slice outside of quoted regions.
+///
+/// The parser considers two quoted regions: a double-quoted (`"..."`) and
+/// a single-quoted (`'...'`) region. Matches found inside those regions are not
+/// considered as results. Each region starts and ends by its quote symbol,
+/// which cannot be escaped (but can be encoded as XML character entity or named
+/// entity. Anyway, that encoding does not contain literal quotes).
+///
+/// To use a parser create an instance of parser and [`feed`] data into it.
+/// After successful search the parser will return [`Some`] with position of
+/// found symbol. If search is unsuccessful, a [`None`] will be returned. You
+/// typically would expect positive result of search, so that you should feed
+/// new data until you get it.
+///
+/// NOTE: after successful match the parser does not returned to the initial
+/// state and should not be used anymore. Create a new parser if you want to perform
+/// new search.
+///
+/// # Example
+///
+/// ```
+/// # use quick_xml::reader::ElementParser;
+/// # use pretty_assertions::assert_eq;
+/// let mut parser = ElementParser::default();
+///
+/// // Parse `<my-element  with = 'some > inside'>and the text follow...`
+/// // splitted into three chunks
+/// assert_eq!(parser.feed(b"<my-element"), None);
+/// // ...get new chunk of data
+/// assert_eq!(parser.feed(b" with = 'some >"), None);
+/// // ...get another chunk of data
+/// assert_eq!(parser.feed(b" inside'>and the text follow..."), Some(8));
+/// //                       ^       ^
+/// //                       0       8
+/// ```
+///
+/// [`feed`]: Self::feed()
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ElementParser {
+    /// The initial state (inside element, but outside of attribute value).
+    Outside,
+    /// Inside a single-quoted region (`'...'`).
+    SingleQ,
+    /// Inside a double-quoted region (`"..."`).
+    DoubleQ,
+}
+
+impl ElementParser {
+    /// Returns number of consumed bytes or `None` if `>` was not found in `bytes`.
+    #[inline]
+    pub fn feed(&mut self, bytes: &[u8]) -> Option<usize> {
+        for i in memchr::memchr3_iter(b'>', b'\'', b'"', bytes) {
+            *self = match (*self, bytes[i]) {
+                // only allowed to match `>` while we are in state `Outside`
+                (Self::Outside, b'>') => return Some(i),
+                (Self::Outside, b'\'') => Self::SingleQ,
+                (Self::Outside, b'\"') => Self::DoubleQ,
+
+                // the only end_byte that gets us out if the same character
+                (Self::SingleQ, b'\'') | (Self::DoubleQ, b'"') => Self::Outside,
+
+                // all other bytes: no state change
+                _ => continue,
+            };
+        }
+        None
+    }
+}
+
+impl Default for ElementParser {
+    #[inline]
+    fn default() -> Self {
+        Self::Outside
+    }
+}
+
+#[test]
+fn parse() {
+    use pretty_assertions::assert_eq;
+    use ElementParser::*;
+
+    /// Returns `Ok(pos)` with the position in the buffer where element is ended.
+    ///
+    /// Returns `Err(internal_state)` if parsing does not done yet.
+    fn parse_element(bytes: &[u8], mut parser: ElementParser) -> Result<usize, ElementParser> {
+        match parser.feed(bytes) {
+            Some(i) => Ok(i),
+            None => Err(parser),
+        }
+    }
+
+    assert_eq!(parse_element(b"", Outside), Err(Outside));
+    assert_eq!(parse_element(b"", SingleQ), Err(SingleQ));
+    assert_eq!(parse_element(b"", DoubleQ), Err(DoubleQ));
+
+    assert_eq!(parse_element(b"'", Outside), Err(SingleQ));
+    assert_eq!(parse_element(b"'", SingleQ), Err(Outside));
+    assert_eq!(parse_element(b"'", DoubleQ), Err(DoubleQ));
+
+    assert_eq!(parse_element(b"\"", Outside), Err(DoubleQ));
+    assert_eq!(parse_element(b"\"", SingleQ), Err(SingleQ));
+    assert_eq!(parse_element(b"\"", DoubleQ), Err(Outside));
+
+    assert_eq!(parse_element(b">", Outside), Ok(0));
+    assert_eq!(parse_element(b">", SingleQ), Err(SingleQ));
+    assert_eq!(parse_element(b">", DoubleQ), Err(DoubleQ));
+
+    assert_eq!(parse_element(b"''>", Outside), Ok(2));
+    assert_eq!(parse_element(b"''>", SingleQ), Err(SingleQ));
+    assert_eq!(parse_element(b"''>", DoubleQ), Err(DoubleQ));
+}

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -364,14 +364,13 @@ macro_rules! read_until_close {
                 .read_pi($buf, &mut $self.state.offset)
                 $(.$await)?
             {
-                Ok((bytes, true)) => $self.state.emit_question_mark(bytes),
-                Ok((_, false)) => {
+                Ok(bytes) => $self.state.emit_question_mark(bytes),
+                Err(e) => {
                     // We want to report error at `<`, but offset was increased,
                     // so return it back (-1 for `<`)
                     $self.state.last_error_offset = start - 1;
-                    Err(Error::Syntax(SyntaxError::UnclosedPIOrXmlDecl))
+                    Err(e)
                 }
-                Err(e) => Err(e),
             },
             // `<...` - opening or self-closed tag
             Ok(Some(_)) => match $reader
@@ -833,7 +832,7 @@ trait XmlSource<'r, B> {
     /// - `position`: Will be increased by amount of bytes consumed
     ///
     /// [events]: crate::events::Event
-    fn read_pi(&mut self, buf: B, position: &mut usize) -> Result<(&'r [u8], bool)>;
+    fn read_pi(&mut self, buf: B, position: &mut usize) -> Result<&'r [u8]>;
 
     /// Read input until comment or CDATA is finished.
     ///

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -279,7 +279,8 @@ macro_rules! read_until_open {
         }
 
         // If we already at the `<` symbol, do not try to return an empty Text event
-        if $reader.skip_one(b'<', &mut $self.state.offset) $(.$await)? ? {
+        if $reader.skip_one(b'<') $(.$await)? ? {
+            $self.state.offset += 1;
             $self.state.state = ParseState::OpenedTag;
             // Pass $buf to the next next iteration of parsing loop
             return Ok(Err($buf));
@@ -889,8 +890,8 @@ trait XmlSource<'r, B> {
     /// `true` if it matched.
     ///
     /// # Parameters
-    /// - `position`: Will be increased by 1 if byte is matched
-    fn skip_one(&mut self, byte: u8, position: &mut usize) -> Result<bool>;
+    /// - `byte`: Character to skip
+    fn skip_one(&mut self, byte: u8) -> Result<bool>;
 
     /// Return one character without consuming it, so that future `read_*` calls
     /// will still include it. On EOF, return `None`.

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -322,12 +322,11 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         Ok(())
     }
 
-    fn skip_one(&mut self, byte: u8, position: &mut usize) -> Result<bool> {
+    fn skip_one(&mut self, byte: u8) -> Result<bool> {
         // search byte must be within the ascii range
         debug_assert!(byte.is_ascii());
         if self.first() == Some(&byte) {
             *self = &self[1..];
-            *position += 1;
             Ok(true)
         } else {
             Ok(false)

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -237,6 +237,7 @@ impl<'a> Reader<&'a [u8]> {
 /// that will be borrowed by events. This implementation provides a zero-copy deserialization
 impl<'a> XmlSource<'a, ()> for &'a [u8] {
     #[cfg(not(feature = "encoding"))]
+    #[inline]
     fn remove_utf8_bom(&mut self) -> Result<()> {
         if self.starts_with(crate::encoding::UTF8_BOM) {
             *self = &self[crate::encoding::UTF8_BOM.len()..];
@@ -245,6 +246,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     #[cfg(feature = "encoding")]
+    #[inline]
     fn detect_encoding(&mut self) -> Result<Option<&'static Encoding>> {
         if let Some((enc, bom_len)) = crate::encoding::detect_encoding(self) {
             *self = &self[bom_len..];
@@ -253,6 +255,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         Ok(None)
     }
 
+    #[inline]
     fn read_bytes_until(
         &mut self,
         byte: u8,
@@ -275,6 +278,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         }
     }
 
+    #[inline]
     fn read_with<P>(&mut self, mut parser: P, _buf: (), position: &mut usize) -> Result<&'a [u8]>
     where
         P: Parser,
@@ -291,6 +295,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         Err(Error::Syntax(P::eof_error()))
     }
 
+    #[inline]
     fn read_bang_element(
         &mut self,
         _buf: (),
@@ -312,6 +317,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         Err(bang_type.to_err())
     }
 
+    #[inline]
     fn skip_whitespace(&mut self, position: &mut usize) -> Result<()> {
         let whitespaces = self
             .iter()
@@ -322,6 +328,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         Ok(())
     }
 
+    #[inline]
     fn skip_one(&mut self, byte: u8) -> Result<bool> {
         // search byte must be within the ascii range
         debug_assert!(byte.is_ascii());
@@ -333,6 +340,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         }
     }
 
+    #[inline]
     fn peek_one(&mut self) -> Result<Option<u8>> {
         Ok(self.first().copied())
     }

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -12,7 +12,7 @@ use encoding_rs::{Encoding, UTF_8};
 use crate::errors::{Error, Result, SyntaxError};
 use crate::events::Event;
 use crate::name::QName;
-use crate::reader::{is_whitespace, BangType, PiParser, ReadElementState, Reader, Span, XmlSource};
+use crate::reader::{is_whitespace, BangType, ElementParser, PiParser, Reader, Span, XmlSource};
 
 /// This is an implementation for reading from a `&[u8]` as underlying byte stream.
 /// This implementation supports not using an intermediate buffer as the byte slice
@@ -312,12 +312,13 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     fn read_element(&mut self, _buf: (), position: &mut usize) -> Result<&'a [u8]> {
-        let mut state = ReadElementState::Elem;
+        let mut parser = ElementParser::default();
 
-        if let Some((bytes, i)) = state.change(self) {
-            // Position now just after the `>` symbol
-            *position += i;
-            *self = &self[i..];
+        if let Some(i) = parser.feed(self) {
+            // +1 for `>` which we do not include
+            *position += i + 1;
+            let bytes = &self[..i];
+            *self = &self[i + 1..];
             return Ok(bytes);
         }
 

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -279,10 +279,10 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         let mut parser = PiParser::default();
 
         if let Some(i) = parser.feed(self) {
-            *position += i;
-            // We does not include `>` in data
-            let bytes = &self[..i - 1];
-            *self = &self[i..];
+            // +1 for `>` which we do not include
+            *position += i + 1;
+            let bytes = &self[..i];
+            *self = &self[i + 1..];
             Ok((bytes, true))
         } else {
             *position += self.len();

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -275,7 +275,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         }
     }
 
-    fn read_pi(&mut self, _buf: (), position: &mut usize) -> Result<(&'a [u8], bool)> {
+    fn read_pi(&mut self, _buf: (), position: &mut usize) -> Result<&'a [u8]> {
         let mut parser = PiParser::default();
 
         if let Some(i) = parser.feed(self) {
@@ -283,13 +283,11 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
             *position += i + 1;
             let bytes = &self[..i];
             *self = &self[i + 1..];
-            Ok((bytes, true))
-        } else {
-            *position += self.len();
-            let bytes = &self[..];
-            *self = &[];
-            Ok((bytes, false))
+            return Ok(bytes);
         }
+
+        *position += self.len();
+        Err(Error::Syntax(SyntaxError::UnclosedPIOrXmlDecl))
     }
 
     fn read_bang_element(


### PR DESCRIPTION
This is follow-up PR to #753 which polish API of introduced `PiParser` (which could be used to parse DTD) and add the similar parser to handle elements (which also could be used to parse `<!ELEMENT>` and `<!ATTLIST>` DTD tags). Also, this PR reduces amount of duplicated code and probably slightly increases performance as showed by benchmarks (master -- 385a1f8229abb35acac16b3eba574fe215bdcb1d). However, in some tests there is a deviation of > = 5% even on consecutive runs on master, so most likely the acceleration is quite insignificant. `escape_test` are also quite sensitive to noise, which reaches 15% there.

Full diff:
```
> critcmp master element-parser
group                                                                  element-parser                         master
-----                                                                  --------------                         ------
NsReader::read_resolved_event_into/trim_text = false                   1.00    398.9±6.30µs        ? ?/sec    1.05    419.6±7.94µs        ? ?/sec
NsReader::read_resolved_event_into/trim_text = true                    1.00    382.1±7.06µs        ? ?/sec    1.06    404.0±7.44µs        ? ?/sec
One event/CData                                                        1.00     56.3±0.97ns        ? ?/sec    1.21     68.1±1.35ns        ? ?/sec
One event/Comment                                                      1.00    141.2±2.52ns        ? ?/sec    1.14    161.4±2.79ns        ? ?/sec
One event/Start                                                        1.00    206.4±3.41ns        ? ?/sec    1.01    209.3±4.15ns        ? ?/sec
attributes/try_get_attribute                                           1.01     94.8±1.64µs        ? ?/sec    1.00     93.9±1.76µs        ? ?/sec
attributes/with_checks = false                                         1.02     53.0±1.02µs        ? ?/sec    1.00     52.2±0.91µs        ? ?/sec
attributes/with_checks = true                                          1.03     88.0±1.66µs        ? ?/sec    1.00     85.8±1.67µs        ? ?/sec
decode_and_parse_document/document.xml                                 1.02     93.2±1.80µs   118.0 MB/sec    1.00     91.7±1.67µs   119.9 MB/sec
decode_and_parse_document/libreoffice_document.fodt                    1.00    345.8±6.24µs   157.9 MB/sec    1.00    345.0±6.41µs   158.3 MB/sec
decode_and_parse_document/linescore.xml                                1.00     22.2±0.43µs   159.1 MB/sec    1.01     22.4±0.42µs   157.8 MB/sec
decode_and_parse_document/players.xml                                  1.00    128.2±2.44µs   113.1 MB/sec    1.01    129.2±2.03µs   112.2 MB/sec
decode_and_parse_document/rpm_filelists.xml                            1.01     69.3±1.21µs   158.4 MB/sec    1.00     68.7±1.28µs   160.0 MB/sec
decode_and_parse_document/rpm_other.xml                                1.03    112.9±2.12µs   196.2 MB/sec    1.00    109.7±2.12µs   201.7 MB/sec
decode_and_parse_document/rpm_primary.xml                              1.01    150.8±2.72µs   134.4 MB/sec    1.00    149.1±3.14µs   136.0 MB/sec
decode_and_parse_document/rpm_primary2.xml                             1.01     49.3±0.99µs   145.5 MB/sec    1.00     48.8±0.90µs   147.1 MB/sec
decode_and_parse_document/sample_1.xml                                 1.01      8.7±0.16µs   126.3 MB/sec    1.00      8.6±0.15µs   127.6 MB/sec
decode_and_parse_document/sample_ns.xml                                1.00      6.4±0.12µs   113.8 MB/sec    1.00      6.4±0.11µs   113.6 MB/sec
decode_and_parse_document/sample_rss.xml                               1.02   610.0±10.55µs   309.2 MB/sec    1.00   599.2±10.85µs   314.7 MB/sec
decode_and_parse_document/test_writer_ident.xml                        1.00     20.9±0.38µs   203.5 MB/sec    1.00     20.8±0.40µs   203.7 MB/sec
decode_and_parse_document_with_namespaces/document.xml                 1.00    140.0±2.47µs    78.5 MB/sec    1.03    144.0±2.80µs    76.3 MB/sec
decode_and_parse_document_with_namespaces/libreoffice_document.fodt    1.00   537.4±10.61µs   101.6 MB/sec    1.03   553.9±10.50µs    98.6 MB/sec
decode_and_parse_document_with_namespaces/linescore.xml                1.00     28.3±0.53µs   124.6 MB/sec    1.02     29.0±0.54µs   121.9 MB/sec
decode_and_parse_document_with_namespaces/players.xml                  1.00    161.9±2.86µs    89.5 MB/sec    1.00    162.2±2.70µs    89.3 MB/sec
decode_and_parse_document_with_namespaces/rpm_filelists.xml            1.00     95.1±1.45µs   115.5 MB/sec    1.07    102.2±1.65µs   107.5 MB/sec
decode_and_parse_document_with_namespaces/rpm_other.xml                1.00    145.7±2.69µs   151.9 MB/sec    1.03    150.3±3.00µs   147.3 MB/sec
decode_and_parse_document_with_namespaces/rpm_primary.xml              1.00    204.7±3.66µs    99.0 MB/sec    1.05    214.1±3.97µs    94.7 MB/sec
decode_and_parse_document_with_namespaces/rpm_primary2.xml             1.00     66.9±1.58µs   107.2 MB/sec    1.05     70.1±1.20µs   102.3 MB/sec
decode_and_parse_document_with_namespaces/sample_1.xml                 1.00     11.5±0.22µs    95.3 MB/sec    1.01     11.7±0.22µs    94.2 MB/sec
decode_and_parse_document_with_namespaces/sample_ns.xml                1.00      9.3±0.16µs    78.0 MB/sec    1.04      9.6±0.18µs    75.3 MB/sec
decode_and_parse_document_with_namespaces/sample_rss.xml               1.00   854.7±13.16µs   220.7 MB/sec    1.03   882.0±14.76µs   213.8 MB/sec
decode_and_parse_document_with_namespaces/test_writer_ident.xml        1.00     31.1±0.59µs   136.4 MB/sec    1.02     31.7±0.55µs   133.7 MB/sec
escape_text/escaped_chars_long                                         1.42  1806.4±34.20ns        ? ?/sec    1.00  1275.0±23.98ns        ? ?/sec
escape_text/escaped_chars_short                                        1.00    491.5±8.35ns        ? ?/sec    1.07   526.6±10.80ns        ? ?/sec
escape_text/no_chars_to_escape_long                                    2.06  1831.1±36.31ns        ? ?/sec    1.00   887.1±17.00ns        ? ?/sec
escape_text/no_chars_to_escape_short                                   1.02     16.7±0.30ns        ? ?/sec    1.00     16.4±0.31ns        ? ?/sec
parse_document_nocopy/document.xml                                     1.00     87.4±1.66µs   125.8 MB/sec    1.01     87.8±1.76µs   125.1 MB/sec
parse_document_nocopy/libreoffice_document.fodt                        1.00    325.5±5.91µs   167.7 MB/sec    1.01    329.7±5.93µs   165.6 MB/sec
parse_document_nocopy/linescore.xml                                    1.00     21.6±0.34µs   163.6 MB/sec    1.00     21.5±0.38µs   163.9 MB/sec
parse_document_nocopy/players.xml                                      1.00    127.0±2.00µs   114.1 MB/sec    1.00    126.5±2.28µs   114.6 MB/sec
parse_document_nocopy/rpm_filelists.xml                                1.00     63.7±1.14µs   172.5 MB/sec    1.03     65.6±1.14µs   167.5 MB/sec
parse_document_nocopy/rpm_other.xml                                    1.00    106.5±2.01µs   207.9 MB/sec    1.00    107.0±1.91µs   206.9 MB/sec
parse_document_nocopy/rpm_primary.xml                                  1.00    140.0±2.44µs   144.8 MB/sec    1.03    144.1±2.66µs   140.6 MB/sec
parse_document_nocopy/rpm_primary2.xml                                 1.00     45.5±0.89µs   157.6 MB/sec    1.01     46.1±0.80µs   155.5 MB/sec
parse_document_nocopy/sample_1.xml                                     1.00      7.8±0.13µs   140.6 MB/sec    1.03      8.0±0.13µs   137.1 MB/sec
parse_document_nocopy/sample_ns.xml                                    1.00      5.6±0.10µs   129.0 MB/sec    1.01      5.7±0.10µs   127.6 MB/sec
parse_document_nocopy/sample_rss.xml                                   1.00   555.7±10.46µs   339.4 MB/sec    1.03   573.1±10.46µs   329.1 MB/sec
parse_document_nocopy/test_writer_ident.xml                            1.00     19.4±0.32µs   218.8 MB/sec    1.00     19.4±0.35µs   218.7 MB/sec
parse_document_nocopy_with_namespaces/document.xml                     1.00    133.0±2.54µs    82.7 MB/sec    1.05    139.4±2.32µs    78.8 MB/sec
parse_document_nocopy_with_namespaces/libreoffice_document.fodt        1.00    507.2±8.56µs   107.6 MB/sec    1.08   546.2±10.20µs   100.0 MB/sec
parse_document_nocopy_with_namespaces/linescore.xml                    1.00     27.6±0.45µs   127.8 MB/sec    1.03     28.3±0.60µs   124.6 MB/sec
parse_document_nocopy_with_namespaces/players.xml                      1.00    158.0±2.95µs    91.8 MB/sec    1.02    160.6±2.72µs    90.3 MB/sec
parse_document_nocopy_with_namespaces/rpm_filelists.xml                1.00     87.2±1.64µs   126.0 MB/sec    1.14     99.2±1.74µs   110.7 MB/sec
parse_document_nocopy_with_namespaces/rpm_other.xml                    1.00    139.6±2.83µs   158.5 MB/sec    1.07    148.7±2.71µs   148.9 MB/sec
parse_document_nocopy_with_namespaces/rpm_primary.xml                  1.00    190.5±3.43µs   106.4 MB/sec    1.09    207.9±3.79µs    97.5 MB/sec
parse_document_nocopy_with_namespaces/rpm_primary2.xml                 1.00     61.7±1.10µs   116.2 MB/sec    1.09     67.5±1.28µs   106.2 MB/sec
parse_document_nocopy_with_namespaces/sample_1.xml                     1.00     10.5±0.20µs   105.0 MB/sec    1.06     11.1±0.21µs    99.3 MB/sec
parse_document_nocopy_with_namespaces/sample_ns.xml                    1.00      8.4±0.16µs    86.5 MB/sec    1.08      9.0±0.18µs    80.0 MB/sec
parse_document_nocopy_with_namespaces/sample_rss.xml                   1.00   786.4±13.46µs   239.8 MB/sec    1.09   859.9±12.82µs   219.3 MB/sec
parse_document_nocopy_with_namespaces/test_writer_ident.xml            1.00     29.0±0.55µs   146.4 MB/sec    1.06     30.8±0.55µs   138.0 MB/sec
read_event/trim_text = false                                           1.00    199.3±3.59µs        ? ?/sec    1.10    218.5±3.98µs        ? ?/sec
read_event/trim_text = true                                            1.00    190.4±3.76µs        ? ?/sec    1.11    211.7±4.11µs        ? ?/sec
unescape_text/char_reference                                           1.01    270.4±5.27ns        ? ?/sec    1.00    268.7±5.46ns        ? ?/sec
unescape_text/entity_reference                                         1.00    399.6±7.31ns        ? ?/sec    1.04    417.4±7.35ns        ? ?/sec
unescape_text/mixed                                                    1.00    364.4±7.30ns        ? ?/sec    1.01    367.5±7.24ns        ? ?/sec
unescape_text/no_chars_to_unescape_long                                1.00     71.1±1.33ns        ? ?/sec    1.00     70.9±1.37ns        ? ?/sec
unescape_text/no_chars_to_unescape_short                               1.00     11.8±0.21ns        ? ?/sec    1.06     12.4±0.23ns        ? ?/sec
```
Only >=5% diff:
```
> critcmp master element-parser -t 5
group                                                              element-parser                         master
-----                                                              --------------                         ------
NsReader::read_resolved_event_into/trim_text = false               1.00    398.9±6.30µs        ? ?/sec    1.05    419.6±7.94µs        ? ?/sec
NsReader::read_resolved_event_into/trim_text = true                1.00    382.1±7.06µs        ? ?/sec    1.06    404.0±7.44µs        ? ?/sec
One event/CData                                                    1.00     56.3±0.97ns        ? ?/sec    1.21     68.1±1.35ns        ? ?/sec
One event/Comment                                                  1.00    141.2±2.52ns        ? ?/sec    1.14    161.4±2.79ns        ? ?/sec
decode_and_parse_document_with_namespaces/rpm_filelists.xml        1.00     95.1±1.45µs   115.5 MB/sec    1.07    102.2±1.65µs   107.5 MB/sec
escape_text/escaped_chars_long                                     1.42  1806.4±34.20ns        ? ?/sec    1.00  1275.0±23.98ns        ? ?/sec
escape_text/escaped_chars_short                                    1.00    491.5±8.35ns        ? ?/sec    1.07   526.6±10.80ns        ? ?/sec
escape_text/no_chars_to_escape_long                                2.06  1831.1±36.31ns        ? ?/sec    1.00   887.1±17.00ns        ? ?/sec
parse_document_nocopy_with_namespaces/libreoffice_document.fodt    1.00    507.2±8.56µs   107.6 MB/sec    1.08   546.2±10.20µs   100.0 MB/sec
parse_document_nocopy_with_namespaces/rpm_filelists.xml            1.00     87.2±1.64µs   126.0 MB/sec    1.14     99.2±1.74µs   110.7 MB/sec
parse_document_nocopy_with_namespaces/rpm_other.xml                1.00    139.6±2.83µs   158.5 MB/sec    1.07    148.7±2.71µs   148.9 MB/sec
parse_document_nocopy_with_namespaces/rpm_primary.xml              1.00    190.5±3.43µs   106.4 MB/sec    1.09    207.9±3.79µs    97.5 MB/sec
parse_document_nocopy_with_namespaces/rpm_primary2.xml             1.00     61.7±1.10µs   116.2 MB/sec    1.09     67.5±1.28µs   106.2 MB/sec
parse_document_nocopy_with_namespaces/sample_1.xml                 1.00     10.5±0.20µs   105.0 MB/sec    1.06     11.1±0.21µs    99.3 MB/sec
parse_document_nocopy_with_namespaces/sample_ns.xml                1.00      8.4±0.16µs    86.5 MB/sec    1.08      9.0±0.18µs    80.0 MB/sec
parse_document_nocopy_with_namespaces/sample_rss.xml               1.00   786.4±13.46µs   239.8 MB/sec    1.09   859.9±12.82µs   219.3 MB/sec
parse_document_nocopy_with_namespaces/test_writer_ident.xml        1.00     29.0±0.55µs   146.4 MB/sec    1.06     30.8±0.55µs   138.0 MB/sec
read_event/trim_text = false                                       1.00    199.3±3.59µs        ? ?/sec    1.10    218.5±3.98µs        ? ?/sec
read_event/trim_text = true                                        1.00    190.4±3.76µs        ? ?/sec    1.11    211.7±4.11µs        ? ?/sec
unescape_text/no_chars_to_unescape_short                           1.00     11.8±0.21ns        ? ?/sec    1.06     12.4±0.23ns        ? ?/sec
```

`escape_text` results floats even at master

This is the last PR before release `0.32.0`.