### PR TITLE
Fix overflow when read 4GB+ fiiles on 32-bit targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,3 +103,29 @@ jobs:
         verbose: true
       continue-on-error: true
 
+  # Check that tests that are sensitive to target are passed
+  x86:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install 32-bit target
+      run: rustup target add i686-unknown-linux-gnu
+    - name: Install 32-bit libs (for criterion)
+      # Criterion wants to compile something.
+      # Cargo builds criterion even when it is not required for those tests.
+      # Without those libs compilation failed with:
+      # error: linking with `cc` failed: exit status: 1
+      #   |
+      #   = note: LC_ALL="C" PATH="..." ...
+      #   = note: /usr/bin/ld: cannot find Scrt1.o: No such file or directory
+      #           /usr/bin/ld: cannot find crti.o: No such file or directory
+      #           /usr/bin/ld: skipping incompatible /usr/lib/gcc/x86_64-linux-gnu/11/libgcc.a when searching for -lgcc
+      #           /usr/bin/ld: cannot find -lgcc: No such file or directory
+      #           collect2: error: ld returned 1 exit status
+      # Fixed as suggested in this answer:
+      # https://stackoverflow.com/a/16016792/7518605
+      run: sudo apt install gcc-multilib
+    - name: Run some tests on 32-bit target
+      run: cargo test --target i686-unknown-linux-gnu --test issues
+    - name: Run some tests on 32-bit target (async-tokio)
+      run: cargo test --target i686-unknown-linux-gnu --features async-tokio --test async-tokio

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,12 +17,17 @@
 
 ### Bug Fixes
 
+- [#751]: Fix internal overflow when read 4GB+ files on 32-bit targets using `Reader<impl BufRead>` readers.
+
 ### Misc Changes
 
 - [#760]: `Attribute::decode_and_unescape_value` and `Attribute::decode_and_unescape_value_with` now
   accepts `Decoder` instead of `Reader`. Use `Reader::decoder()` to get it.
 - [#760]: `Writer::write_event` now consumes event. Use `Event::borrow()` if you want to keep ownership.
+- [#751]: Type of `Reader::error_position()` and `Reader::buffer_position()` changed from `usize` to `u64`.
+- [#751]: Type alias `Span` changed from `Range<usize>` to `Range<u64>`.
 
+[#751]: https://github.com/tafia/quick-xml/issues/751
 [#760]: https://github.com/tafia/quick-xml/pull/760
 
 

--- a/tests/async-tokio.rs
+++ b/tests/async-tokio.rs
@@ -1,5 +1,8 @@
+use std::iter;
+
 use pretty_assertions::assert_eq;
 use quick_xml::events::Event::*;
+use quick_xml::name::QName;
 use quick_xml::reader::Reader;
 
 // Import `small_buffers_tests!`
@@ -35,4 +38,66 @@ async fn test_sample() {
         buf.clear();
     }
     assert_eq!((count, reads), (1247, 5245));
+}
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/751
+///
+/// Actually, that error was not found in async reader, but we would to test it as well.
+#[tokio::test]
+async fn issue751() {
+    let mut text = Vec::new();
+    let mut chunk = Vec::new();
+    chunk.extend_from_slice(b"<content>");
+    for data in iter::repeat(b"some text inside").take(1000) {
+        chunk.extend_from_slice(data);
+        text.extend_from_slice(data);
+    }
+    chunk.extend_from_slice(b"</content>");
+
+    let mut reader = Reader::from_reader(quick_xml::utils::Fountain {
+        chunk: &chunk,
+        consumed: 0,
+        overall_read: 0,
+    });
+    let mut buf = Vec::new();
+    let mut starts = 0u64;
+    let mut ends = 0u64;
+    let mut texts = 0u64;
+    loop {
+        buf.clear();
+        match reader.read_event_into_async(&mut buf).await {
+            Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
+            Ok(Eof) => break,
+
+            Ok(Start(e)) => {
+                starts += 1;
+                assert_eq!(
+                    e.name(),
+                    QName(b"content"),
+                    "starts: {starts}, ends: {ends}, texts: {texts}"
+                );
+            }
+            Ok(End(e)) => {
+                ends += 1;
+                assert_eq!(
+                    e.name(),
+                    QName(b"content"),
+                    "starts: {starts}, ends: {ends}, texts: {texts}"
+                );
+            }
+            Ok(Text(e)) => {
+                texts += 1;
+                assert_eq!(
+                    e.as_ref(),
+                    text,
+                    "starts: {starts}, ends: {ends}, texts: {texts}"
+                );
+            }
+            _ => (),
+        }
+        // If we successfully read more than `u32::MAX`, the test is passed
+        if reader.get_ref().overall_read >= u32::MAX as u64 {
+            break;
+        }
+    }
 }

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -219,7 +219,7 @@ mod syntax {
             }
         };
         ($test:ident($xml:literal) => $cause:expr) => {
-            err!($test($xml) => $xml.len(), $cause);
+            err!($test($xml) => $xml.len() as u64, $cause);
         };
     }
 
@@ -435,7 +435,7 @@ mod ill_formed {
                         match reader.read_event() {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -447,7 +447,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -461,7 +461,7 @@ mod ill_formed {
                         match reader.read_event_into(&mut buf) {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -473,7 +473,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -488,7 +488,7 @@ mod ill_formed {
                         match reader.read_event_into_async(&mut buf).await {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -500,7 +500,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -518,7 +518,7 @@ mod ill_formed {
                         match reader.read_resolved_event() {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -533,7 +533,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -547,7 +547,7 @@ mod ill_formed {
                         match reader.read_resolved_event_into(&mut buf) {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -562,7 +562,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -577,7 +577,7 @@ mod ill_formed {
                         match reader.read_resolved_event_into_async(&mut buf).await {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -593,7 +593,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -621,7 +621,7 @@ mod ill_formed {
                         match reader.read_event() {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -633,7 +633,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -650,7 +650,7 @@ mod ill_formed {
                         match reader.read_event_into(&mut buf) {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -662,7 +662,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -681,7 +681,7 @@ mod ill_formed {
                         match reader.read_event_into_async(&mut buf).await {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -693,7 +693,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -714,7 +714,7 @@ mod ill_formed {
                         match reader.read_resolved_event() {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -729,7 +729,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -746,7 +746,7 @@ mod ill_formed {
                         match reader.read_resolved_event_into(&mut buf) {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -761,7 +761,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }
@@ -780,7 +780,7 @@ mod ill_formed {
                         match reader.read_resolved_event_into_async(&mut buf).await {
                             Err(Error::IllFormed(cause)) => assert_eq!(
                                 (cause, reader.error_position(), reader.buffer_position()),
-                                ($cause, $pos, $xml.len()),
+                                ($cause, $pos, $xml.len() as u64),
                             ),
                             x => panic!("Expected `Err(IllFormed(_))`, but got {:?}", x),
                         }
@@ -796,7 +796,7 @@ mod ill_formed {
                         );
                         assert_eq!(
                             reader.buffer_position(),
-                            xml.len(),
+                            xml.len() as u64,
                             ".buffer_position() is incorrect in the end"
                         );
                     }


### PR DESCRIPTION
Added new check to CI and check that tests (for sync and async methods) are failed before the fix (I checked) and passed after.

Fixes #751

Commit which is failed before the fix: https://github.com/Mingun/quick-xml/commit/f5608f0929a83df15b97da664e44ebb608c12749
Job result for it: https://github.com/Mingun/quick-xml/actions/runs/9650155180/job/26615200796