### PR TITLE
Implement ability to read data directly from the underlying reader

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,14 @@
 
 ### New Features
 
+- [#623]: Added `Reader::stream()` that can be used to read arbitrary data
+  from the inner reader while track position for XML reader.
+
 ### Bug Fixes
 
 ### Misc Changes
+
+[#623]: https://github.com/tafia/quick-xml/issues/623
 
 
 ## 0.36.0 -- 2024-07-08

--- a/tests/async-tokio.rs
+++ b/tests/async-tokio.rs
@@ -1,10 +1,12 @@
+use std::io::Cursor;
 use std::iter;
 
 use pretty_assertions::assert_eq;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event::*};
 use quick_xml::name::QName;
 use quick_xml::reader::Reader;
-use tokio::io::BufReader;
+use quick_xml::utils::Bytes;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 
 // Import `small_buffers_tests!`
 #[macro_use]
@@ -86,6 +88,48 @@ mod read_to_end {
         );
         assert_eq!(r.read_event_into_async(&mut buf).await.unwrap(), Eof);
     }
+}
+
+#[tokio::test]
+async fn issue623() {
+    let mut buf = Vec::new();
+    let mut reader = Reader::from_reader(Cursor::new(
+        b"
+        <AppendedData>
+            _binary << data&>
+        </AppendedData>
+    ",
+    ));
+    reader.config_mut().trim_text(true);
+
+    assert_eq!(
+        (
+            reader.read_event_into_async(&mut buf).await.unwrap(),
+            reader.buffer_position()
+        ),
+        (Start(BytesStart::new("AppendedData")), 23)
+    );
+
+    let mut inner = reader.stream();
+    // Read to start of data marker
+    inner.read_until(b'_', &mut buf).await.unwrap();
+
+    // Read binary data. We must know its size
+    let mut binary = [0u8; 16];
+    inner.read_exact(&mut binary).await.unwrap();
+    assert_eq!(Bytes(&binary), Bytes(b"binary << data&>"));
+    assert_eq!(inner.offset(), 53);
+    assert_eq!(reader.buffer_position(), 53);
+
+    assert_eq!(
+        (
+            reader.read_event_into_async(&mut buf).await.unwrap(),
+            reader.buffer_position()
+        ),
+        (End(BytesEnd::new("AppendedData")), 77)
+    );
+
+    assert_eq!(reader.read_event_into_async(&mut buf).await.unwrap(), Eof);
 }
 
 /// Regression test for https://github.com/tafia/quick-xml/issues/751

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -2,7 +2,7 @@
 //!
 //! Name each module / test as `issue<GH number>` and keep sorted by issue number
 
-use std::io::BufReader;
+use std::io::{BufRead, BufReader, Cursor, Read};
 use std::iter;
 use std::sync::mpsc;
 
@@ -10,6 +10,9 @@ use quick_xml::errors::{Error, IllFormedError, SyntaxError};
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 use quick_xml::reader::Reader;
+use quick_xml::utils::Bytes;
+
+use pretty_assertions::assert_eq;
 
 /// Regression test for https://github.com/tafia/quick-xml/issues/94
 #[test]
@@ -255,6 +258,89 @@ fn issue622() {
     match reader.read_event() {
         Err(Error::Syntax(cause)) => assert_eq!(cause, SyntaxError::UnclosedTag),
         x => panic!("Expected `Err(Syntax(_))`, but got `{:?}`", x),
+    }
+}
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/623
+mod issue623 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn borrowed() {
+        let mut reader = Reader::from_str(
+            "
+            <AppendedData>
+                _binary << data&>
+            </AppendedData>
+        ",
+        );
+        reader.config_mut().trim_text(true);
+
+        assert_eq!(
+            (reader.read_event().unwrap(), reader.buffer_position()),
+            (Event::Start(BytesStart::new("AppendedData")), 27)
+        );
+
+        let mut inner = reader.stream();
+        // Read to start of data marker
+        inner.read_until(b'_', &mut Vec::new()).unwrap();
+
+        // Read binary data. We must know its size
+        let mut binary = [0u8; 16];
+        inner.read_exact(&mut binary).unwrap();
+        assert_eq!(Bytes(&binary), Bytes(b"binary << data&>"));
+        assert_eq!(inner.offset(), 61);
+        assert_eq!(reader.buffer_position(), 61);
+
+        assert_eq!(
+            (reader.read_event().unwrap(), reader.buffer_position()),
+            (Event::End(BytesEnd::new("AppendedData")), 89)
+        );
+
+        assert_eq!(reader.read_event().unwrap(), Event::Eof);
+    }
+
+    #[test]
+    fn buffered() {
+        let mut buf = Vec::new();
+        let mut reader = Reader::from_reader(Cursor::new(
+            b"
+            <AppendedData>
+                _binary << data&>
+            </AppendedData>
+        ",
+        ));
+        reader.config_mut().trim_text(true);
+
+        assert_eq!(
+            (
+                reader.read_event_into(&mut buf).unwrap(),
+                reader.buffer_position()
+            ),
+            (Event::Start(BytesStart::new("AppendedData")), 27)
+        );
+
+        let mut inner = reader.stream();
+        // Read to start of data marker
+        inner.read_until(b'_', &mut buf).unwrap();
+
+        // Read binary data. We must know its size
+        let mut binary = [0u8; 16];
+        inner.read_exact(&mut binary).unwrap();
+        assert_eq!(Bytes(&binary), Bytes(b"binary << data&>"));
+        assert_eq!(inner.offset(), 61);
+        assert_eq!(reader.buffer_position(), 61);
+
+        assert_eq!(
+            (
+                reader.read_event_into(&mut buf).unwrap(),
+                reader.buffer_position()
+            ),
+            (Event::End(BytesEnd::new("AppendedData")), 89)
+        );
+
+        assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
     }
 }
 


### PR DESCRIPTION
Closes #623

This also implements #260, but the user should manually:
- ensure, that it is reading text
- stop reading when text ends

So I do not consider that #260 is solved.