### PR TITLE
Return `std::io::Error` from Writer methods

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,13 @@
 
 ### Misc Changes
 
+- [#227]: Split `SeError` from `DeError` in the `serialize` feature.
+  Serialize functions and methods now return `SeError`.
+- [#810]: Return `std::io::Error` from `Writer` methods.
+
+[#227]: https://github.com/tafia/quick-xml/issues/227
+[#810]: https://github.com/tafia/quick-xml/pull/810
+
 
 ## 0.36.2 -- 2024-09-20
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -159,7 +159,7 @@ impl std::error::Error for IllFormedError {}
 /// The error type used by this crate.
 #[derive(Clone, Debug)]
 pub enum Error {
-    /// XML document cannot be read from or written to underlying source.
+    /// XML document cannot be read from underlying source.
     ///
     /// Contains the reference-counted I/O error to make the error type `Clone`able.
     Io(Arc<IoError>),
@@ -318,8 +318,6 @@ pub mod serialize {
     pub enum DeError {
         /// Serde custom error
         Custom(String),
-        /// IO error from Writer
-        Io(Arc<IoError>),
         /// Xml parsing error
         InvalidXml(Error),
         /// Cannot parse to integer
@@ -351,13 +349,6 @@ pub mod serialize {
         /// store at current position, for example, attempt to deserialize `struct`
         /// from attribute or attempt to deserialize binary data.
         ///
-        /// Serialized type cannot be represented in an XML due to violation of the
-        /// XML rules in the final XML document. For example, attempt to serialize
-        /// a `HashMap<{integer}, ...>` would cause this error because [XML name]
-        /// cannot start from a digit or a hyphen (minus sign). The same result
-        /// would occur if map key is a complex type that cannot be serialized as
-        /// a primitive type (i.e. string, char, bool, unit struct or unit variant).
-        ///
         /// [XML name]: https://www.w3.org/TR/xml11/#sec-common-syn
         Unsupported(Cow<'static, str>),
         /// Too many events were skipped while deserializing a sequence, event limit
@@ -370,7 +361,6 @@ pub mod serialize {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
                 DeError::Custom(s) => write!(f, "{}", s),
-                DeError::Io(e) => write!(f, "{}", e),
                 DeError::InvalidXml(e) => write!(f, "{}", e),
                 DeError::InvalidInt(e) => write!(f, "{}", e),
                 DeError::InvalidFloat(e) => write!(f, "{}", e),
@@ -403,19 +393,6 @@ pub mod serialize {
     impl serde::de::Error for DeError {
         fn custom<T: fmt::Display>(msg: T) -> Self {
             DeError::Custom(msg.to_string())
-        }
-    }
-
-    impl serde::ser::Error for DeError {
-        fn custom<T: fmt::Display>(msg: T) -> Self {
-            DeError::Custom(msg.to_string())
-        }
-    }
-
-    impl From<IoError> for DeError {
-        #[inline]
-        fn from(e: IoError) -> Self {
-            Self::Io(Arc::new(e))
         }
     }
 
@@ -472,6 +449,78 @@ pub mod serialize {
         #[inline]
         fn from(e: fmt::Error) -> Self {
             Self::Custom(e.to_string())
+        }
+    }
+
+    /// Serialization error
+    #[derive(Clone, Debug)]
+    pub enum SeError {
+        /// Serde custom error
+        Custom(String),
+        /// XML document cannot be written to underlying source.
+        ///
+        /// Contains the reference-counted I/O error to make the error type `Clone`able.
+        Io(Arc<IoError>),
+        /// Some value could not be formatted
+        Fmt(std::fmt::Error),
+        /// Serialized type cannot be represented in an XML due to violation of the
+        /// XML rules in the final XML document. For example, attempt to serialize
+        /// a `HashMap<{integer}, ...>` would cause this error because [XML name]
+        /// cannot start from a digit or a hyphen (minus sign). The same result
+        /// would occur if map key is a complex type that cannot be serialized as
+        /// a primitive type (i.e. string, char, bool, unit struct or unit variant).
+        ///
+        /// [XML name]: https://www.w3.org/TR/xml11/#sec-common-syn
+        Unsupported(Cow<'static, str>),
+        /// Some value could not be turned to UTF-8
+        NonEncodable(Utf8Error),
+    }
+
+    impl fmt::Display for SeError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                SeError::Custom(s) => write!(f, "{}", s),
+                SeError::Io(e) => write!(f, "I/O error: {}", e),
+                SeError::Fmt(e) => write!(f, "Formatting error: {}", e),
+                SeError::Unsupported(s) => write!(f, "Unsupported value: {}", s),
+                SeError::NonEncodable(e) => write!(f, "Malformed UTF-8: {}", e),
+            }
+        }
+    }
+
+    impl ::std::error::Error for SeError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            match self {
+                SeError::Io(e) => Some(e),
+                _ => None,
+            }
+        }
+    }
+
+    impl serde::ser::Error for SeError {
+        fn custom<T: fmt::Display>(msg: T) -> Self {
+            SeError::Custom(msg.to_string())
+        }
+    }
+
+    impl From<IoError> for SeError {
+        #[inline]
+        fn from(e: IoError) -> Self {
+            Self::Io(Arc::new(e))
+        }
+    }
+
+    impl From<Utf8Error> for SeError {
+        #[inline]
+        fn from(e: Utf8Error) -> Self {
+            Self::NonEncodable(e)
+        }
+    }
+
+    impl From<fmt::Error> for SeError {
+        #[inline]
+        fn from(e: fmt::Error) -> Self {
+            Self::Fmt(e)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -467,9 +467,9 @@ pub mod serialize {
             match self {
                 SeError::Custom(s) => write!(f, "{}", s),
                 SeError::Io(e) => write!(f, "I/O error: {}", e),
-                SeError::Fmt(e) => write!(f, "Formatting error: {}", e),
-                SeError::Unsupported(s) => write!(f, "Unsupported value: {}", s),
-                SeError::NonEncodable(e) => write!(f, "Malformed UTF-8: {}", e),
+                SeError::Fmt(e) => write!(f, "formatting error: {}", e),
+                SeError::Unsupported(s) => write!(f, "unsupported value: {}", s),
+                SeError::NonEncodable(e) => write!(f, "malformed UTF-8: {}", e),
             }
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -318,6 +318,8 @@ pub mod serialize {
     pub enum DeError {
         /// Serde custom error
         Custom(String),
+        /// IO error from Writer
+        Io(Arc<IoError>),
         /// Xml parsing error
         InvalidXml(Error),
         /// Cannot parse to integer
@@ -368,6 +370,7 @@ pub mod serialize {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
                 DeError::Custom(s) => write!(f, "{}", s),
+                DeError::Io(e) => write!(f, "{}", e),
                 DeError::InvalidXml(e) => write!(f, "{}", e),
                 DeError::InvalidInt(e) => write!(f, "{}", e),
                 DeError::InvalidFloat(e) => write!(f, "{}", e),
@@ -406,6 +409,13 @@ pub mod serialize {
     impl serde::ser::Error for DeError {
         fn custom<T: fmt::Display>(msg: T) -> Self {
             DeError::Custom(msg.to_string())
+        }
+    }
+
+    impl From<IoError> for DeError {
+        #[inline]
+        fn from(e: IoError) -> Self {
+            Self::Io(Arc::new(e))
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -345,12 +345,6 @@ pub mod serialize {
         /// [`Event::Start`]: crate::events::Event::Start
         /// [`Event::End`]: crate::events::Event::End
         UnexpectedEof,
-        /// An attempt to deserialize to a type, that is not supported by the XML
-        /// store at current position, for example, attempt to deserialize `struct`
-        /// from attribute or attempt to deserialize binary data.
-        ///
-        /// [XML name]: https://www.w3.org/TR/xml11/#sec-common-syn
-        Unsupported(Cow<'static, str>),
         /// Too many events were skipped while deserializing a sequence, event limit
         /// exceeded. The limit was provided as an argument
         #[cfg(feature = "overlapped-lists")]
@@ -372,7 +366,6 @@ pub mod serialize {
                     f.write_str(")`")
                 }
                 DeError::UnexpectedEof => write!(f, "Unexpected `Event::Eof`"),
-                DeError::Unsupported(s) => write!(f, "Unsupported operation: {}", s),
                 #[cfg(feature = "overlapped-lists")]
                 DeError::TooManyEvents(s) => write!(f, "Deserializer buffers {} events, limit exceeded", s),
             }
@@ -442,13 +435,6 @@ pub mod serialize {
         #[inline]
         fn from(e: ParseFloatError) -> Self {
             Self::InvalidFloat(e)
-        }
-    }
-
-    impl From<fmt::Error> for DeError {
-        #[inline]
-        fn from(e: fmt::Error) -> Self {
-            Self::Custom(e.to_string())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub mod writer;
 // reexports
 pub use crate::encoding::Decoder;
 #[cfg(feature = "serialize")]
-pub use crate::errors::serialize::DeError;
+pub use crate::errors::serialize::{DeError, SeError};
 pub use crate::errors::{Error, Result};
 pub use crate::reader::{NsReader, Reader};
 pub use crate::writer::{ElementWriter, Writer};

--- a/src/se/key.rs
+++ b/src/se/key.rs
@@ -1,4 +1,4 @@
-use crate::errors::serialize::DeError;
+use crate::errors::serialize::SeError;
 use serde::ser::{Impossible, Serialize, Serializer};
 use serde::serde_if_integer128;
 use std::fmt::Write;
@@ -18,14 +18,14 @@ pub struct QNameSerializer<W: Write> {
 
 impl<W: Write> QNameSerializer<W> {
     #[inline]
-    fn write_str(&mut self, value: &str) -> Result<(), DeError> {
+    fn write_str(&mut self, value: &str) -> Result<(), SeError> {
         Ok(self.writer.write_str(value)?)
     }
 }
 
 impl<W: Write> Serializer for QNameSerializer<W> {
     type Ok = W;
-    type Error = DeError;
+    type Error = SeError;
 
     type SerializeSeq = Impossible<Self::Ok, Self::Error>;
     type SerializeTuple = Impossible<Self::Ok, Self::Error>;
@@ -45,7 +45,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
     /// Because unit type can be represented only by empty string which is not
     /// a valid XML name, serialization of unit returns `Err(Unsupported)`
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             "cannot serialize unit type `()` as an XML tag name".into(),
         ))
     }
@@ -53,7 +53,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
     /// Because unit struct can be represented only by empty string which is not
     /// a valid XML name, serialization of unit struct returns `Err(Unsupported)`
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!("cannot serialize unit struct `{}` as an XML tag name", name).into(),
         ))
     }
@@ -66,8 +66,8 @@ impl<W: Write> Serializer for QNameSerializer<W> {
         _variant_index: u32,
         variant: &'static str,
         _value: &T,
-    ) -> Result<Self::Ok, DeError> {
-        Err(DeError::Unsupported(
+    ) -> Result<Self::Ok, SeError> {
+        Err(SeError::Unsupported(
             format!(
                 "cannot serialize enum newtype variant `{}::{}` as an XML tag name",
                 name, variant
@@ -77,13 +77,13 @@ impl<W: Write> Serializer for QNameSerializer<W> {
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             "cannot serialize sequence as an XML tag name".into(),
         ))
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             "cannot serialize tuple as an XML tag name".into(),
         ))
     }
@@ -93,7 +93,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!(
                 "cannot serialize tuple struct `{}` as an XML tag name",
                 name
@@ -109,7 +109,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!(
                 "cannot serialize enum tuple variant `{}::{}` as an XML tag name",
                 name, variant
@@ -119,7 +119,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             "cannot serialize map as an XML tag name".into(),
         ))
     }
@@ -129,7 +129,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!("cannot serialize struct `{}` as an XML tag name", name).into(),
         ))
     }
@@ -141,7 +141,7 @@ impl<W: Write> Serializer for QNameSerializer<W> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!(
                 "cannot serialize enum struct variant `{}::{}` as an XML tag name",
                 name, variant
@@ -214,7 +214,7 @@ mod tests {
                 };
 
                 match $data.serialize(ser).unwrap_err() {
-                    DeError::$kind(e) => assert_eq!(e, $reason),
+                    SeError::$kind(e) => assert_eq!(e, $reason),
                     e => panic!(
                         "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),

--- a/src/se/key.rs
+++ b/src/se/key.rs
@@ -1,4 +1,4 @@
-use crate::errors::serialize::SeError;
+use crate::se::SeError;
 use serde::ser::{Impossible, Serialize, Serializer};
 use serde::serde_if_integer128;
 use std::fmt::Write;

--- a/src/se/text.rs
+++ b/src/se/text.rs
@@ -1,8 +1,8 @@
 //! Contains serializer for a special `&text` field
 
 use crate::de::TEXT_KEY;
-use crate::errors::serialize::DeError;
 use crate::se::simple_type::{SimpleSeq, SimpleTypeSerializer};
+use crate::se::SeError;
 use serde::ser::{Impossible, Serialize, Serializer};
 use serde::serde_if_integer128;
 use std::fmt::Write;
@@ -27,7 +27,7 @@ pub struct TextSerializer<'i, W: Write>(pub SimpleTypeSerializer<'i, W>);
 
 impl<'i, W: Write> Serializer for TextSerializer<'i, W> {
     type Ok = W;
-    type Error = DeError;
+    type Error = SeError;
 
     type SerializeSeq = SimpleSeq<'i, W>;
     type SerializeTuple = SimpleSeq<'i, W>;
@@ -110,7 +110,7 @@ impl<'i, W: Write> Serializer for TextSerializer<'i, W> {
         variant: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!(
                 "cannot serialize enum newtype variant `{}::{}` as text content value",
                 name, variant
@@ -146,7 +146,7 @@ impl<'i, W: Write> Serializer for TextSerializer<'i, W> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!(
                 "cannot serialize enum tuple variant `{}::{}` as text content value",
                 name, variant
@@ -157,7 +157,7 @@ impl<'i, W: Write> Serializer for TextSerializer<'i, W> {
 
     #[inline]
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             "cannot serialize map as text content value".into(),
         ))
     }
@@ -168,7 +168,7 @@ impl<'i, W: Write> Serializer for TextSerializer<'i, W> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!("cannot serialize struct `{}` as text content value", name).into(),
         ))
     }
@@ -181,7 +181,7 @@ impl<'i, W: Write> Serializer for TextSerializer<'i, W> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(DeError::Unsupported(
+        Err(SeError::Unsupported(
             format!(
                 "cannot serialize enum struct variant `{}::{}` as text content value",
                 name, variant

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -278,7 +278,7 @@ impl<W: Write> Writer<W> {
     /// # use serde::Serialize;
     /// # use quick_xml::events::{BytesStart, Event};
     /// # use quick_xml::writer::Writer;
-    /// # use quick_xml::SeError;
+    /// # use quick_xml::se::SeError;
     /// # fn main() -> Result<(), SeError> {
     /// #[derive(Debug, PartialEq, Serialize)]
     /// struct MyData {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,11 +1,9 @@
 //! Contains high-level interface for an events-based XML emitter.
 
 use std::borrow::Cow;
-use std::io::Write;
-use std::result::Result as StdResult;
+use std::io::{self, Write};
 
 use crate::encoding::UTF8_BOM;
-use crate::errors::{Error, Result};
 use crate::events::{attributes::Attribute, BytesCData, BytesPI, BytesStart, BytesText, Event};
 
 #[cfg(feature = "async-tokio")]
@@ -129,7 +127,7 @@ impl<W> Writer<W> {
     /// // writes <tag><fruit quantity="0">apple</fruit><fruit quantity="1">orange</fruit></tag>
     /// writer.create_element("tag")
     ///     // We need to provide error type, because it is not named somewhere explicitly
-    ///     .write_inner_content::<_, Error>(|writer| {
+    ///     .write_inner_content(|writer| {
     ///         let fruits = ["apple", "orange"];
     ///         for (quant, item) in fruits.iter().enumerate() {
     ///             writer
@@ -187,12 +185,12 @@ impl<W: Write> Writer<W> {
     /// # }
     /// ```
     /// [Byte-Order-Mark]: https://unicode.org/faq/utf_bom.html#BOM
-    pub fn write_bom(&mut self) -> Result<()> {
+    pub fn write_bom(&mut self) -> io::Result<()> {
         self.write(UTF8_BOM)
     }
 
     /// Writes the given event to the underlying writer.
-    pub fn write_event<'a, E: Into<Event<'a>>>(&mut self, event: E) -> Result<()> {
+    pub fn write_event<'a, E: Into<Event<'a>>>(&mut self, event: E) -> io::Result<()> {
         let mut next_should_line_break = true;
         let result = match event.into() {
             Event::Start(e) => {
@@ -233,12 +231,12 @@ impl<W: Write> Writer<W> {
 
     /// Writes bytes
     #[inline]
-    pub(crate) fn write(&mut self, value: &[u8]) -> Result<()> {
+    pub(crate) fn write(&mut self, value: &[u8]) -> io::Result<()> {
         self.writer.write_all(value).map_err(Into::into)
     }
 
     #[inline]
-    fn write_wrapped(&mut self, before: &[u8], value: &[u8], after: &[u8]) -> Result<()> {
+    fn write_wrapped(&mut self, before: &[u8], value: &[u8], after: &[u8]) -> io::Result<()> {
         if let Some(ref i) = self.indent {
             if i.should_line_break {
                 self.writer.write_all(b"\n")?;
@@ -262,7 +260,7 @@ impl<W: Write> Writer<W> {
     /// [`Text`]: Event::Text
     /// [`Start`]: Event::Start
     /// [`new_with_indent`]: Self::new_with_indent
-    pub fn write_indent(&mut self) -> Result<()> {
+    pub fn write_indent(&mut self) -> io::Result<()> {
         if let Some(ref i) = self.indent {
             self.writer.write_all(b"\n")?;
             self.writer.write_all(i.current())?;
@@ -320,7 +318,7 @@ impl<W: Write> Writer<W> {
         &mut self,
         tag_name: &str,
         content: &T,
-    ) -> std::result::Result<(), DeError> {
+    ) -> Result<(), DeError> {
         use crate::se::{Indent, Serializer};
 
         self.write_indent()?;
@@ -530,7 +528,7 @@ impl<'a, W> ElementWriter<'a, W> {
 
 impl<'a, W: Write> ElementWriter<'a, W> {
     /// Write some text inside the current element.
-    pub fn write_text_content(self, text: BytesText) -> Result<&'a mut Writer<W>> {
+    pub fn write_text_content(self, text: BytesText) -> io::Result<&'a mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.borrow()))?;
         self.writer.write_event(Event::Text(text))?;
@@ -540,7 +538,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write a CData event `<![CDATA[...]]>` inside the current element.
-    pub fn write_cdata_content(self, text: BytesCData) -> Result<&'a mut Writer<W>> {
+    pub fn write_cdata_content(self, text: BytesCData) -> io::Result<&'a mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.borrow()))?;
         self.writer.write_event(Event::CData(text))?;
@@ -550,7 +548,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write a processing instruction `<?...?>` inside the current element.
-    pub fn write_pi_content(self, pi: BytesPI) -> Result<&'a mut Writer<W>> {
+    pub fn write_pi_content(self, pi: BytesPI) -> io::Result<&'a mut Writer<W>> {
         self.writer
             .write_event(Event::Start(self.start_tag.borrow()))?;
         self.writer.write_event(Event::PI(pi))?;
@@ -560,16 +558,15 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 
     /// Write an empty (self-closing) tag.
-    pub fn write_empty(self) -> Result<&'a mut Writer<W>> {
+    pub fn write_empty(self) -> io::Result<&'a mut Writer<W>> {
         self.writer.write_event(Event::Empty(self.start_tag))?;
         Ok(self.writer)
     }
 
     /// Create a new scope for writing XML inside the current element.
-    pub fn write_inner_content<F, E>(self, closure: F) -> StdResult<&'a mut Writer<W>, E>
+    pub fn write_inner_content<F>(self, closure: F) -> io::Result<&'a mut Writer<W>>
     where
-        F: FnOnce(&mut Writer<W>) -> StdResult<(), E>,
-        E: From<Error>,
+        F: FnOnce(&mut Writer<W>) -> io::Result<()>,
     {
         self.writer
             .write_event(Event::Start(self.start_tag.borrow()))?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,7 +11,7 @@ mod async_tokio;
 
 /// XML writer. Writes XML [`Event`]s to a [`std::io::Write`] or [`tokio::io::AsyncWrite`] implementor.
 #[cfg(feature = "serialize")]
-use {crate::de::DeError, serde::Serialize};
+use {crate::se::SeError, serde::Serialize};
 
 /// XML writer. Writes XML [`Event`]s to a [`std::io::Write`] implementor.
 ///
@@ -278,8 +278,8 @@ impl<W: Write> Writer<W> {
     /// # use serde::Serialize;
     /// # use quick_xml::events::{BytesStart, Event};
     /// # use quick_xml::writer::Writer;
-    /// # use quick_xml::DeError;
-    /// # fn main() -> Result<(), DeError> {
+    /// # use quick_xml::SeError;
+    /// # fn main() -> Result<(), SeError> {
     /// #[derive(Debug, PartialEq, Serialize)]
     /// struct MyData {
     ///     question: String,
@@ -318,7 +318,7 @@ impl<W: Write> Writer<W> {
         &mut self,
         tag_name: &str,
         content: &T,
-    ) -> Result<(), DeError> {
+    ) -> Result<(), SeError> {
         use crate::se::{Indent, Serializer};
 
         self.write_indent()?;

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -1,7 +1,7 @@
 use quick_xml::de::from_str;
 use quick_xml::se::Serializer;
 use quick_xml::utils::Bytes;
-use quick_xml::DeError;
+use quick_xml::SeError;
 
 use serde::{serde_if_integer128, Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -275,7 +275,7 @@ mod without_root {
                 let ser = Serializer::new(&mut buffer);
 
                 match $data.serialize(ser) {
-                    Err(DeError::$kind(e)) => assert_eq!(e, $reason),
+                    Err(SeError::$kind(e)) => assert_eq!(e, $reason),
                     e => panic!(
                         "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),
@@ -1324,7 +1324,7 @@ mod without_root {
                     let ser = Serializer::new(&mut buffer);
 
                     match $data.serialize(ser) {
-                        Err(DeError::$kind(e)) => assert_eq!(e, $reason),
+                        Err(SeError::$kind(e)) => assert_eq!(e, $reason),
                         e => panic!(
                             "Expected `Err({}({}))`, but got `{:?}`",
                             stringify!($kind),
@@ -1883,7 +1883,7 @@ mod with_root {
                 let ser = Serializer::with_root(&mut buffer, Some("root")).unwrap();
 
                 match $data.serialize(ser) {
-                    Err(DeError::$kind(e)) => assert_eq!(e, $reason),
+                    Err(SeError::$kind(e)) => assert_eq!(e, $reason),
                     e => panic!(
                         "Expected `Err({}({}))`, but got `{:?}`",
                         stringify!($kind),

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -1,7 +1,6 @@
 use quick_xml::de::from_str;
-use quick_xml::se::Serializer;
+use quick_xml::se::{SeError, Serializer};
 use quick_xml::utils::Bytes;
-use quick_xml::SeError;
 
 use serde::{serde_if_integer128, Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/tests/writer-indentation.rs
+++ b/tests/writer-indentation.rs
@@ -1,4 +1,3 @@
-use quick_xml::errors::Error;
 use quick_xml::events::{BytesStart, BytesText, Event};
 use quick_xml::writer::Writer;
 
@@ -276,7 +275,7 @@ fn element_writer_nested() {
         .create_element("outer")
         .with_attribute(("attr1", "value1"))
         .with_attribute(("attr2", "value2"))
-        .write_inner_content::<_, Error>(|writer| {
+        .write_inner_content(|writer| {
             let fruits = ["apple", "orange", "banana"];
             for (quant, item) in fruits.iter().enumerate() {
                 writer


### PR DESCRIPTION
I recently made a PR to update this crate in [another crate (inferno)](https://github.com/jonhoo/inferno/pull/332) and needed to remove this crates errors from the public API. While doing this I realized that the `Writer` could never return any error other than `Error::Io`. Wrapping this error in `Arc` and putting it in the `Error` enum feels unnecessary.

This does change the public API of `Writer` and introduces the `DeError::Io` kind which may not be desirable. In case this change will not happen a note in the documentation of `Writer` about not returning errors other than `Error::Io` may be useful (but may be hard to enforce, leading to outdated/incorrect docs).

I'd be more than willing to make any other changes if needed.