### PR TITLE
Fix incorrect missing of trimming all-space text events when `trim_text_start = false` and `trim_text_end = true`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,11 +14,15 @@
 
 ### Bug Fixes
 
+- [#755]: Fix incorrect missing of trimming all-space text events when
+  `trim_text_start = false` and `trim_text_end = true`.
+
 ### Misc Changes
 
 - [#650]: Change the type of `Event::PI` to a new dedicated `BytesPI` type.
 
 [#650]: https://github.com/tafia/quick-xml/issues/650
+[#755]: https://github.com/tafia/quick-xml/pull/755
 
 
 ## 0.32.0 -- 2024-06-10

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -78,7 +78,6 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
         read_event_impl!(
             self, buf,
             TokioAdapter(&mut self.reader),
-            read_until_open_async,
             read_until_close_async,
             await
         )
@@ -140,17 +139,6 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
         buf: &mut Vec<u8>,
     ) -> Result<Span> {
         Ok(read_to_end!(self, end, buf, read_event_into_async, { buf.clear(); }, await))
-    }
-
-    /// Read until '<' is found, moves reader to an `OpenedTag` state and returns a `Text` event.
-    ///
-    /// Returns inner `Ok` if the loop should be broken and an event returned.
-    /// Returns inner `Err` with the same `buf` because Rust borrowck stumbles upon this case in particular.
-    async fn read_until_open_async<'b>(
-        &mut self,
-        buf: &'b mut Vec<u8>,
-    ) -> Result<std::result::Result<Event<'b>, &'b mut Vec<u8>>> {
-        read_until_open!(self, buf, TokioAdapter(&mut self.reader), read_event_into_async, await)
     }
 
     /// Private function to read until `>` is found. This function expects that

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -9,7 +9,8 @@ use crate::events::Event;
 use crate::name::{QName, ResolveResult};
 use crate::reader::buffered_reader::impl_buffered_source;
 use crate::reader::{
-    is_whitespace, BangType, ElementParser, NsReader, ParseState, Parser, PiParser, Reader, Span,
+    is_whitespace, BangType, ElementParser, NsReader, ParseState, Parser, PiParser, ReadTextResult,
+    Reader, Span,
 };
 
 /// A struct for read XML asynchronously from an [`AsyncBufRead`].

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -72,19 +72,23 @@ macro_rules! impl_buffered_source {
                     }
                 };
 
-                let used = match memchr::memchr(byte, available) {
+                match memchr::memchr(byte, available) {
                     Some(i) => {
                         buf.extend_from_slice(&available[..i]);
                         done = true;
-                        i + 1
+
+                        let used = i + 1;
+                        self $(.$reader)? .consume(used);
+                        read += used;
                     }
                     None => {
                         buf.extend_from_slice(available);
-                        available.len()
+
+                        let used = available.len();
+                        self $(.$reader)? .consume(used);
+                        read += used;
                     }
-                };
-                self $(.$reader)? .consume(used);
-                read += used;
+                }
             }
             *position += read;
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -230,7 +230,7 @@ macro_rules! read_event_impl {
                     $self.state.state = ParseState::ClosedTag;
                     continue;
                 },
-                ParseState::ClosedTag => { // Go to OpenedTag state
+                ParseState::ClosedTag => { // Go to OpenedTag or Exit state
                     if $self.state.config.trim_text_start {
                         $reader.skip_whitespace(&mut $self.state.offset) $(.$await)? ?;
                     }
@@ -248,6 +248,7 @@ macro_rules! read_event_impl {
                             $self.state.emit_text(bytes)
                         }
                         ReadTextResult::UpToEof(bytes) => {
+                            $self.state.state = ParseState::Exit;
                             // Return Text event with `bytes` content or Eof if bytes is empty
                             $self.state.emit_text(bytes)
                         }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -328,7 +328,7 @@ macro_rules! read_until_close {
                     $self.state.last_error_offset = start - 1;
                     Err(Error::Syntax(SyntaxError::UnclosedTag))
                 }
-                Err(e) => Err(e),
+                Err(e) => Err(Error::Io(e.into())),
             },
             // `<?` - processing instruction
             Ok(Some(b'?')) => match $reader
@@ -358,7 +358,7 @@ macro_rules! read_until_close {
                 $self.state.last_error_offset = start - 1;
                 Err(Error::Syntax(SyntaxError::UnclosedTag))
             }
-            Err(e) => Err(e),
+            Err(e) => Err(Error::Io(e.into())),
         }
     }};
 }
@@ -774,11 +774,11 @@ pub trait Parser {
 trait XmlSource<'r, B> {
     /// Removes UTF-8 BOM if it is present
     #[cfg(not(feature = "encoding"))]
-    fn remove_utf8_bom(&mut self) -> Result<()>;
+    fn remove_utf8_bom(&mut self) -> io::Result<()>;
 
     /// Determines encoding from the start of input and removes BOM if it is present
     #[cfg(feature = "encoding")]
-    fn detect_encoding(&mut self) -> Result<Option<&'static Encoding>>;
+    fn detect_encoding(&mut self) -> io::Result<Option<&'static Encoding>>;
 
     /// Read input until start of markup (the `<`) is found or end of input is reached.
     ///
@@ -838,7 +838,7 @@ trait XmlSource<'r, B> {
         byte: u8,
         buf: B,
         position: &mut usize,
-    ) -> Result<(&'r [u8], bool)>;
+    ) -> io::Result<(&'r [u8], bool)>;
 
     /// Read input until processing instruction is finished.
     ///
@@ -884,11 +884,11 @@ trait XmlSource<'r, B> {
     ///
     /// # Parameters
     /// - `position`: Will be increased by amount of bytes consumed
-    fn skip_whitespace(&mut self, position: &mut usize) -> Result<()>;
+    fn skip_whitespace(&mut self, position: &mut usize) -> io::Result<()>;
 
     /// Return one character without consuming it, so that future `read_*` calls
     /// will still include it. On EOF, return `None`.
-    fn peek_one(&mut self) -> Result<Option<u8>>;
+    fn peek_one(&mut self) -> io::Result<Option<u8>>;
 }
 
 /// Possible elements started with `<!`

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -227,12 +227,7 @@ macro_rules! read_event_impl {
                     #[cfg(not(feature = "encoding"))]
                     $reader.remove_utf8_bom() $(.$await)? ?;
 
-                    // Go to OpenedTag state
-                    match $self.$read_until_open($buf) $(.$await)? {
-                        Ok(Ok(ev)) => break Ok(ev),
-                        Ok(Err(b)) => $buf = b,
-                        Err(err)   => break Err(err),
-                    }
+                    $self.state.state = ParseState::ClosedTag;
                 },
                 ParseState::ClosedTag => { // Go to OpenedTag state
                     match $self.$read_until_open($buf) $(.$await)? {

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -12,7 +12,7 @@ use encoding_rs::{Encoding, UTF_8};
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::reader::{is_whitespace, BangType, Parser, Reader, Span, XmlSource};
+use crate::reader::{is_whitespace, BangType, Parser, ReadTextResult, Reader, Span, XmlSource};
 
 /// This is an implementation for reading from a `&[u8]` as underlying byte stream.
 /// This implementation supports not using an intermediate buffer as the byte slice
@@ -256,17 +256,17 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     #[inline]
-    fn read_text(&mut self, _buf: (), position: &mut usize) -> Result<(&'a [u8], bool)> {
+    fn read_text(&mut self, _buf: (), position: &mut usize) -> ReadTextResult<'a> {
         if let Some(i) = memchr::memchr(b'<', self) {
             *position += i + 1;
             let bytes = &self[..i];
             *self = &self[i + 1..];
-            Ok((bytes, true))
+            ReadTextResult::UpToMarkup(bytes)
         } else {
             *position += self.len();
             let bytes = &self[..];
             *self = &[];
-            Ok((bytes, false))
+            ReadTextResult::UpToEof(bytes)
         }
     }
 

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -3,6 +3,7 @@
 //! intermediate buffer as the byte slice itself can be used to borrow from.
 
 use std::borrow::Cow;
+use std::io;
 
 #[cfg(feature = "encoding")]
 use crate::reader::EncodingRef;
@@ -238,7 +239,7 @@ impl<'a> Reader<&'a [u8]> {
 impl<'a> XmlSource<'a, ()> for &'a [u8] {
     #[cfg(not(feature = "encoding"))]
     #[inline]
-    fn remove_utf8_bom(&mut self) -> Result<()> {
+    fn remove_utf8_bom(&mut self) -> io::Result<()> {
         if self.starts_with(crate::encoding::UTF8_BOM) {
             *self = &self[crate::encoding::UTF8_BOM.len()..];
         }
@@ -247,7 +248,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
 
     #[cfg(feature = "encoding")]
     #[inline]
-    fn detect_encoding(&mut self) -> Result<Option<&'static Encoding>> {
+    fn detect_encoding(&mut self) -> io::Result<Option<&'static Encoding>> {
         if let Some((enc, bom_len)) = crate::encoding::detect_encoding(self) {
             *self = &self[bom_len..];
             return Ok(Some(enc));
@@ -284,7 +285,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         byte: u8,
         _buf: (),
         position: &mut usize,
-    ) -> Result<(&'a [u8], bool)> {
+    ) -> io::Result<(&'a [u8], bool)> {
         // search byte must be within the ascii range
         debug_assert!(byte.is_ascii());
 
@@ -341,7 +342,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     #[inline]
-    fn skip_whitespace(&mut self, position: &mut usize) -> Result<()> {
+    fn skip_whitespace(&mut self, position: &mut usize) -> io::Result<()> {
         let whitespaces = self
             .iter()
             .position(|b| !is_whitespace(*b))
@@ -352,7 +353,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     #[inline]
-    fn peek_one(&mut self) -> Result<Option<u8>> {
+    fn peek_one(&mut self) -> io::Result<Option<u8>> {
         Ok(self.first().copied())
     }
 }

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -256,6 +256,21 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     #[inline]
+    fn read_text(&mut self, _buf: (), position: &mut usize) -> Result<(&'a [u8], bool)> {
+        if let Some(i) = memchr::memchr(b'<', self) {
+            *position += i + 1;
+            let bytes = &self[..i];
+            *self = &self[i + 1..];
+            Ok((bytes, true))
+        } else {
+            *position += self.len();
+            let bytes = &self[..];
+            *self = &[];
+            Ok((bytes, false))
+        }
+    }
+
+    #[inline]
     fn read_bytes_until(
         &mut self,
         byte: u8,

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -52,15 +52,11 @@ pub(super) struct ReaderState {
 }
 
 impl ReaderState {
-    /// Trims end whitespaces from `bytes`, if required, and returns a [`Text`]
-    /// event or an [`Eof`] event, if text after trimming is empty.
+    /// Trims end whitespaces from `bytes`, if required, and returns a text event.
     ///
     /// # Parameters
     /// - `bytes`: data from the start of stream to the first `<` or from `>` to `<`
-    ///
-    /// [`Text`]: Event::Text
-    /// [`Eof`]: Event::Eof
-    pub fn emit_text<'b>(&mut self, bytes: &'b [u8]) -> Event<'b> {
+    pub fn emit_text<'b>(&mut self, bytes: &'b [u8]) -> BytesText<'b> {
         let mut content = bytes;
 
         if self.config.trim_text_end {
@@ -68,15 +64,10 @@ impl ReaderState {
             let len = bytes
                 .iter()
                 .rposition(|&b| !is_whitespace(b))
-                .map_or_else(|| bytes.len(), |p| p + 1);
+                .map_or(0, |p| p + 1);
             content = &bytes[..len];
         }
-
-        if content.is_empty() {
-            Event::Eof
-        } else {
-            Event::Text(BytesText::wrap(content, self.decoder()))
-        }
+        BytesText::wrap(content, self.decoder())
     }
 
     /// reads `BytesElement` starting with a `!`,

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -263,7 +263,7 @@ impl ReaderState {
             let event = BytesStart::wrap(content, name_len(content));
 
             if self.config.expand_empty_elements {
-                self.state = ParseState::Empty;
+                self.state = ParseState::InsideEmpty;
                 self.opened_starts.push(self.opened_buffer.len());
                 self.opened_buffer.extend(event.name().as_ref());
                 Ok(Event::Start(event))
@@ -284,7 +284,7 @@ impl ReaderState {
 
     #[inline]
     pub fn close_expanded_empty(&mut self) -> Result<Event<'static>> {
-        self.state = ParseState::ClosedTag;
+        self.state = ParseState::InsideText;
         let name = self
             .opened_buffer
             .split_off(self.opened_starts.pop().unwrap());

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -60,7 +60,7 @@ impl ReaderState {
     ///
     /// [`Text`]: Event::Text
     /// [`Eof`]: Event::Eof
-    pub fn emit_text<'b>(&mut self, bytes: &'b [u8]) -> Result<Event<'b>> {
+    pub fn emit_text<'b>(&mut self, bytes: &'b [u8]) -> Event<'b> {
         let mut content = bytes;
 
         if self.config.trim_text_end {
@@ -73,9 +73,9 @@ impl ReaderState {
         }
 
         if content.is_empty() {
-            Ok(Event::Eof)
+            Event::Eof
         } else {
-            Ok(Event::Text(BytesText::wrap(content, self.decoder())))
+            Event::Text(BytesText::wrap(content, self.decoder()))
         }
     }
 
@@ -257,7 +257,7 @@ impl ReaderState {
     ///
     /// # Parameters
     /// - `content`: Content of a tag between `<` and `>`
-    pub fn emit_start<'b>(&mut self, content: &'b [u8]) -> Result<Event<'b>> {
+    pub fn emit_start<'b>(&mut self, content: &'b [u8]) -> Event<'b> {
         if let Some(content) = content.strip_suffix(b"/") {
             // This is self-closed tag `<something/>`
             let event = BytesStart::wrap(content, name_len(content));
@@ -266,9 +266,9 @@ impl ReaderState {
                 self.state = ParseState::InsideEmpty;
                 self.opened_starts.push(self.opened_buffer.len());
                 self.opened_buffer.extend(event.name().as_ref());
-                Ok(Event::Start(event))
+                Event::Start(event)
             } else {
-                Ok(Event::Empty(event))
+                Event::Empty(event)
             }
         } else {
             let event = BytesStart::wrap(content, name_len(content));
@@ -278,17 +278,17 @@ impl ReaderState {
             // enabled, we should have that information
             self.opened_starts.push(self.opened_buffer.len());
             self.opened_buffer.extend(event.name().as_ref());
-            Ok(Event::Start(event))
+            Event::Start(event)
         }
     }
 
     #[inline]
-    pub fn close_expanded_empty(&mut self) -> Result<Event<'static>> {
+    pub fn close_expanded_empty(&mut self) -> BytesEnd<'static> {
         self.state = ParseState::InsideText;
         let name = self
             .opened_buffer
             .split_off(self.opened_starts.pop().unwrap());
-        Ok(Event::End(BytesEnd::wrap(name.into())))
+        BytesEnd::wrap(name.into())
     }
 
     /// Get the decoder, used to decode bytes, read by this reader, to the strings.


### PR DESCRIPTION
I was refactoring for another task and accidentally found 2 errors:
- in `ReaderState::emit_text` there was a misprint: if string does not contain non-space symbols it remains unchanged instead of making empty
- This error was actually masked by the previous. After fixing it `ReaderState::emit_text` could make empty slice which then translated to `Event::Eof`. However, this function is called in two cases:
  - when we found `<` which switches parser from `InsideText` to `InsideMarkup` state
  - when we found EOF while parser in the `InsideText` state

  `Event::Eof` should be generated only in the latter case.

The changes also shows small performance improvements:
```
> critcmp master trim -t 5
group                                                          master                                 fix-trim-end
-----                                                          ------                                 ------------
One event/Comment                                              1.08    157.2±2.92ns        ? ?/sec    1.00    146.0±2.42ns        ? ?/sec
decode_and_parse_document/rpm_filelists.xml                    1.06     68.4±1.24µs   160.6 MB/sec    1.00     64.5±1.93µs   170.3 MB/sec
decode_and_parse_document_with_namespaces/rpm_filelists.xml    1.07     95.7±1.62µs   114.7 MB/sec    1.00     89.3±1.63µs   122.9 MB/sec
decode_and_parse_document_with_namespaces/rpm_primary.xml      1.06    205.8±4.17µs    98.5 MB/sec    1.00    193.6±3.81µs   104.7 MB/sec
decode_and_parse_document_with_namespaces/rpm_primary2.xml     1.06     66.9±1.38µs   107.1 MB/sec    1.00     63.4±1.34µs   113.1 MB/sec
parse_document_nocopy/rpm_filelists.xml                        1.09     63.1±1.27µs   174.0 MB/sec    1.00     58.1±1.06µs   189.1 MB/sec
parse_document_nocopy/rpm_primary2.xml                         1.05     45.1±1.34µs   159.0 MB/sec    1.00     42.8±0.88µs   167.6 MB/sec
read_event/trim_text = false                                   1.27    206.1±3.85µs        ? ?/sec    1.00    162.9±2.66µs        ? ?/sec
read_event/trim_text = true                                    1.15    199.5±3.72µs        ? ?/sec    1.00    172.8±3.04µs        ? ?/sec
unescape_text/mixed                                            1.05    384.1±6.97ns        ? ?/sec    1.00    364.9±6.66ns        ? ?/sec
```