### PR TITLE
Fixes in unescape routine

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,9 @@
 
 ### Misc Changes
 
+- [#771]: `EscapeError::UnrecognizedSymbol` renamed to `EscapeError::UnrecognizedEntity`.
+
+[#771]: https://github.com/tafia/quick-xml/pull/771
 [#772]: https://github.com/tafia/quick-xml/pull/772
 [#773]: https://github.com/tafia/quick-xml/pull/773
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
   As a result, the following variants of `quick_xml::escape::EscapeError` are removed:
   - `TooLongDecimal`
   - `TooLongHexadecimal`
+- [#771]: Fixed `Attribute::unescape_value` which does not unescape predefined values since 0.32.0.
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -32,9 +32,11 @@
 - [#771]: `EscapeError::UnrecognizedSymbol` renamed to `EscapeError::UnrecognizedEntity`.
 - [#771]: Implemented `PartialEq` for `EscapeError`.
 - [#771]: Replace the following variants of `EscapeError` by `InvalidCharRef` variant
-  with a standard `ParseIntError` inside:
+  with a new `ParseCharRefError` inside:
+  - `EntityWithNull`
   - `InvalidDecimal`
   - `InvalidHexadecimal`
+  - `InvalidCodepoint`
 
 [#771]: https://github.com/tafia/quick-xml/pull/771
 [#772]: https://github.com/tafia/quick-xml/pull/772

--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 ### Misc Changes
 
 - [#771]: `EscapeError::UnrecognizedSymbol` renamed to `EscapeError::UnrecognizedEntity`.
+- [#771]: Implemented `PartialEq` for `EscapeError`.
 
 [#771]: https://github.com/tafia/quick-xml/pull/771
 [#772]: https://github.com/tafia/quick-xml/pull/772

--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,10 @@
 
 - [#771]: `EscapeError::UnrecognizedSymbol` renamed to `EscapeError::UnrecognizedEntity`.
 - [#771]: Implemented `PartialEq` for `EscapeError`.
+- [#771]: Replace the following variants of `EscapeError` by `InvalidCharRef` variant
+  with a standard `ParseIntError` inside:
+  - `InvalidDecimal`
+  - `InvalidHexadecimal`
 
 [#771]: https://github.com/tafia/quick-xml/pull/771
 [#772]: https://github.com/tafia/quick-xml/pull/772

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,10 @@
 - [#773]: Fixed reporting incorrect end position in `Reader::read_to_end` family
   of methods and trimming of the trailing spaces in `Reader::read_text` when
   `trim_text_start` is set and the last event is not a `Text` event.
+- [#771]: Character references now allow any number of leading zeroes as it should.
+  As a result, the following variants of `quick_xml::escape::EscapeError` are removed:
+  - `TooLongDecimal`
+  - `TooLongHexadecimal`
 
 ### Misc Changes
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2135,9 +2135,9 @@ struct XmlReader<'i, R: XmlRead<'i>, E: EntityResolver = PredefinedEntityResolve
     lookahead: Result<PayloadEvent<'i>, DeError>,
 
     /// Used to resolve unknown entities that would otherwise cause the parser
-    /// to return an [`EscapeError::UnrecognizedSymbol`] error.
+    /// to return an [`EscapeError::UnrecognizedEntity`] error.
     ///
-    /// [`EscapeError::UnrecognizedSymbol`]: crate::escape::EscapeError::UnrecognizedSymbol
+    /// [`EscapeError::UnrecognizedEntity`]: crate::escape::EscapeError::UnrecognizedEntity
     entity_resolver: E,
 }
 

--- a/src/de/resolver.rs
+++ b/src/de/resolver.rs
@@ -81,10 +81,10 @@ pub trait EntityResolver {
     /// Called when an entity needs to be resolved.
     ///
     /// `None` is returned if a suitable value can not be found.
-    /// In that case an [`EscapeError::UnrecognizedSymbol`] will be returned by
+    /// In that case an [`EscapeError::UnrecognizedEntity`] will be returned by
     /// a deserializer.
     ///
-    /// [`EscapeError::UnrecognizedSymbol`]: crate::escape::EscapeError::UnrecognizedSymbol
+    /// [`EscapeError::UnrecognizedEntity`]: crate::escape::EscapeError::UnrecognizedEntity
     fn resolve(&self, entity: &str) -> Option<&str>;
 }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -99,6 +99,15 @@ impl Decoder {
 
         Ok(())
     }
+
+    /// Decodes the `Cow` buffer, preserves the lifetime
+    pub(crate) fn decode_cow<'b>(&self, bytes: &Cow<'b, [u8]>) -> Result<Cow<'b, str>> {
+        match bytes {
+            Cow::Borrowed(bytes) => self.decode(bytes),
+            // Convert to owned, because otherwise Cow will be bound with wrong lifetime
+            Cow::Owned(bytes) => Ok(self.decode(bytes)?.into_owned().into()),
+        }
+    }
 }
 
 /// Decodes the provided bytes using the specified encoding.

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -12,8 +12,8 @@ use pretty_assertions::assert_eq;
 pub enum EscapeError {
     /// Entity with Null character
     EntityWithNull(Range<usize>),
-    /// Unrecognized escape symbol
-    UnrecognizedSymbol(Range<usize>, String),
+    /// Referenced entity in unknown to the parser.
+    UnrecognizedEntity(Range<usize>, String),
     /// Cannot find `;` after `&`
     UnterminatedEntity(Range<usize>),
     /// Cannot convert Hexa to utf8
@@ -36,11 +36,9 @@ impl std::fmt::Display for EscapeError {
                 "Error while escaping character at range {:?}: Null character entity not allowed",
                 e
             ),
-            EscapeError::UnrecognizedSymbol(rge, res) => write!(
-                f,
-                "Error while escaping character at range {:?}: Unrecognized escape symbol: {:?}",
-                rge, res
-            ),
+            EscapeError::UnrecognizedEntity(rge, res) => {
+                write!(f, "at {:?}: unrecognized entity `{}`", rge, res)
+            }
             EscapeError::UnterminatedEntity(e) => write!(
                 f,
                 "Error while escaping character at range {:?}: Cannot find ';' after '&'",
@@ -256,7 +254,7 @@ where
                 } else if let Some(value) = resolve_entity(pat) {
                     unescaped.push_str(value);
                 } else {
-                    return Err(EscapeError::UnrecognizedSymbol(
+                    return Err(EscapeError::UnrecognizedEntity(
                         start + 1..end,
                         pat.to_string(),
                     ));

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -13,12 +13,8 @@ pub enum EscapeError {
     UnrecognizedEntity(Range<usize>, String),
     /// Cannot find `;` after `&`
     UnterminatedEntity(Range<usize>),
-    /// Cannot convert Hexa to utf8
-    TooLongHexadecimal,
     /// Character is not a valid hexadecimal value
     InvalidHexadecimal(char),
-    /// Cannot convert decimal to hexa
-    TooLongDecimal,
     /// Character is not a valid decimal value
     InvalidDecimal(char),
     /// Not a valid unicode codepoint
@@ -41,11 +37,9 @@ impl std::fmt::Display for EscapeError {
                 "Error while escaping character at range {:?}: Cannot find ';' after '&'",
                 e
             ),
-            EscapeError::TooLongHexadecimal => write!(f, "Cannot convert hexadecimal to utf8"),
             EscapeError::InvalidHexadecimal(e) => {
                 write!(f, "'{}' is not a valid hexadecimal character", e)
             }
-            EscapeError::TooLongDecimal => write!(f, "Cannot convert decimal to utf8"),
             EscapeError::InvalidDecimal(e) => write!(f, "'{}' is not a valid decimal character", e),
             EscapeError::InvalidCodepoint(n) => write!(f, "'{}' is not a valid codepoint", n),
         }
@@ -1807,10 +1801,6 @@ fn parse_number(bytes: &str, range: Range<usize>) -> Result<char, EscapeError> {
 }
 
 fn parse_hexadecimal(bytes: &str) -> Result<u32, EscapeError> {
-    // maximum code is 0x10FFFF => 6 characters
-    if bytes.len() > 6 {
-        return Err(EscapeError::TooLongHexadecimal);
-    }
     let mut code = 0;
     for b in bytes.bytes() {
         code <<= 4;
@@ -1825,10 +1815,6 @@ fn parse_hexadecimal(bytes: &str) -> Result<u32, EscapeError> {
 }
 
 fn parse_decimal(bytes: &str) -> Result<u32, EscapeError> {
-    // maximum code is 0x10FFFF = 1114111 => 7 characters
-    if bytes.len() > 7 {
-        return Err(EscapeError::TooLongDecimal);
-    }
     let mut code = 0;
     for b in bytes.bytes() {
         code *= 10;

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -4,9 +4,6 @@ use memchr::memchr2_iter;
 use std::borrow::Cow;
 use std::ops::Range;
 
-#[cfg(test)]
-use pretty_assertions::assert_eq;
-
 /// Error for XML escape / unescape.
 #[derive(Clone, Debug, PartialEq)]
 pub enum EscapeError {
@@ -1841,94 +1838,4 @@ fn parse_decimal(bytes: &str) -> Result<u32, EscapeError> {
         } as u32;
     }
     Ok(code)
-}
-
-#[test]
-fn test_unescape() {
-    let unchanged = unescape("test");
-    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
-    // because it influences diff
-    // TODO: use assert_matches! when stabilized and other features will bump MSRV
-    assert_eq!(unchanged, Ok(Cow::Borrowed("test")));
-    assert!(matches!(unchanged, Ok(Cow::Borrowed(_))));
-
-    assert_eq!(
-        unescape("&lt;&amp;test&apos;&quot;&gt;"),
-        Ok("<&test'\">".into())
-    );
-    assert_eq!(unescape("&#x30;"), Ok("0".into()));
-    assert_eq!(unescape("&#48;"), Ok("0".into()));
-    assert!(unescape("&foo;").is_err());
-}
-
-#[test]
-fn test_unescape_with() {
-    let custom_entities = |ent: &str| match ent {
-        "foo" => Some("BAR"),
-        _ => None,
-    };
-
-    let unchanged = unescape_with("test", custom_entities);
-    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
-    // because it influences diff
-    // TODO: use assert_matches! when stabilized and other features will bump MSRV
-    assert_eq!(unchanged, Ok(Cow::Borrowed("test")));
-    assert!(matches!(unchanged, Ok(Cow::Borrowed(_))));
-
-    assert!(unescape_with("&lt;", custom_entities).is_err());
-    assert_eq!(unescape_with("&#x30;", custom_entities), Ok("0".into()));
-    assert_eq!(unescape_with("&#48;", custom_entities), Ok("0".into()));
-    assert_eq!(unescape_with("&foo;", custom_entities), Ok("BAR".into()));
-    assert!(unescape_with("&fop;", custom_entities).is_err());
-}
-
-#[test]
-fn test_escape() {
-    let unchanged = escape("test");
-    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
-    // because it influences diff
-    // TODO: use assert_matches! when stabilized and other features will bump MSRV
-    assert_eq!(unchanged, Cow::Borrowed("test"));
-    assert!(matches!(unchanged, Cow::Borrowed(_)));
-
-    assert_eq!(escape("<&\"'>"), "&lt;&amp;&quot;&apos;&gt;");
-    assert_eq!(escape("<test>"), "&lt;test&gt;");
-    assert_eq!(escape("\"a\"bc"), "&quot;a&quot;bc");
-    assert_eq!(escape("\"a\"b&c"), "&quot;a&quot;b&amp;c");
-    assert_eq!(
-        escape("prefix_\"a\"b&<>c"),
-        "prefix_&quot;a&quot;b&amp;&lt;&gt;c"
-    );
-}
-
-#[test]
-fn test_partial_escape() {
-    let unchanged = partial_escape("test");
-    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
-    // because it influences diff
-    // TODO: use assert_matches! when stabilized and other features will bump MSRV
-    assert_eq!(unchanged, Cow::Borrowed("test"));
-    assert!(matches!(unchanged, Cow::Borrowed(_)));
-
-    assert_eq!(partial_escape("<&\"'>"), "&lt;&amp;\"'&gt;");
-    assert_eq!(partial_escape("<test>"), "&lt;test&gt;");
-    assert_eq!(partial_escape("\"a\"bc"), "\"a\"bc");
-    assert_eq!(partial_escape("\"a\"b&c"), "\"a\"b&amp;c");
-    assert_eq!(
-        partial_escape("prefix_\"a\"b&<>c"),
-        "prefix_\"a\"b&amp;&lt;&gt;c"
-    );
-}
-
-#[test]
-fn test_minimal_escape() {
-    assert_eq!(minimal_escape("test"), Cow::Borrowed("test"));
-    assert_eq!(minimal_escape("<&\"'>"), "&lt;&amp;\"'>");
-    assert_eq!(minimal_escape("<test>"), "&lt;test>");
-    assert_eq!(minimal_escape("\"a\"bc"), "\"a\"bc");
-    assert_eq!(minimal_escape("\"a\"b&c"), "\"a\"b&amp;c");
-    assert_eq!(
-        minimal_escape("prefix_\"a\"b&<>c"),
-        "prefix_\"a\"b&amp;&lt;>c"
-    );
 }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use pretty_assertions::assert_eq;
 
 /// Error for XML escape / unescape.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum EscapeError {
     /// Entity with Null character
     EntityWithNull(Range<usize>),
@@ -1845,19 +1845,19 @@ fn parse_decimal(bytes: &str) -> Result<u32, EscapeError> {
 
 #[test]
 fn test_unescape() {
-    let unchanged = unescape("test").unwrap();
+    let unchanged = unescape("test");
     // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
     // because it influences diff
     // TODO: use assert_matches! when stabilized and other features will bump MSRV
-    assert_eq!(unchanged, Cow::Borrowed("test"));
-    assert!(matches!(unchanged, Cow::Borrowed(_)));
+    assert_eq!(unchanged, Ok(Cow::Borrowed("test")));
+    assert!(matches!(unchanged, Ok(Cow::Borrowed(_))));
 
     assert_eq!(
-        unescape("&lt;&amp;test&apos;&quot;&gt;").unwrap(),
-        "<&test'\">"
+        unescape("&lt;&amp;test&apos;&quot;&gt;"),
+        Ok("<&test'\">".into())
     );
-    assert_eq!(unescape("&#x30;").unwrap(), "0");
-    assert_eq!(unescape("&#48;").unwrap(), "0");
+    assert_eq!(unescape("&#x30;"), Ok("0".into()));
+    assert_eq!(unescape("&#48;"), Ok("0".into()));
     assert!(unescape("&foo;").is_err());
 }
 
@@ -1868,17 +1868,17 @@ fn test_unescape_with() {
         _ => None,
     };
 
-    let unchanged = unescape_with("test", custom_entities).unwrap();
+    let unchanged = unescape_with("test", custom_entities);
     // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
     // because it influences diff
     // TODO: use assert_matches! when stabilized and other features will bump MSRV
-    assert_eq!(unchanged, Cow::Borrowed("test"));
-    assert!(matches!(unchanged, Cow::Borrowed(_)));
+    assert_eq!(unchanged, Ok(Cow::Borrowed("test")));
+    assert!(matches!(unchanged, Ok(Cow::Borrowed(_))));
 
     assert!(unescape_with("&lt;", custom_entities).is_err());
-    assert_eq!(unescape_with("&#x30;", custom_entities).unwrap(), "0");
-    assert_eq!(unescape_with("&#48;", custom_entities).unwrap(), "0");
-    assert_eq!(unescape_with("&foo;", custom_entities).unwrap(), "BAR");
+    assert_eq!(unescape_with("&#x30;", custom_entities), Ok("0".into()));
+    assert_eq!(unescape_with("&#48;", custom_entities), Ok("0".into()));
+    assert_eq!(unescape_with("&foo;", custom_entities), Ok("BAR".into()));
     assert!(unescape_with("&fop;", custom_entities).is_err());
 }
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -98,11 +98,7 @@ impl<'a> Attribute<'a> {
         decoder: Decoder,
         resolve_entity: impl FnMut(&str) -> Option<&'entity str>,
     ) -> XmlResult<Cow<'a, str>> {
-        let decoded = match &self.value {
-            Cow::Borrowed(bytes) => decoder.decode(bytes)?,
-            // Convert to owned, because otherwise Cow will be bound with wrong lifetime
-            Cow::Owned(bytes) => decoder.decode(bytes)?.into_owned().into(),
-        };
+        let decoded = decoder.decode_cow(&self.value)?;
 
         match unescape_with(&decoded, resolve_entity)? {
             // Because result is borrowed, no replacements was done and we can use original string

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -45,7 +45,7 @@ impl<'a> Attribute<'a> {
     /// [`encoding`]: ../../index.html#encoding
     #[cfg(any(doc, not(feature = "encoding")))]
     pub fn unescape_value(&self) -> XmlResult<Cow<'a, str>> {
-        self.unescape_value_with(|_| None)
+        self.unescape_value_with(resolve_predefined_entity)
     }
 
     /// Decodes using UTF-8 then unescapes the value, using custom entities.

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -63,22 +63,12 @@ impl<'a> Attribute<'a> {
     ///
     /// [`encoding`]: ../../index.html#encoding
     #[cfg(any(doc, not(feature = "encoding")))]
+    #[inline]
     pub fn unescape_value_with<'entity>(
         &self,
         resolve_entity: impl FnMut(&str) -> Option<&'entity str>,
     ) -> XmlResult<Cow<'a, str>> {
-        // from_utf8 should never fail because content is always UTF-8 encoded
-        let decoded = match &self.value {
-            Cow::Borrowed(bytes) => Cow::Borrowed(std::str::from_utf8(bytes)?),
-            // Convert to owned, because otherwise Cow will be bound with wrong lifetime
-            Cow::Owned(bytes) => Cow::Owned(std::str::from_utf8(bytes)?.to_string()),
-        };
-
-        match unescape_with(&decoded, resolve_entity)? {
-            // Because result is borrowed, no replacements was done and we can use original string
-            Cow::Borrowed(_) => Ok(decoded),
-            Cow::Owned(s) => Ok(s.into()),
-        }
+        self.decode_and_unescape_value_with(Decoder::utf8(), resolve_entity)
     }
 
     /// Decodes then unescapes the value.

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -595,11 +595,7 @@ impl<'a> BytesText<'a> {
         &self,
         resolve_entity: impl FnMut(&str) -> Option<&'entity str>,
     ) -> Result<Cow<'a, str>> {
-        let decoded = match &self.content {
-            Cow::Borrowed(bytes) => self.decoder.decode(bytes)?,
-            // Convert to owned, because otherwise Cow will be bound with wrong lifetime
-            Cow::Owned(bytes) => self.decoder.decode(bytes)?.into_owned().into(),
-        };
+        let decoded = self.decoder.decode_cow(&self.content)?;
 
         match unescape_with(&decoded, resolve_entity)? {
             // Because result is borrowed, no replacements was done and we can use original string
@@ -810,11 +806,7 @@ impl<'a> BytesCData<'a> {
 
     /// Gets content of this text buffer in the specified encoding
     pub(crate) fn decode(&self) -> Result<Cow<'a, str>> {
-        Ok(match &self.content {
-            Cow::Borrowed(bytes) => self.decoder.decode(bytes)?,
-            // Convert to owned, because otherwise Cow will be bound with wrong lifetime
-            Cow::Owned(bytes) => self.decoder.decode(bytes)?.into_owned().into(),
-        })
+        self.decoder.decode_cow(&self.content)
     }
 }
 

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -74,6 +74,23 @@ fn unescape() {
     );
 }
 
+/// XML allows any number of leading zeroes. That is not explicitly mentioned
+/// in the specification, but enforced by the conformance test suite
+/// (https://www.w3.org/XML/Test/)
+/// 100 digits should be enough to ensure that any artificial restrictions
+/// (such as maximal string of u128 representation) does not applied
+#[test]
+fn unescape_long() {
+    assert_eq!(
+        escape::unescape("&#0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000048;"),
+        Ok("0".into()),
+    );
+    assert_eq!(
+        escape::unescape("&#x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030;"),
+        Ok("0".into()),
+    );
+}
+
 #[test]
 fn unescape_with() {
     let custom_entities = |ent: &str| match ent {
@@ -107,5 +124,22 @@ fn unescape_with() {
     assert_eq!(
         escape::unescape_with("&fop;", custom_entities),
         Err(EscapeError::UnrecognizedEntity(1..4, "fop".into()))
+    );
+}
+
+/// XML allows any number of leading zeroes. That is not explicitly mentioned
+/// in the specification, but enforced by the conformance test suite
+/// (https://www.w3.org/XML/Test/)
+/// 100 digits should be enough to ensure that any artificial restrictions
+/// (such as maximal string of u128 representation) does not applied
+#[test]
+fn unescape_with_long() {
+    assert_eq!(
+        escape::unescape_with("&#0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000048;", |_| None),
+        Ok("0".into()),
+    );
+    assert_eq!(
+        escape::unescape_with("&#x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030;", |_| None),
+        Ok("0".into()),
     );
 }

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -1,5 +1,5 @@
 use pretty_assertions::assert_eq;
-use quick_xml::escape;
+use quick_xml::escape::{self, EscapeError};
 use std::borrow::Cow;
 
 #[test]
@@ -68,7 +68,10 @@ fn unescape() {
     );
     assert_eq!(escape::unescape("&#x30;"), Ok("0".into()));
     assert_eq!(escape::unescape("&#48;"), Ok("0".into()));
-    assert!(escape::unescape("&foo;").is_err());
+    assert_eq!(
+        escape::unescape("&foo;"),
+        Err(EscapeError::UnrecognizedEntity(1..4, "foo".into()))
+    );
 }
 
 #[test]
@@ -85,7 +88,10 @@ fn unescape_with() {
     assert_eq!(unchanged, Ok(Cow::Borrowed("test")));
     assert!(matches!(unchanged, Ok(Cow::Borrowed(_))));
 
-    assert!(escape::unescape_with("&lt;", custom_entities).is_err());
+    assert_eq!(
+        escape::unescape_with("&lt;", custom_entities),
+        Err(EscapeError::UnrecognizedEntity(1..3, "lt".into())),
+    );
     assert_eq!(
         escape::unescape_with("&#x30;", custom_entities),
         Ok("0".into())
@@ -98,5 +104,8 @@ fn unescape_with() {
         escape::unescape_with("&foo;", custom_entities),
         Ok("BAR".into())
     );
-    assert!(escape::unescape_with("&fop;", custom_entities).is_err());
+    assert_eq!(
+        escape::unescape_with("&fop;", custom_entities),
+        Err(EscapeError::UnrecognizedEntity(1..4, "fop".into()))
+    );
 }

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -1,0 +1,102 @@
+use pretty_assertions::assert_eq;
+use quick_xml::escape;
+use std::borrow::Cow;
+
+#[test]
+fn escape() {
+    let unchanged = escape::escape("test");
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Cow::Borrowed("test"));
+    assert!(matches!(unchanged, Cow::Borrowed(_)));
+
+    assert_eq!(escape::escape("<&\"'>"), "&lt;&amp;&quot;&apos;&gt;");
+    assert_eq!(escape::escape("<test>"), "&lt;test&gt;");
+    assert_eq!(escape::escape("\"a\"bc"), "&quot;a&quot;bc");
+    assert_eq!(escape::escape("\"a\"b&c"), "&quot;a&quot;b&amp;c");
+    assert_eq!(
+        escape::escape("prefix_\"a\"b&<>c"),
+        "prefix_&quot;a&quot;b&amp;&lt;&gt;c"
+    );
+}
+
+#[test]
+fn partial_escape() {
+    let unchanged = escape::partial_escape("test");
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Cow::Borrowed("test"));
+    assert!(matches!(unchanged, Cow::Borrowed(_)));
+
+    assert_eq!(escape::partial_escape("<&\"'>"), "&lt;&amp;\"'&gt;");
+    assert_eq!(escape::partial_escape("<test>"), "&lt;test&gt;");
+    assert_eq!(escape::partial_escape("\"a\"bc"), "\"a\"bc");
+    assert_eq!(escape::partial_escape("\"a\"b&c"), "\"a\"b&amp;c");
+    assert_eq!(
+        escape::partial_escape("prefix_\"a\"b&<>c"),
+        "prefix_\"a\"b&amp;&lt;&gt;c"
+    );
+}
+
+#[test]
+fn minimal_escape() {
+    assert_eq!(escape::minimal_escape("test"), Cow::Borrowed("test"));
+    assert_eq!(escape::minimal_escape("<&\"'>"), "&lt;&amp;\"'>");
+    assert_eq!(escape::minimal_escape("<test>"), "&lt;test>");
+    assert_eq!(escape::minimal_escape("\"a\"bc"), "\"a\"bc");
+    assert_eq!(escape::minimal_escape("\"a\"b&c"), "\"a\"b&amp;c");
+    assert_eq!(
+        escape::minimal_escape("prefix_\"a\"b&<>c"),
+        "prefix_\"a\"b&amp;&lt;>c"
+    );
+}
+
+#[test]
+fn unescape() {
+    let unchanged = escape::unescape("test");
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Ok(Cow::Borrowed("test")));
+    assert!(matches!(unchanged, Ok(Cow::Borrowed(_))));
+
+    assert_eq!(
+        escape::unescape("&lt;&amp;test&apos;&quot;&gt;"),
+        Ok("<&test'\">".into())
+    );
+    assert_eq!(escape::unescape("&#x30;"), Ok("0".into()));
+    assert_eq!(escape::unescape("&#48;"), Ok("0".into()));
+    assert!(escape::unescape("&foo;").is_err());
+}
+
+#[test]
+fn unescape_with() {
+    let custom_entities = |ent: &str| match ent {
+        "foo" => Some("BAR"),
+        _ => None,
+    };
+
+    let unchanged = escape::unescape_with("test", custom_entities);
+    // assert_eq does not check that Cow is borrowed, but we explicitly use Cow
+    // because it influences diff
+    // TODO: use assert_matches! when stabilized and other features will bump MSRV
+    assert_eq!(unchanged, Ok(Cow::Borrowed("test")));
+    assert!(matches!(unchanged, Ok(Cow::Borrowed(_))));
+
+    assert!(escape::unescape_with("&lt;", custom_entities).is_err());
+    assert_eq!(
+        escape::unescape_with("&#x30;", custom_entities),
+        Ok("0".into())
+    );
+    assert_eq!(
+        escape::unescape_with("&#48;", custom_entities),
+        Ok("0".into())
+    );
+    assert_eq!(
+        escape::unescape_with("&foo;", custom_entities),
+        Ok("BAR".into())
+    );
+    assert!(escape::unescape_with("&fop;", custom_entities).is_err());
+}


### PR DESCRIPTION
This PR fixes 2 errors that I found when working on a new way to represent entity references:
1. Currently, `quick_xml` does not allow too long numbers to represent character references. It, however, does not takes in account, that any number of leading zeroes are allowed, so the real character entity length can be any. [Conformance](https://github.com/belingueres/xml-conformance) test suite contains such tests.
2. #739 introduced regression where `Attribute::unescape_value` no longer unescaped predefined entities. That was fixed and checked that no similar places remains

[Corresponding test](https://dev.w3.org/cvsweb/2001/XML-Test-Suite/xmlconf/xmltest/valid/sa/042.xml?rev=1.1.1.1) (xmltest\valid\sa\042.xml -- one of):
```xml
<!DOCTYPE doc [
<!ELEMENT doc (#PCDATA)>
]>
<doc>&#00000000000000000000000000000000065;</doc>
```