### PR TITLE
Hide `quick_xml::escape::resolve_html5_entity` under `escape-html` feature again

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -48,11 +48,14 @@
   - `SliceReader::get_ref()`
   - `Writer::get_ref()`
   - `Writer::new()`
+- [#763]: Hide `quick_xml::escape::resolve_html5_entity` under `escape-html` feature again.
+  This function has significant influence to the compilation time (10+ seconds or 5x times)
 
 [#650]: https://github.com/tafia/quick-xml/issues/650
 [#755]: https://github.com/tafia/quick-xml/pull/755
 [#758]: https://github.com/tafia/quick-xml/pull/758
 [#759]: https://github.com/tafia/quick-xml/pull/759
+[#763]: https://github.com/tafia/quick-xml/issues/763
 
 
 ## 0.32.0 -- 2024-06-10

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -328,10 +328,14 @@ pub const fn resolve_xml_entity(entity: &str) -> Option<&'static str> {
 }
 
 /// Resolves all HTML5 entities. For complete list see <https://dev.w3.org/html5/html-author/charref>.
+#[cfg(feature = "escape-html")]
 pub const fn resolve_html5_entity(entity: &str) -> Option<&'static str> {
     // imported from https://dev.w3.org/html5/html-author/charref
     // match over strings are not allowed in const functions
     //TODO: automate up-to-dating using https://html.spec.whatwg.org/entities.json
+    //TODO: building this function increases compilation time by 10+ seconds (or 5x times)
+    // Maybe this is because of very long match
+    // See https://github.com/tafia/quick-xml/issues/763
     let s = match entity.as_bytes() {
         b"Tab" => "\u{09}",
         b"NewLine" => "\u{0A}",


### PR DESCRIPTION
This function has significant influence to the compilation time (10+ seconds or 5x times)

Closes #763

Maybe it can be solved without hiding function under feature flag, but that is not in my priority list. If someone wants to investigate this issue, they can do PR :smile: 