### PR TITLE
Start CDATA section only after uppercase `<![CDATA[`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,12 @@
 
 ### Bug Fixes
 
+- [#781]: Fix conditions to start CDATA section. Only uppercase `<![CDATA[` can start it.
+  Previously any case was allowed.
+
 ### Misc Changes
+
+[#781]: https://github.com/tafia/quick-xml/pull/781
 
 
 ## 0.35.0 -- 2024-06-29

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -51,7 +51,7 @@ fn fuzz_101() {
 
 #[test]
 fn fuzz_empty_doctype() {
-    let data: &[u8] = b"<!doctype  \n    >";
+    let data: &[u8] = b"<!DOCTYPE  \n    >";
     let mut reader = Reader::from_reader(data);
     let mut buf = Vec::new();
     assert!(matches!(

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -471,7 +471,7 @@ mod trim_markup_names_in_closing_tags {
 }
 
 const XML: &str = " \t\r\n\
-<!doctype root \t\r\n> \t\r\n\
+<!DOCTYPE root \t\r\n> \t\r\n\
 <root \t\r\n> \t\r\n\
     <empty \t\r\n/> \t\r\n\
     text \t\r\n\

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -343,6 +343,8 @@ mod syntax {
         err!(unclosed24("<![CDATA[]h") => SyntaxError::UnclosedCData);
         err!(unclosed25("<![CDATA[]>") => SyntaxError::UnclosedCData);
 
+        err!(lowercase("<![cdata[]]>") => SyntaxError::UnclosedCData);
+
         ok!(normal1("<![CDATA[]]>")     => 12: Event::CData(BytesCData::new("")));
         ok!(normal2("<![CDATA[]]>rest") => 12: Event::CData(BytesCData::new("")));
     }


### PR DESCRIPTION
Implement more strict check for the start of CDATA section. Incorrect case is a syntax error. In that sense this PR is differs from #780 where attributes in the end tag is validation error. So we should not be case tolerant in this case.