### PR TITLE
Remove requirement to have Reader when decoding attributes and write anything converted to Event

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 
 - [#760]: `Attribute::decode_and_unescape_value` and `Attribute::decode_and_unescape_value_with` now
   accepts `Decoder` instead of `Reader`. Use `Reader::decoder()` to get it.
+- [#760]: `Writer::write_event` now consumes event. Use `Event::borrow()` if you want to keep ownership.
 
 [#760]: https://github.com/tafia/quick-xml/pull/760
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,11 @@
 
 ### Misc Changes
 
+- [#760]: `Attribute::decode_and_unescape_value` and `Attribute::decode_and_unescape_value_with` now
+  accepts `Decoder` instead of `Reader`. Use `Reader::decoder()` to get it.
+
+[#760]: https://github.com/tafia/quick-xml/pull/760
+
 
 ## 0.33.0 -- 2024-06-21
 

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -50,7 +50,7 @@ fn parse_document_from_str(doc: &str) -> XmlResult<()> {
         match criterion::black_box(r.read_event()?) {
             Event::Start(e) | Event::Empty(e) => {
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(&r)?);
+                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             Event::Text(e) => {
@@ -75,7 +75,7 @@ fn parse_document_from_bytes(doc: &[u8]) -> XmlResult<()> {
         match criterion::black_box(r.read_event_into(&mut buf)?) {
             Event::Start(e) | Event::Empty(e) => {
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(&r)?);
+                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             Event::Text(e) => {
@@ -101,7 +101,7 @@ fn parse_document_from_str_with_namespaces(doc: &str) -> XmlResult<()> {
             (resolved_ns, Event::Start(e) | Event::Empty(e)) => {
                 criterion::black_box(resolved_ns);
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(&r)?);
+                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             (resolved_ns, Event::Text(e)) => {
@@ -129,7 +129,7 @@ fn parse_document_from_bytes_with_namespaces(doc: &[u8]) -> XmlResult<()> {
             (resolved_ns, Event::Start(e) | Event::Empty(e)) => {
                 criterion::black_box(resolved_ns);
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(&r)?);
+                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             (resolved_ns, Event::Text(e)) => {

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .attributes()
                         .map(|a| {
                             a.unwrap()
-                                .decode_and_unescape_value_with(&reader, |ent| {
+                                .decode_and_unescape_value_with(reader.decoder(), |ent| {
                                     custom_entities.get(ent).map(|s| s.as_str())
                                 })
                                 .unwrap()

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -70,8 +70,8 @@ impl Translation {
         for attr_result in element.attributes() {
             let a = attr_result?;
             match a.key.as_ref() {
-                b"Language" => lang = a.decode_and_unescape_value(reader)?,
-                b"Tag" => tag = a.decode_and_unescape_value(reader)?,
+                b"Language" => lang = a.decode_and_unescape_value(reader.decoder())?,
+                b"Tag" => tag = a.decode_and_unescape_value(reader.decoder())?,
                 _ => (),
             }
         }
@@ -138,7 +138,7 @@ fn main() -> Result<(), AppError> {
                                             Ok::<Cow<'_, str>, Infallible>(std::borrow::Cow::from(""))
                                         })
                                         .unwrap().to_string();
-                                    let value = a.decode_and_unescape_value(&reader).or_else(|err| {
+                                    let value = a.decode_and_unescape_value(reader.decoder()).or_else(|err| {
                                             dbg!("unable to read key in DefaultSettings attribute {:?}, utf8 error {:?}", &a, err);
                                             Ok::<Cow<'_, str>, Infallible>(std::borrow::Cow::from(""))
                                     }).unwrap().to_string();

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -26,7 +26,7 @@ where
             let _event = black_box(event.borrow());
             let _event = black_box(event.as_ref());
             debug_format!(event);
-            debug_format!(writer.write_event(event));
+            debug_format!(writer.write_event(event.borrow()));
         }
         match event_result {
             Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {

--- a/fuzz/fuzz_targets/structured_roundtrip.rs
+++ b/fuzz/fuzz_targets/structured_roundtrip.rs
@@ -51,7 +51,7 @@ fn fuzz_round_trip(driver: Driver) -> quick_xml::Result<()> {
         // TODO: Handle error cases.
         use WriterFunc::*;
         match writer_func {
-            WriteEvent(event) => writer.write_event(event)?,
+            WriteEvent(event) => writer.write_event(event.borrow())?,
             WriteBom => writer.write_bom()?,
             WriteIndent => writer.write_indent()?,
             CreateElement {

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -337,7 +337,6 @@ impl<R> NsReader<R> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::Event;
-    /// use quick_xml::events::attributes::Attribute;
     /// use quick_xml::name::{Namespace, QName, ResolveResult::*};
     /// use quick_xml::reader::NsReader;
     ///

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -30,9 +30,9 @@ fn fuzz_101() {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) | Ok(Event::Empty(e)) => {
                 for a in e.attributes() {
-                    if a.ok()
-                        .map_or(true, |a| a.decode_and_unescape_value(&reader).is_err())
-                    {
+                    if a.ok().map_or(true, |a| {
+                        a.decode_and_unescape_value(reader.decoder()).is_err()
+                    }) {
                         break;
                     }
                 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -180,7 +180,7 @@ fn with_trim_ref() {
     loop {
         match reader.read_event().unwrap() {
             Eof => break,
-            e => assert!(writer.write_event(&e).is_ok()), // either `e` or `&e`
+            e => assert!(writer.write_event(e.borrow()).is_ok()), // either `e` or `&e`
         }
     }
 


### PR DESCRIPTION
This PR includes two changes, which both related to my work of splitting event into two event classes -- for reading and for writing. Events for reading then would only borrow data and this will help to fix #332 and also open doors to `no_std` reader (not sure why it would be needed although).

The first commit just removes unused import that I noticed while working on this.

The second commit relaxes requirements for decoding values from `Attribute`. If you created attribute for writing and then for whatever reason wants to read its value back, you need a `Reader` which you does not have. This commit fixes that.

The third commit makes writing methods take `Into<Event>` instead of `AsRef<Event>`. The former trait give a lesser abilities then `Into`. It allows you to pass your own struct to write, but you need to have event in your struct to be able to take a ref to it. `Into` would allow you to construct event on demand and also would allow to directly pass reader event to the writer method that would require writer event if (when?) event splitting will be implemented. In any case, I think, that taking `Into` is better.

If there are any objections, then unnecessary commits can be removed from PR.