### PR TITLE
fix namespace prefix deserialize

### DIFF
--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -41,7 +41,7 @@ fn decode_name<'n>(name: QName<'n>, decoder: Decoder) -> Result<Cow<'n, str>, De
 ///   to the identifier
 /// - put the decoded [`local_name()`] of a name to the identifier
 ///
-/// The final identifier looks like `[@]local_name`, or `@xmlns`, or `@xmlns:binding`
+/// The final identifier looks like `[@]local_name`, or `@xmlns`, or `@xmlns:binding`, or `@r:id`
 /// (where `[]` means optional element).
 ///
 /// The deserializer also supports deserializing names as other primitive types:
@@ -86,7 +86,9 @@ impl<'i, 'd> QNameDeserializer<'i, 'd> {
 
         // https://github.com/tafia/quick-xml/issues/537
         // Namespace bindings (xmlns:xxx) map to `@xmlns:xxx` instead of `@xxx`
-        if name.as_namespace_binding().is_some() {
+        // https://github.com/tafia/quick-xml/issues/591
+        // Or any namespace prefix (e.g. r:id) map to `@r:id` instead of `@id`
+        if name.as_namespace_binding().is_some() || name.prefix().is_some()  {
             decoder.decode_into(name.into_inner(), key_buf)?;
         } else {
             let local = name.local_name();

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -88,7 +88,7 @@ impl<'i, 'd> QNameDeserializer<'i, 'd> {
         // Namespace bindings (xmlns:xxx) map to `@xmlns:xxx` instead of `@xxx`
         // https://github.com/tafia/quick-xml/issues/591
         // Or any namespace prefix (e.g. r:id) map to `@r:id` instead of `@id`
-        if name.as_namespace_binding().is_some() || name.prefix().is_some()  {
+        if name.as_namespace_binding().is_some() || name.prefix().is_some() {
             decoder.decode_into(name.into_inner(), key_buf)?;
         } else {
             let local = name.local_name();

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -494,3 +494,43 @@ fn issue683() {
         }
     );
 }
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/591.
+mod issue591 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename = "p:sldLayoutId")]
+    struct CtSlideLayoutIdListEntry<'a> {
+        #[serde(rename = "@id")]
+        id_attr: &'a str,
+
+        #[serde(rename = "@r:id")]
+        r_id_attr: &'a str,
+    }
+
+    #[test]
+    fn de() {
+        assert_eq!(
+            from_str::<CtSlideLayoutIdListEntry>(r#"<p:sldLayoutId id="2147483649" r:id="rId1"/>"#)
+                .unwrap(),
+            CtSlideLayoutIdListEntry {
+                id_attr: "2147483649",
+                r_id_attr: "rId1",
+            }
+        );
+    }
+
+    #[test]
+    fn se() {
+        assert_eq!(
+            to_string(&CtSlideLayoutIdListEntry {
+                id_attr: "2147483649",
+                r_id_attr: "rId1",
+            })
+            .unwrap(),
+            r#"<p:sldLayoutId id="2147483649" r:id="rId1"/>"#
+        );
+    }
+}


### PR DESCRIPTION
Similar to #539, namespace prefix (e.g. r:id) also map to `@r:id` instead of `@id`, possibly fix #591.