### PR TITLE
Allow attributes in the `Event::End` and fix `.error_position()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 
 - [#781]: Fix conditions to start CDATA section. Only uppercase `<![CDATA[` can start it.
   Previously any case was allowed.
+- [#780]: Fixed incorrect `.error_position()` when encountering syntax error for open or self-closed tag.
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,9 @@
 
 ### Misc Changes
 
+- [#780]: `reader::Parser`, `reader::ElementParser` and `reader::PiParser` moved to the new module `parser`.
+
+[#780]: https://github.com/tafia/quick-xml/pull/780
 [#781]: https://github.com/tafia/quick-xml/pull/781
 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,7 +24,9 @@
 ### Misc Changes
 
 - [#780]: `reader::Parser`, `reader::ElementParser` and `reader::PiParser` moved to the new module `parser`.
+- [#776]: Allow to have attributes in the end tag for compatibility reasons with Adobe Flash XML parser.
 
+[#776]: https://github.com/tafia/quick-xml/issues/776
 [#780]: https://github.com/tafia/quick-xml/pull/780
 [#781]: https://github.com/tafia/quick-xml/pull/781
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ loop {
     // when the input is a &str or a &[u8], we don't actually need to use another
     // buffer, we could directly call `reader.read_event()`
     match reader.read_event_into(&mut buf) {
-        Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
         // exits the loop when reaching end of file
         Ok(Event::Eof) => break,
 
@@ -98,7 +98,7 @@ loop {
         Ok(Event::Eof) => break,
         // we can either move or borrow the event to write, depending on your use-case
         Ok(e) => assert!(writer.write_event(e).is_ok()),
-        Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
     }
 }
 

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
             }
             Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
             _ => (),
         }
     }

--- a/examples/read_buffered.rs
+++ b/examples/read_buffered.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), quick_xml::Error> {
                 count += 1;
             }
             Ok(Event::Eof) => break, // exits the loop when reaching end of file
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
             _ => (), // There are several other `Event`s we do not consider here
         }
     }

--- a/examples/read_texts.rs
+++ b/examples/read_texts.rs
@@ -18,7 +18,7 @@ fn main() {
                 println!("{:?}", txt);
             }
             Ok(Event::Eof) => break, // exits the loop when reaching end of file
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
             _ => (), // There are several other `Event`s we do not consider here
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod errors;
 pub mod escape;
 pub mod events;
 pub mod name;
+pub mod parser;
 pub mod reader;
 #[cfg(feature = "serialize")]
 pub mod se;

--- a/src/parser/element.rs
+++ b/src/parser/element.rs
@@ -1,7 +1,7 @@
 //! Contains a parser for an XML element.
 
 use crate::errors::SyntaxError;
-use crate::reader::Parser;
+use crate::parser::Parser;
 
 /// A parser that search a `>` symbol in the slice outside of quoted regions.
 ///
@@ -25,7 +25,7 @@ use crate::reader::Parser;
 ///
 /// ```
 /// # use pretty_assertions::assert_eq;
-/// use quick_xml::reader::{ElementParser, Parser};
+/// use quick_xml::parser::{ElementParser, Parser};
 ///
 /// let mut parser = ElementParser::default();
 ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,29 @@
+//! Contains low-level parsers of different XML pieces.
+
+use crate::errors::SyntaxError;
+
+mod element;
+mod pi;
+
+pub use element::ElementParser;
+pub use pi::PiParser;
+
+/// Used to decouple reading of data from data source and parsing XML structure from it.
+/// This is a state preserved between getting chunks of bytes from the reader.
+///
+/// This trait is implemented for every parser that processes piece of XML grammar.
+pub trait Parser {
+    /// Process new data and try to determine end of the parsed thing.
+    ///
+    /// Returns position of the end of thing in `bytes` in case of successful search
+    /// and `None` otherwise.
+    ///
+    /// # Parameters
+    /// - `bytes`: a slice to find the end of a thing.
+    ///   Should contain text in ASCII-compatible encoding
+    fn feed(&mut self, bytes: &[u8]) -> Option<usize>;
+
+    /// Returns parse error produced by this parser in case of reaching end of
+    /// input without finding the end of a parsed thing.
+    fn eof_error() -> SyntaxError;
+}

--- a/src/parser/pi.rs
+++ b/src/parser/pi.rs
@@ -1,7 +1,7 @@
 //! Contains a parser for an XML processing instruction.
 
 use crate::errors::SyntaxError;
-use crate::reader::Parser;
+use crate::parser::Parser;
 
 /// A parser that search a `?>` sequence in the slice.
 ///
@@ -19,7 +19,7 @@ use crate::reader::Parser;
 ///
 /// ```
 /// # use pretty_assertions::assert_eq;
-/// use quick_xml::reader::{Parser, PiParser};
+/// use quick_xml::parser::{Parser, PiParser};
 ///
 /// let mut parser = PiParser::default();
 ///

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -58,7 +58,7 @@ impl<R: AsyncBufRead + Unpin> Reader<R> {
     ///     match reader.read_event_into_async(&mut buf).await {
     ///         Ok(Event::Start(_)) => count += 1,
     ///         Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
-    ///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+    ///         Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
     ///         Ok(Event::Eof) => break,
     ///         _ => (),
     ///     }

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -7,10 +7,9 @@ use tokio::io::{self, AsyncBufRead, AsyncBufReadExt};
 use crate::errors::{Error, Result, SyntaxError};
 use crate::events::Event;
 use crate::name::{QName, ResolveResult};
+use crate::parser::{ElementParser, Parser, PiParser};
 use crate::reader::buffered_reader::impl_buffered_source;
-use crate::reader::{
-    BangType, ElementParser, NsReader, ParseState, Parser, PiParser, ReadTextResult, Reader, Span,
-};
+use crate::reader::{BangType, NsReader, ParseState, ReadTextResult, Reader, Span};
 use crate::utils::is_whitespace;
 
 /// A struct for read XML asynchronously from an [`AsyncBufRead`].

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -328,7 +328,7 @@ impl<R: BufRead> Reader<R> {
     ///     match reader.read_event_into(&mut buf) {
     ///         Ok(Event::Start(_)) => count += 1,
     ///         Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
-    ///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+    ///         Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
     ///         Ok(Event::Eof) => break,
     ///         _ => (),
     ///     }

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::reader::{BangType, Parser, ReadTextResult, Reader, Span, XmlSource};
+use crate::parser::Parser;
+use crate::reader::{BangType, ReadTextResult, Reader, Span, XmlSource};
 use crate::utils::is_whitespace;
 
 macro_rules! impl_buffered_source {

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -589,7 +589,7 @@ impl EncodingRef {
 ///     // when the input is a &str or a &[u8], we don't actually need to use another
 ///     // buffer, we could directly call `reader.read_event()`
 ///     match reader.read_event_into(&mut buf) {
-///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+///         Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
 ///         // exits the loop when reaching end of file
 ///         Ok(Event::Eof) => break,
 ///

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -360,7 +360,7 @@ macro_rules! read_until_close {
             },
             // `<?` - processing instruction
             Ok(Some(b'?')) => match $reader
-                .read_with(PiParser::default(), $buf, &mut $self.state.offset)
+                .read_with(PiParser(false), $buf, &mut $self.state.offset)
                 $(.$await)?
             {
                 Ok(bytes) => $self.state.emit_question_mark(bytes),
@@ -373,7 +373,7 @@ macro_rules! read_until_close {
             },
             // `<...` - opening or self-closed tag
             Ok(Some(_)) => match $reader
-                .read_with(ElementParser::default(), $buf, &mut $self.state.offset)
+                .read_with(ElementParser::Outside, $buf, &mut $self.state.offset)
                 $(.$await)?
             {
                 Ok(bytes) => Ok($self.state.emit_start(bytes)),

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1172,9 +1172,9 @@ mod test {
                         //                ^= 1
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                            Err(Error::Syntax(SyntaxError::UnclosedCData)) => {}
+                            Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedCData),
                             x => panic!(
-                                "Expected `Err(Syntax(UnclosedCData))`, but got `{:?}`",
+                                "Expected `Err(Syntax(_))`, but got `{:?}`",
                                 x
                             ),
                         }
@@ -1191,9 +1191,9 @@ mod test {
                         //                ^= 1                 ^= 22
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                            Err(Error::Syntax(SyntaxError::UnclosedCData)) => {}
+                            Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedCData),
                             x => panic!(
-                                "Expected `Err(Syntax(UnclosedCData))`, but got `{:?}`",
+                                "Expected `Err(Syntax(_))`, but got `{:?}`",
                                 x
                             ),
                         }
@@ -1270,9 +1270,9 @@ mod test {
                         //                ^= 1
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                            Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
+                            Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedComment),
                             x => panic!(
-                                "Expected `Err(Syntax(UnclosedComment))`, but got `{:?}`",
+                                "Expected `Err(Syntax(_))`, but got `{:?}`",
                                 x
                             ),
                         }
@@ -1287,9 +1287,9 @@ mod test {
                         //                ^= 1            ^= 17
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                            Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
+                            Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedComment),
                             x => panic!(
-                                "Expected `Err(Syntax(UnclosedComment))`, but got `{:?}`",
+                                "Expected `Err(Syntax(_))`, but got `{:?}`",
                                 x
                             ),
                         }
@@ -1304,9 +1304,9 @@ mod test {
                         //                ^= 1            ^= 17
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                            Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
+                            Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedComment),
                             x => panic!(
-                                "Expected `Err(Syntax(UnclosedComment))`, but got `{:?}`",
+                                "Expected `Err(Syntax(_))`, but got `{:?}`",
                                 x
                             ),
                         }
@@ -1321,9 +1321,9 @@ mod test {
                         //                ^= 1             ^= 18
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                            Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
+                            Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedComment),
                             x => panic!(
-                                "Expected `Err(Syntax(UnclosedComment))`, but got `{:?}`",
+                                "Expected `Err(Syntax(_))`, but got `{:?}`",
                                 x
                             ),
                         }
@@ -1338,9 +1338,9 @@ mod test {
                         //                ^= 1              ^= 19
 
                         match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                            Err(Error::Syntax(SyntaxError::UnclosedComment)) => {}
+                            Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedComment),
                             x => panic!(
-                                "Expected `Err(Syntax(UnclosedComment))`, but got `{:?}`",
+                                "Expected `Err(Syntax(_))`, but got `{:?}`",
                                 x
                             ),
                         }
@@ -1400,9 +1400,9 @@ mod test {
                             //                ^= 1            ^= 17
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                                Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
+                                Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedDoctype),
                                 x => panic!(
-                                    "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
+                                    "Expected `Err(Syntax(_))`, but got `{:?}`",
                                     x
                                 ),
                             }
@@ -1417,9 +1417,9 @@ mod test {
                             //                ^= 1                 ^= 22
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                                Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
+                                Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedDoctype),
                                 x => panic!(
-                                    "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
+                                    "Expected `Err(Syntax(_))`, but got `{:?}`",
                                     x
                                 ),
                             }
@@ -1452,9 +1452,9 @@ mod test {
                             //                ^= 1                  ^23
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                                Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
+                                Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedDoctype),
                                 x => panic!(
-                                    "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
+                                    "Expected `Err(Syntax(_))`, but got `{:?}`",
                                     x
                                 ),
                             }
@@ -1474,9 +1474,9 @@ mod test {
                             //                ^= 1            ^= 17
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                                Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
+                                Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedDoctype),
                                 x => panic!(
-                                    "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
+                                    "Expected `Err(Syntax(_))`, but got `{:?}`",
                                     x
                                 ),
                             }
@@ -1491,9 +1491,9 @@ mod test {
                             //                ^= 1                 ^= 22
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                                Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
+                                Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedDoctype),
                                 x => panic!(
-                                    "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
+                                    "Expected `Err(Syntax(_))`, but got `{:?}`",
                                     x
                                 ),
                             }
@@ -1526,9 +1526,9 @@ mod test {
                             //                ^= 1                  ^= 23
 
                             match $source(&mut input).read_bang_element(buf, &mut position) $(.$await)? {
-                                Err(Error::Syntax(SyntaxError::UnclosedDoctype)) => {}
+                                Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedDoctype),
                                 x => panic!(
-                                    "Expected `Err(Syntax(UnclosedDoctype))`, but got `{:?}`",
+                                    "Expected `Err(Syntax(_))`, but got `{:?}`",
                                     x
                                 ),
                             }
@@ -1554,9 +1554,9 @@ mod test {
                     //                ^= 1
 
                     match $source(&mut input).read_with(ElementParser::default(), buf, &mut position) $(.$await)? {
-                        Err(Error::Syntax(SyntaxError::UnclosedTag)) => {}
+                        Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedTag),
                         x => panic!(
-                            "Expected `Err(Syntax(UnclosedTag))`, but got `{:?}`",
+                            "Expected `Err(Syntax(_))`, but got `{:?}`",
                             x
                         ),
                     }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -23,6 +23,25 @@ use crate::reader::state::ReaderState;
 #[cfg_attr(feature = "serde-types", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
 pub struct Config {
+    /// Whether unmatched closing tag names should be allowed. Unless enabled,
+    /// in case of a dangling end tag, the [`Error::IllFormed(UnmatchedEndTag)`]
+    /// is returned from read methods.
+    ///
+    /// When set to `true`, it won't check if a closing tag has a corresponding
+    /// opening tag at all. For example, `<a></a></b>` will be permitted.
+    ///
+    /// Note that the emitted [`End`] event will not be modified if this is enabled,
+    /// ie. it will contain the data of the unmatched end tag.
+    ///
+    /// Note, that setting this to `true` will lead to additional allocates that
+    /// needed to store tag name for an [`End`] event.
+    ///
+    /// Default: `false`
+    ///
+    /// [`Error::IllFormed(UnmatchedEndTag)`]: crate::errors::IllFormedError::UnmatchedEndTag
+    /// [`End`]: crate::events::Event::End
+    pub allow_unmatched_ends: bool,
+
     /// Whether comments should be validated. If enabled, in case of invalid comment
     /// [`Error::IllFormed(DoubleHyphenInComment)`] is returned from read methods.
     ///
@@ -75,25 +94,6 @@ pub struct Config {
     /// [`End`]: crate::events::Event::End
     /// [`expand_empty_elements`]: Self::expand_empty_elements
     pub check_end_names: bool,
-
-    /// Whether unmatched closing tag names should be allowed. Unless enabled,
-    /// in case of a dangling end tag, the [`Error::IllFormed(UnmatchedEndTag)`]
-    /// is returned from read methods.
-    ///
-    /// When set to `true`, it won't check if a closing tag has a corresponding
-    /// opening tag at all. For example, `<a></a></b>` will be permitted.
-    ///
-    /// Note that the emitted [`End`] event will not be modified if this is enabled,
-    /// ie. it will contain the data of the unmatched end tag.
-    ///
-    /// Note, that setting this to `true` will lead to additional allocates that
-    /// needed to store tag name for an [`End`] event.
-    ///
-    /// Default: `false`
-    ///
-    /// [`Error::IllFormed(UnmatchedEndTag)`]: crate::errors::IllFormedError::UnmatchedEndTag
-    /// [`End`]: crate::events::Event::End
-    pub allow_unmatched_ends: bool,
 
     /// Whether empty elements should be split into an `Open` and a `Close` event.
     ///
@@ -209,9 +209,9 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            allow_unmatched_ends: false,
             check_comments: false,
             check_end_names: true,
-            allow_unmatched_ends: false,
             expand_empty_elements: false,
             trim_markup_names_in_closing_tags: true,
             trim_text_start: false,

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -835,23 +835,6 @@ trait XmlSource<'r, B> {
 
     /// Read input until start of markup (the `<`) is found or end of input is reached.
     ///
-    /// Returns a slice of data read up to `<` (exclusive), and a flag noting whether
-    /// `<` was found in the input or not.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let mut position = 0;
-    /// let mut input = b"abc<def".as_ref();
-    /// //                    ^= 4
-    ///
-    /// assert_eq!(
-    ///     input.read_text((), &mut position).unwrap(),
-    ///     (b"abc".as_ref(), true)
-    /// );
-    /// assert_eq!(position, 4); // position after the symbol matched
-    /// ```
-    ///
     /// # Parameters
     /// - `buf`: Buffer that could be filled from an input (`Self`) and
     ///   from which [events] could borrow their data

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -285,29 +285,6 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     #[inline]
-    fn read_bytes_until(
-        &mut self,
-        byte: u8,
-        _buf: (),
-        position: &mut u64,
-    ) -> io::Result<(&'a [u8], bool)> {
-        // search byte must be within the ascii range
-        debug_assert!(byte.is_ascii());
-
-        if let Some(i) = memchr::memchr(byte, self) {
-            *position += i as u64 + 1;
-            let bytes = &self[..i];
-            *self = &self[i + 1..];
-            Ok((bytes, true))
-        } else {
-            *position += self.len() as u64;
-            let bytes = &self[..];
-            *self = &[];
-            Ok((bytes, false))
-        }
-    }
-
-    #[inline]
     fn read_with<P>(&mut self, mut parser: P, _buf: (), position: &mut u64) -> Result<&'a [u8]>
     where
         P: Parser,

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -13,7 +13,8 @@ use encoding_rs::{Encoding, UTF_8};
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::reader::{BangType, Parser, ReadTextResult, Reader, Span, XmlSource};
+use crate::parser::Parser;
+use crate::reader::{BangType, ReadTextResult, Reader, Span, XmlSource};
 use crate::utils::is_whitespace;
 
 /// This is an implementation for reading from a `&[u8]` as underlying byte stream.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -52,7 +52,7 @@ use {crate::de::DeError, serde::Serialize};
 ///         Ok(Event::Eof) => break,
 ///         // we can either move or borrow the event to write, depending on your use-case
 ///         Ok(e) => assert!(writer.write_event(e.borrow()).is_ok()),
-///         Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+///         Err(e) => panic!("Error at position {}: {:?}", reader.error_position(), e),
 ///     }
 /// }
 ///

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -364,3 +364,30 @@ fn issue774() {
         Event::End(BytesEnd::new("tag"))
     );
 }
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/776
+#[test]
+fn issue776() {
+    let mut reader = Reader::from_str(r#"<tag></tag/><tag></tag attr=">">"#);
+    // We still think that the name of the end tag is everything between `</` and `>`
+    // and if we do not disable this check we get error
+    reader.config_mut().check_end_names = false;
+
+    assert_eq!(
+        reader.read_event().unwrap(),
+        Event::Start(BytesStart::new("tag"))
+    );
+    assert_eq!(
+        reader.read_event().unwrap(),
+        Event::End(BytesEnd::new("tag/"))
+    );
+
+    assert_eq!(
+        reader.read_event().unwrap(),
+        Event::Start(BytesStart::new("tag"))
+    );
+    assert_eq!(
+        reader.read_event().unwrap(),
+        Event::End(BytesEnd::new(r#"tag attr=">""#))
+    );
+}

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -175,7 +175,7 @@ fn test_escaped_content() {
                 Ok(c) => assert_eq!(c, "<test>"),
                 Err(e) => panic!(
                     "cannot escape content at position {}: {:?}",
-                    r.buffer_position(),
+                    r.error_position(),
                     e
                 ),
             }
@@ -183,7 +183,7 @@ fn test_escaped_content() {
         Ok(e) => panic!("Expecting text event, got {:?}", e),
         Err(e) => panic!(
             "Cannot get next event at position {}: {:?}",
-            r.buffer_position(),
+            r.error_position(),
             e
         ),
     }


### PR DESCRIPTION
This PR allows us to have attributes in the `Event::End` (but they are not accessible via `BytesEnd` directly). As explained in https://github.com/tafia/quick-xml/issues/776#issuecomment-2208078867 we anyway can produce an event which `.name()` does not valid, so it is better ar least keep it useful for some scenarios. When validation API would be added (I'm working on it) we can validate all events and report an error.

Closes #776

When changing parser I noticed, that in one arm we do not set `last_error_offset`. I checked if we really cover that lines -- yes, but we actually does not check anything. `last_error_offset` was checked for `0`, but this is its default value, so was unclear is that code running or not. I improved check and fix the bug that was found due to that.