### PR TITLE
Fix missing text event in some circumstances

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,8 @@
   - `TooLongDecimal`
   - `TooLongHexadecimal`
 - [#771]: Fixed `Attribute::unescape_value` which does not unescape predefined values since 0.32.0.
+- [#774]: Fixed regression since 0.33.0: `Text` event may be skipped in `read_event_into()`
+  and `read_event_into_async()` in some circumstances.
 
 ### Misc Changes
 
@@ -42,6 +44,7 @@
 [#771]: https://github.com/tafia/quick-xml/pull/771
 [#772]: https://github.com/tafia/quick-xml/pull/772
 [#773]: https://github.com/tafia/quick-xml/pull/773
+[#774]: https://github.com/tafia/quick-xml/issues/774
 
 
 ## 0.34.0 -- 2024-06-25

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -69,7 +69,9 @@ macro_rules! impl_buffered_source {
                 };
 
                 match memchr::memchr(b'<', available) {
-                    Some(0) => {
+                    // Special handling is needed only on the first iteration.
+                    // On next iterations we already read something and should emit Text event
+                    Some(0) if read == 0 => {
                         self $(.$reader)? .consume(1);
                         *position += 1;
                         return ReadTextResult::Markup(buf);


### PR DESCRIPTION
Specially handle `<` in the first position of read data only after first `fill_buf()` call

Fixes #774