### PR TITLE
Make `const` as many functions as possible

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,10 +22,37 @@
 ### Misc Changes
 
 - [#650]: Change the type of `Event::PI` to a new dedicated `BytesPI` type.
+- [#759]: Make `const` as much functions as possible:
+  - `resolve_html5_entity()`
+  - `resolve_predefined_entity()`
+  - `resolve_xml_entity()`
+  - `Attr::key()`
+  - `Attr::value()`
+  - `Attributes::html()`
+  - `Attributes::new()`
+  - `BytesDecl::from_start()`
+  - `Decoder::encoding()`
+  - `Deserializer::get_ref()`
+  - `IoReader::get_ref()`
+  - `LocalName::into_inner()`
+  - `Namespace::into_inner()`
+  - `NsReader::config()`
+  - `NsReader::prefixes()`
+  - `Prefix::into_inner()`
+  - `QName::into_inner()`
+  - `Reader::buffer_position()`
+  - `Reader::config()`
+  - `Reader::decoder()`
+  - `Reader::error_position()`
+  - `Reader::get_ref()`
+  - `SliceReader::get_ref()`
+  - `Writer::get_ref()`
+  - `Writer::new()`
 
 [#650]: https://github.com/tafia/quick-xml/issues/650
 [#755]: https://github.com/tafia/quick-xml/pull/755
 [#758]: https://github.com/tafia/quick-xml/pull/758
+[#759]: https://github.com/tafia/quick-xml/pull/759
 
 
 ## 0.32.0 -- 2024-06-10

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2155,7 +2155,7 @@ impl<'i, R: XmlRead<'i>, E: EntityResolver> XmlReader<'i, R, E> {
     }
 
     /// Returns `true` if all events was consumed
-    fn is_empty(&self) -> bool {
+    const fn is_empty(&self) -> bool {
         matches!(self.lookahead, Ok(PayloadEvent::Eof))
     }
 
@@ -2166,7 +2166,7 @@ impl<'i, R: XmlRead<'i>, E: EntityResolver> XmlReader<'i, R, E> {
     }
 
     #[inline(always)]
-    fn need_trim_end(&self) -> bool {
+    const fn need_trim_end(&self) -> bool {
         // If next event is a text or CDATA, we should not trim trailing spaces
         !matches!(
             self.lookahead,
@@ -2464,7 +2464,7 @@ where
     /// assert_eq!(reader.error_position(), 28);
     /// assert_eq!(reader.buffer_position(), 41);
     /// ```
-    pub fn get_ref(&self) -> &R {
+    pub const fn get_ref(&self) -> &R {
         &self.reader.reader
     }
 
@@ -3127,7 +3127,7 @@ impl<R: BufRead> IoReader<R> {
     /// assert_eq!(reader.error_position(), 28);
     /// assert_eq!(reader.buffer_position(), 41);
     /// ```
-    pub fn get_ref(&self) -> &Reader<R> {
+    pub const fn get_ref(&self) -> &Reader<R> {
         &self.reader
     }
 }
@@ -3194,7 +3194,7 @@ impl<'de> SliceReader<'de> {
     /// assert_eq!(reader.error_position(), 28);
     /// assert_eq!(reader.buffer_position(), 41);
     /// ```
-    pub fn get_ref(&self) -> &Reader<&'de [u8]> {
+    pub const fn get_ref(&self) -> &Reader<&'de [u8]> {
         &self.reader
     }
 }

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -551,7 +551,7 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
 
     /// Constructor for tests
     #[inline]
-    fn new(content: CowRef<'de, 'a, [u8]>, escaped: bool, decoder: Decoder) -> Self {
+    const fn new(content: CowRef<'de, 'a, [u8]>, escaped: bool, decoder: Decoder) -> Self {
         Self {
             content,
             escaped,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -62,7 +62,7 @@ impl Decoder {
     ///
     /// [`decode`]: Self::decode
     #[cfg(feature = "encoding")]
-    pub fn encoding(&self) -> &'static Encoding {
+    pub const fn encoding(&self) -> &'static Encoding {
         self.encoding
     }
 

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -284,7 +284,7 @@ where
 /// Behaves like [`resolve_xml_entity`] if feature is not enabled and as
 /// [`resolve_html5_entity`] if enabled.
 #[inline]
-pub fn resolve_predefined_entity(entity: &str) -> Option<&'static str> {
+pub const fn resolve_predefined_entity(entity: &str) -> Option<&'static str> {
     #[cfg(not(feature = "escape-html"))]
     {
         resolve_xml_entity(entity)
@@ -314,7 +314,7 @@ pub fn resolve_predefined_entity(entity: &str) -> Option<&'static str> {
 /// ```
 ///
 /// [specification]: https://www.w3.org/TR/xml11/#sec-predefined-ent
-pub fn resolve_xml_entity(entity: &str) -> Option<&'static str> {
+pub const fn resolve_xml_entity(entity: &str) -> Option<&'static str> {
     // match over strings are not allowed in const functions
     let s = match entity.as_bytes() {
         b"lt" => "<",
@@ -328,7 +328,7 @@ pub fn resolve_xml_entity(entity: &str) -> Option<&'static str> {
 }
 
 /// Resolves all HTML5 entities. For complete list see <https://dev.w3.org/html5/html-author/charref>.
-pub fn resolve_html5_entity(entity: &str) -> Option<&'static str> {
+pub const fn resolve_html5_entity(entity: &str) -> Option<&'static str> {
     // imported from https://dev.w3.org/html5/html-author/charref
     // match over strings are not allowed in const functions
     //TODO: automate up-to-dating using https://html.spec.whatwg.org/entities.json

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -195,7 +195,7 @@ pub struct Attributes<'a> {
 impl<'a> Attributes<'a> {
     /// Internal constructor, used by `BytesStart`. Supplies data in reader's encoding
     #[inline]
-    pub(crate) fn wrap(buf: &'a [u8], pos: usize, html: bool) -> Self {
+    pub(crate) const fn wrap(buf: &'a [u8], pos: usize, html: bool) -> Self {
         Self {
             bytes: buf,
             state: IterState::new(pos, html),
@@ -203,12 +203,12 @@ impl<'a> Attributes<'a> {
     }
 
     /// Creates a new attribute iterator from a buffer.
-    pub fn new(buf: &'a str, pos: usize) -> Self {
+    pub const fn new(buf: &'a str, pos: usize) -> Self {
         Self::wrap(buf.as_bytes(), pos, false)
     }
 
     /// Creates a new attribute iterator from a buffer, allowing HTML attribute syntax.
-    pub fn html(buf: &'a str, pos: usize) -> Self {
+    pub const fn html(buf: &'a str, pos: usize) -> Self {
         Self::wrap(buf.as_bytes(), pos, true)
     }
 
@@ -416,7 +416,7 @@ impl<T> Attr<T> {
 impl<'a> Attr<&'a [u8]> {
     /// Returns the key value
     #[inline]
-    pub fn key(&self) -> QName<'a> {
+    pub const fn key(&self) -> QName<'a> {
         QName(match self {
             Attr::DoubleQ(key, _) => key,
             Attr::SingleQ(key, _) => key,
@@ -429,7 +429,7 @@ impl<'a> Attr<&'a [u8]> {
     ///
     /// [HTML specification]: https://www.w3.org/TR/2012/WD-html-markup-20120329/syntax.html#syntax-attr-empty
     #[inline]
-    pub fn value(&self) -> &'a [u8] {
+    pub const fn value(&self) -> &'a [u8] {
         match self {
             Attr::DoubleQ(_, value) => value,
             Attr::SingleQ(_, value) => value,
@@ -518,7 +518,7 @@ pub(crate) struct IterState {
 }
 
 impl IterState {
-    pub fn new(offset: usize, html: bool) -> Self {
+    pub const fn new(offset: usize, html: bool) -> Self {
         Self {
             state: State::Next(offset),
             html,

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -5,8 +5,8 @@
 use crate::errors::Result as XmlResult;
 use crate::escape::{escape, resolve_predefined_entity, unescape_with};
 use crate::name::QName;
-use crate::reader::{is_whitespace, Reader};
-use crate::utils::{write_byte_string, write_cow_string, Bytes};
+use crate::reader::Reader;
+use crate::utils::{is_whitespace, write_byte_string, write_cow_string, Bytes};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::iter::FusedIterator;
 use std::{borrow::Cow, ops::Range};

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -77,7 +77,7 @@ pub struct BytesStart<'a> {
 impl<'a> BytesStart<'a> {
     /// Internal constructor, used by `Reader`. Supplies data in reader's encoding
     #[inline]
-    pub(crate) fn wrap(content: &'a [u8], name_len: usize) -> Self {
+    pub(crate) const fn wrap(content: &'a [u8], name_len: usize) -> Self {
         BytesStart {
             buf: Cow::Borrowed(content),
             name_len,
@@ -405,7 +405,7 @@ impl<'a> BytesDecl<'a> {
     }
 
     /// Creates a `BytesDecl` from a `BytesStart`
-    pub fn from_start(start: BytesStart<'a>) -> Self {
+    pub const fn from_start(start: BytesStart<'a>) -> Self {
         Self { content: start }
     }
 
@@ -620,7 +620,7 @@ pub struct BytesEnd<'a> {
 impl<'a> BytesEnd<'a> {
     /// Internal constructor, used by `Reader`. Supplies data in reader's encoding
     #[inline]
-    pub(crate) fn wrap(name: Cow<'a, [u8]>) -> Self {
+    pub(crate) const fn wrap(name: Cow<'a, [u8]>) -> Self {
         BytesEnd { name }
     }
 
@@ -1018,7 +1018,7 @@ pub struct BytesPI<'a> {
 impl<'a> BytesPI<'a> {
     /// Creates a new `BytesPI` from a byte sequence in the specified encoding.
     #[inline]
-    pub(crate) fn wrap(content: &'a [u8], target_len: usize) -> Self {
+    pub(crate) const fn wrap(content: &'a [u8], target_len: usize) -> Self {
         Self {
             content: BytesStart::wrap(content, target_len),
         }

--- a/src/name.rs
+++ b/src/name.rs
@@ -20,7 +20,7 @@ pub struct QName<'a>(pub &'a [u8]);
 impl<'a> QName<'a> {
     /// Converts this name to an internal slice representation.
     #[inline(always)]
-    pub fn into_inner(self) -> &'a [u8] {
+    pub const fn into_inner(self) -> &'a [u8] {
         self.0
     }
 
@@ -137,7 +137,7 @@ pub struct LocalName<'a>(&'a [u8]);
 impl<'a> LocalName<'a> {
     /// Converts this name to an internal slice representation.
     #[inline(always)]
-    pub fn into_inner(self) -> &'a [u8] {
+    pub const fn into_inner(self) -> &'a [u8] {
         self.0
     }
 }
@@ -187,7 +187,7 @@ pub struct Prefix<'a>(&'a [u8]);
 impl<'a> Prefix<'a> {
     /// Extracts internal slice
     #[inline(always)]
-    pub fn into_inner(self) -> &'a [u8] {
+    pub const fn into_inner(self) -> &'a [u8] {
         self.0
     }
 }
@@ -252,7 +252,7 @@ impl<'a> Namespace<'a> {
     /// [non-normalized]: https://www.w3.org/TR/xml11/#AVNormalize
     /// [IRI reference]: https://datatracker.ietf.org/doc/html/rfc3987
     #[inline(always)]
-    pub fn into_inner(self) -> &'a [u8] {
+    pub const fn into_inner(self) -> &'a [u8] {
         self.0
     }
     //TODO: implement value normalization and use it when comparing namespaces
@@ -618,7 +618,7 @@ impl NamespaceResolver {
     }
 
     #[inline]
-    pub fn iter(&self) -> PrefixIter {
+    pub const fn iter(&self) -> PrefixIter {
         PrefixIter {
             resolver: self,
             // We initialize the cursor to 2 to skip the two default namespaces xml: and xmlns:

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -9,9 +9,9 @@ use crate::events::Event;
 use crate::name::{QName, ResolveResult};
 use crate::reader::buffered_reader::impl_buffered_source;
 use crate::reader::{
-    is_whitespace, BangType, ElementParser, NsReader, ParseState, Parser, PiParser, ReadTextResult,
-    Reader, Span,
+    BangType, ElementParser, NsReader, ParseState, Parser, PiParser, ReadTextResult, Reader, Span,
 };
+use crate::utils::is_whitespace;
 
 /// A struct for read XML asynchronously from an [`AsyncBufRead`].
 ///

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::reader::{is_whitespace, BangType, Parser, ReadTextResult, Reader, Span, XmlSource};
+use crate::reader::{BangType, Parser, ReadTextResult, Reader, Span, XmlSource};
+use crate::utils::is_whitespace;
 
 macro_rules! impl_buffered_source {
     ($($lf:lifetime, $reader:tt, $async:ident, $await:ident)?) => {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -865,6 +865,7 @@ trait XmlSource<'r, B> {
     ///
     /// A `P` type parameter is used to preserve state between calls to the underlying
     /// reader which provides bytes fed into the parser.
+    ///
     /// [events]: crate::events::Event
     fn read_with<P>(&mut self, parser: P, buf: B, position: &mut usize) -> Result<&'r [u8]>
     where
@@ -989,22 +990,6 @@ impl BangType {
             Self::DocType => Error::Syntax(SyntaxError::UnclosedDoctype),
         }
     }
-}
-
-/// A function to check whether the byte is a whitespace (blank, new line, carriage return or tab)
-#[inline]
-pub(crate) const fn is_whitespace(b: u8) -> bool {
-    matches!(b, b' ' | b'\r' | b'\n' | b'\t')
-}
-
-/// Calculates name from an element-like content. Name is the first word in `content`,
-/// where word boundaries is XML space characters.
-#[inline]
-pub(crate) fn name_len(content: &[u8]) -> usize {
-    content
-        .iter()
-        .position(|&b| is_whitespace(b))
-        .unwrap_or(content.len())
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -495,7 +495,7 @@ enum EncodingRef {
 #[cfg(feature = "encoding")]
 impl EncodingRef {
     #[inline]
-    fn encoding(&self) -> &'static Encoding {
+    const fn encoding(&self) -> &'static Encoding {
         match self {
             Self::Implicit(e) => e,
             Self::Explicit(e) => e,
@@ -504,7 +504,7 @@ impl EncodingRef {
         }
     }
     #[inline]
-    fn can_be_refined(&self) -> bool {
+    const fn can_be_refined(&self) -> bool {
         match self {
             Self::Implicit(_) | Self::BomDetected(_) => true,
             Self::Explicit(_) | Self::XmlDetected(_) => false,
@@ -587,7 +587,7 @@ impl<R> Reader<R> {
     }
 
     /// Returns reference to the parser configuration
-    pub fn config(&self) -> &Config {
+    pub const fn config(&self) -> &Config {
         &self.state.config
     }
 
@@ -657,7 +657,7 @@ impl<R> Reader<R> {
     }
 
     /// Gets a reference to the underlying reader.
-    pub fn get_ref(&self) -> &R {
+    pub const fn get_ref(&self) -> &R {
         &self.reader
     }
 
@@ -667,7 +667,7 @@ impl<R> Reader<R> {
     }
 
     /// Gets the current byte position in the input data.
-    pub fn buffer_position(&self) -> usize {
+    pub const fn buffer_position(&self) -> usize {
         // when internal state is InsideMarkup, we have actually read until '<',
         // which we don't want to show
         if let ParseState::InsideMarkup = self.state.state {
@@ -688,7 +688,7 @@ impl<R> Reader<R> {
     /// markup element (i. e. to the `<` character).
     ///
     /// This position is always `<= buffer_position()`.
-    pub fn error_position(&self) -> usize {
+    pub const fn error_position(&self) -> usize {
         self.state.last_error_offset
     }
 
@@ -702,7 +702,7 @@ impl<R> Reader<R> {
     ///
     /// [`encoding`]: ../index.html#encoding
     #[inline]
-    pub fn decoder(&self) -> Decoder {
+    pub const fn decoder(&self) -> Decoder {
         self.state.decoder()
     }
 }
@@ -912,7 +912,7 @@ enum BangType {
 }
 impl BangType {
     #[inline(always)]
-    fn new(byte: Option<u8>) -> Result<Self> {
+    const fn new(byte: Option<u8>) -> Result<Self> {
         Ok(match byte {
             Some(b'[') => Self::CData,
             Some(b'-') => Self::Comment,
@@ -983,7 +983,7 @@ impl BangType {
         None
     }
     #[inline]
-    fn to_err(&self) -> Error {
+    const fn to_err(&self) -> Error {
         match self {
             Self::CData => Error::Syntax(SyntaxError::UnclosedCData),
             Self::Comment => Error::Syntax(SyntaxError::UnclosedComment),

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -39,7 +39,7 @@ impl<R> NsReader<R> {
 
     /// Returns reference to the parser configuration
     #[inline]
-    pub fn config(&self) -> &Config {
+    pub const fn config(&self) -> &Config {
         self.reader.config()
     }
 
@@ -129,7 +129,7 @@ impl<R> NsReader<R> {
     /// # quick_xml::Result::Ok(())
     /// ```
     #[inline]
-    pub fn prefixes(&self) -> PrefixIter {
+    pub const fn prefixes(&self) -> PrefixIter {
         self.ns_resolver.iter()
     }
 }

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -13,7 +13,8 @@ use encoding_rs::{Encoding, UTF_8};
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::reader::{is_whitespace, BangType, Parser, ReadTextResult, Reader, Span, XmlSource};
+use crate::reader::{BangType, Parser, ReadTextResult, Reader, Span, XmlSource};
+use crate::utils::is_whitespace;
 
 /// This is an implementation for reading from a `&[u8]` as underlying byte stream.
 /// This implementation supports not using an intermediate buffer as the byte slice

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -292,7 +292,7 @@ impl ReaderState {
     /// defaults to UTF-8.
     ///
     /// [`encoding`]: ../../index.html#encoding
-    pub fn decoder(&self) -> Decoder {
+    pub const fn decoder(&self) -> Decoder {
         Decoder {
             #[cfg(feature = "encoding")]
             encoding: self.encoding.encoding(),

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -6,7 +6,8 @@ use crate::errors::{Error, IllFormedError, Result, SyntaxError};
 use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event};
 #[cfg(feature = "encoding")]
 use crate::reader::EncodingRef;
-use crate::reader::{is_whitespace, name_len, BangType, Config, ParseState};
+use crate::reader::{BangType, Config, ParseState};
+use crate::utils::{is_whitespace, name_len};
 
 /// A struct that holds a current reader state and a parser configuration.
 /// It is independent on a way of reading data: the reader feed data into it and

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -70,7 +70,7 @@ pub struct Writer<W> {
 
 impl<W> Writer<W> {
     /// Creates a `Writer` from a generic writer.
-    pub fn new(inner: W) -> Writer<W> {
+    pub const fn new(inner: W) -> Writer<W> {
         Writer {
             writer: inner,
             indent: None,
@@ -96,7 +96,7 @@ impl<W> Writer<W> {
     }
 
     /// Get a reference to the underlying writer.
-    pub fn get_ref(&self) -> &W {
+    pub const fn get_ref(&self) -> &W {
         &self.writer
     }
 


### PR DESCRIPTION
I think, that all those functions are such basic, that unlikely will be changed in that way that would prevent them from being `const`. So I added this keyword.

This is all that can be `const` at the moment, I checked all the other functions.