### PR TITLE
Make Errors more "narrow" 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,7 +22,7 @@
 - [#227]: Split `SeError` from `DeError` in the `serialize` feature.
   Serialize functions and methods now return `SeError`.
 - [#810]: Return `std::io::Error` from `Writer` methods.
-- [#811]: Split `NamespaceError` from `Error`.
+- [#811]: Split `NamespaceError` and `EncodingError` from `Error`.
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
 [#810]: https://github.com/tafia/quick-xml/pull/810

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,8 @@
 - [#810]: Return `std::io::Error` from `Writer` methods.
 - [#811]: Split `NamespaceError` and `EncodingError` from `Error`.
 - [#811]: Renamed `Error::EscapeError` to `Error::Escape` to match other variants.
+- [#811]: Narrow down error return type from `Error` where only one variant is ever returned:
+  attribute related methods on `BytesStart` and `BytesDecl` returns `AttrError`
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
 [#810]: https://github.com/tafia/quick-xml/pull/810

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@
   Serialize functions and methods now return `SeError`.
 - [#810]: Return `std::io::Error` from `Writer` methods.
 - [#811]: Split `NamespaceError` and `EncodingError` from `Error`.
+- [#811]: Renamed `Error::EscapeError` to `Error::Escape` to match other variants.
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
 [#810]: https://github.com/tafia/quick-xml/pull/810

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,9 +22,11 @@
 - [#227]: Split `SeError` from `DeError` in the `serialize` feature.
   Serialize functions and methods now return `SeError`.
 - [#810]: Return `std::io::Error` from `Writer` methods.
+- [#811]: Split `NamespaceError` from `Error`.
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
 [#810]: https://github.com/tafia/quick-xml/pull/810
+[#811]: https://github.com/tafia/quick-xml/pull/811
 
 
 ## 0.36.2 -- 2024-09-20

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -90,7 +90,10 @@ impl Translation {
                 })
             } else {
                 dbg!("Expected Event::Start for Text, got: {:?}", &event);
-                let name_string = reader.decoder().decode(name.as_ref())?;
+                let name_string = reader
+                    .decoder()
+                    .decode(name.as_ref())
+                    .map_err(quick_xml::Error::Encoding)?;
                 Err(AppError::NoText(name_string.into()))
             }
         } else {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -358,16 +358,16 @@ pub mod serialize {
                 DeError::InvalidXml(e) => write!(f, "{}", e),
                 DeError::InvalidInt(e) => write!(f, "{}", e),
                 DeError::InvalidFloat(e) => write!(f, "{}", e),
-                DeError::InvalidBoolean(v) => write!(f, "Invalid boolean value '{}'", v),
-                DeError::KeyNotRead => write!(f, "Invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
+                DeError::InvalidBoolean(v) => write!(f, "invalid boolean value '{}'", v),
+                DeError::KeyNotRead => write!(f, "invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
                 DeError::UnexpectedStart(e) => {
-                    f.write_str("Unexpected `Event::Start(")?;
+                    f.write_str("unexpected `Event::Start(")?;
                     write_byte_string(f, e)?;
                     f.write_str(")`")
                 }
-                DeError::UnexpectedEof => write!(f, "Unexpected `Event::Eof`"),
+                DeError::UnexpectedEof => write!(f, "unexpected `Event::Eof`"),
                 #[cfg(feature = "overlapped-lists")]
-                DeError::TooManyEvents(s) => write!(f, "Deserializer buffers {} events, limit exceeded", s),
+                DeError::TooManyEvents(s) => write!(f, "deserializer buffered {} events, limit exceeded", s),
             }
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -123,15 +123,14 @@ impl fmt::Display for IllFormedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::MissingDeclVersion(None) => {
-                write!(f, "an XML declaration does not contain `version` attribute")
+                f.write_str("an XML declaration does not contain `version` attribute")
             }
             Self::MissingDeclVersion(Some(attr)) => {
                 write!(f, "an XML declaration must start with `version` attribute, but in starts with `{}`", attr)
             }
-            Self::MissingDoctypeName => write!(
-                f,
-                "`<!DOCTYPE>` declaration does not contain a name of a document type"
-            ),
+            Self::MissingDoctypeName => {
+                f.write_str("`<!DOCTYPE>` declaration does not contain a name of a document type")
+            }
             Self::MissingEndTag(tag) => write!(
                 f,
                 "start tag not closed: `</{}>` not found before end of input",
@@ -146,7 +145,7 @@ impl fmt::Display for IllFormedError {
                 expected, found,
             ),
             Self::DoubleHyphenInComment => {
-                write!(f, "forbidden string `--` was found in a comment")
+                f.write_str("forbidden string `--` was found in a comment")
             }
         }
     }
@@ -272,7 +271,7 @@ impl fmt::Display for Error {
             Error::NonDecodable(None) => write!(f, "Malformed input, decoding impossible"),
             Error::NonDecodable(Some(e)) => write!(f, "Malformed UTF-8 input: {}", e),
             Error::InvalidAttr(e) => write!(f, "error while parsing attribute: {}", e),
-            Error::EscapeError(e) => write!(f, "{}", e),
+            Error::EscapeError(e) => e.fmt(f),
             Error::UnknownPrefix(prefix) => {
                 f.write_str("Unknown namespace prefix '")?;
                 write_byte_string(f, prefix)?;
@@ -354,25 +353,25 @@ pub mod serialize {
     impl fmt::Display for DeError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
-                DeError::Custom(s) => write!(f, "{}", s),
-                DeError::InvalidXml(e) => write!(f, "{}", e),
-                DeError::InvalidInt(e) => write!(f, "{}", e),
-                DeError::InvalidFloat(e) => write!(f, "{}", e),
+                DeError::Custom(s) => f.write_str(s),
+                DeError::InvalidXml(e) => e.fmt(f),
+                DeError::InvalidInt(e) => write!(f, "invalid integral value: {}", e),
+                DeError::InvalidFloat(e) => write!(f, "invalid floating-point value: {}", e),
                 DeError::InvalidBoolean(v) => write!(f, "invalid boolean value '{}'", v),
-                DeError::KeyNotRead => write!(f, "invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
+                DeError::KeyNotRead => f.write_str("invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
                 DeError::UnexpectedStart(e) => {
                     f.write_str("unexpected `Event::Start(")?;
                     write_byte_string(f, e)?;
                     f.write_str(")`")
                 }
-                DeError::UnexpectedEof => write!(f, "unexpected `Event::Eof`"),
+                DeError::UnexpectedEof => f.write_str("unexpected `Event::Eof`"),
                 #[cfg(feature = "overlapped-lists")]
                 DeError::TooManyEvents(s) => write!(f, "deserializer buffered {} events, limit exceeded", s),
             }
         }
     }
 
-    impl ::std::error::Error for DeError {
+    impl std::error::Error for DeError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match self {
                 DeError::InvalidXml(e) => Some(e),
@@ -465,7 +464,7 @@ pub mod serialize {
     impl fmt::Display for SeError {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
-                SeError::Custom(s) => write!(f, "{}", s),
+                SeError::Custom(s) => f.write_str(s),
                 SeError::Io(e) => write!(f, "I/O error: {}", e),
                 SeError::Fmt(e) => write!(f, "formatting error: {}", e),
                 SeError::Unsupported(s) => write!(f, "unsupported value: {}", s),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -168,7 +168,7 @@ pub enum Error {
     /// Encoding error
     Encoding(EncodingError),
     /// Escape error
-    EscapeError(EscapeError),
+    Escape(EscapeError),
     /// Parsed XML has some namespace-related problems
     Namespace(NamespaceError),
 }
@@ -218,7 +218,7 @@ impl From<EscapeError> for Error {
     /// Creates a new `Error::EscapeError` from the given error
     #[inline]
     fn from(error: EscapeError) -> Error {
-        Self::EscapeError(error)
+        Self::Escape(error)
     }
 }
 
@@ -247,7 +247,7 @@ impl fmt::Display for Error {
             Self::IllFormed(e) => write!(f, "ill-formed document: {}", e),
             Self::InvalidAttr(e) => write!(f, "error while parsing attribute: {}", e),
             Self::Encoding(e) => e.fmt(f),
-            Self::EscapeError(e) => e.fmt(f),
+            Self::Escape(e) => e.fmt(f),
             Self::Namespace(e) => e.fmt(f),
         }
     }
@@ -261,7 +261,7 @@ impl std::error::Error for Error {
             Self::IllFormed(e) => Some(e),
             Self::InvalidAttr(e) => Some(e),
             Self::Encoding(e) => Some(e),
-            Self::EscapeError(e) => Some(e),
+            Self::Escape(e) => Some(e),
             Self::Namespace(e) => Some(e),
         }
     }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -55,15 +55,15 @@ pub enum EscapeError {
 impl std::fmt::Display for EscapeError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            EscapeError::UnrecognizedEntity(rge, res) => {
+            Self::UnrecognizedEntity(rge, res) => {
                 write!(f, "at {:?}: unrecognized entity `{}`", rge, res)
             }
-            EscapeError::UnterminatedEntity(e) => write!(
+            Self::UnterminatedEntity(e) => write!(
                 f,
                 "Error while escaping character at range {:?}: Cannot find ';' after '&'",
                 e
             ),
-            EscapeError::InvalidCharRef(e) => {
+            Self::InvalidCharRef(e) => {
                 write!(f, "invalid character reference: {}", e)
             }
         }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -54,7 +54,7 @@ use crate::name::{LocalName, QName};
 #[cfg(feature = "serialize")]
 use crate::utils::CowRef;
 use crate::utils::{name_len, trim_xml_end, trim_xml_start, write_cow_string};
-use attributes::{Attribute, Attributes};
+use attributes::{AttrError, Attribute, Attributes};
 
 /// Opening tag data (`Event::Start`), with optional attributes: `<name attr="value">`.
 ///
@@ -297,7 +297,7 @@ impl<'a> BytesStart<'a> {
     pub fn try_get_attribute<N: AsRef<[u8]> + Sized>(
         &'a self,
         attr_name: N,
-    ) -> Result<Option<Attribute<'a>>, Error> {
+    ) -> Result<Option<Attribute<'a>>, AttrError> {
         for a in self.attributes().with_checks(false) {
             let a = a?;
             if a.key.as_ref() == attr_name.as_ref() {
@@ -1191,7 +1191,7 @@ impl<'a> BytesDecl<'a> {
     /// ```
     ///
     /// [grammar]: https://www.w3.org/TR/xml11/#NT-XMLDecl
-    pub fn encoding(&self) -> Option<Result<Cow<[u8]>, Error>> {
+    pub fn encoding(&self) -> Option<Result<Cow<[u8]>, AttrError>> {
         self.content
             .try_get_attribute("encoding")
             .map(|a| a.map(|a| a.value))
@@ -1233,7 +1233,7 @@ impl<'a> BytesDecl<'a> {
     /// ```
     ///
     /// [grammar]: https://www.w3.org/TR/xml11/#NT-XMLDecl
-    pub fn standalone(&self) -> Option<Result<Cow<[u8]>, Error>> {
+    pub fn standalone(&self) -> Option<Result<Cow<[u8]>, AttrError>> {
         self.content
             .try_get_attribute("standalone")
             .map(|a| a.map(|a| a.value))

--- a/src/name.rs
+++ b/src/name.rs
@@ -1040,18 +1040,15 @@ mod namespaces {
             fn rebound_to_incorrect_ns() {
                 let mut resolver = NamespaceResolver::default();
                 let s = resolver.buffer.len();
-                match resolver.push(&BytesStart::from_content(
-                    " xmlns:xml='not_correct_namespace'",
-                    0,
-                )) {
-                    Err(NamespaceError::InvalidXmlPrefixBind(namespace)) => {
-                        assert_eq!(namespace, b"not_correct_namespace");
-                    }
-                    x => panic!(
-                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
-                        x
-                    ),
-                }
+                assert_eq!(
+                    resolver.push(&BytesStart::from_content(
+                        " xmlns:xml='not_correct_namespace'",
+                        0,
+                    )),
+                    Err(NamespaceError::InvalidXmlPrefixBind(
+                        b"not_correct_namespace".to_vec()
+                    )),
+                );
                 assert_eq!(&resolver.buffer[s..], b"");
             }
 
@@ -1060,15 +1057,10 @@ mod namespaces {
             fn unbound() {
                 let mut resolver = NamespaceResolver::default();
                 let s = resolver.buffer.len();
-                match resolver.push(&BytesStart::from_content(" xmlns:xml=''", 0)) {
-                    Err(NamespaceError::InvalidXmlPrefixBind(namespace)) => {
-                        assert_eq!(namespace, b"");
-                    }
-                    x => panic!(
-                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
-                        x
-                    ),
-                }
+                assert_eq!(
+                    resolver.push(&BytesStart::from_content(" xmlns:xml=''", 0)),
+                    Err(NamespaceError::InvalidXmlPrefixBind(b"".to_vec())),
+                );
                 assert_eq!(&resolver.buffer[s..], b"");
             }
 
@@ -1077,18 +1069,13 @@ mod namespaces {
             fn other_prefix_bound_to_xml_namespace() {
                 let mut resolver = NamespaceResolver::default();
                 let s = resolver.buffer.len();
-                match resolver.push(&BytesStart::from_content(
-                    " xmlns:not_xml='http://www.w3.org/XML/1998/namespace'",
-                    0,
-                )) {
-                    Err(NamespaceError::InvalidPrefixForXml(prefix)) => {
-                        assert_eq!(prefix, b"not_xml");
-                    }
-                    x => panic!(
-                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
-                        x
-                    ),
-                }
+                assert_eq!(
+                    resolver.push(&BytesStart::from_content(
+                        " xmlns:not_xml='http://www.w3.org/XML/1998/namespace'",
+                        0,
+                    )),
+                    Err(NamespaceError::InvalidPrefixForXml(b"not_xml".to_vec())),
+                );
                 assert_eq!(&resolver.buffer[s..], b"");
             }
         }
@@ -1122,18 +1109,15 @@ mod namespaces {
             fn rebound_to_correct_ns() {
                 let mut resolver = NamespaceResolver::default();
                 let s = resolver.buffer.len();
-                match resolver.push(&BytesStart::from_content(
-                    " xmlns:xmlns='http://www.w3.org/2000/xmlns/'",
-                    0,
-                )) {
-                    Err(NamespaceError::InvalidXmlnsPrefixBind(namespace)) => {
-                        assert_eq!(namespace, b"http://www.w3.org/2000/xmlns/");
-                    }
-                    x => panic!(
-                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
-                        x
-                    ),
-                }
+                assert_eq!(
+                    resolver.push(&BytesStart::from_content(
+                        " xmlns:xmlns='http://www.w3.org/2000/xmlns/'",
+                        0,
+                    )),
+                    Err(NamespaceError::InvalidXmlnsPrefixBind(
+                        b"http://www.w3.org/2000/xmlns/".to_vec()
+                    )),
+                );
                 assert_eq!(&resolver.buffer[s..], b"");
             }
 
@@ -1142,18 +1126,15 @@ mod namespaces {
             fn rebound_to_incorrect_ns() {
                 let mut resolver = NamespaceResolver::default();
                 let s = resolver.buffer.len();
-                match resolver.push(&BytesStart::from_content(
-                    " xmlns:xmlns='not_correct_namespace'",
-                    0,
-                )) {
-                    Err(NamespaceError::InvalidXmlnsPrefixBind(namespace)) => {
-                        assert_eq!(namespace, b"not_correct_namespace");
-                    }
-                    x => panic!(
-                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
-                        x
-                    ),
-                }
+                assert_eq!(
+                    resolver.push(&BytesStart::from_content(
+                        " xmlns:xmlns='not_correct_namespace'",
+                        0,
+                    )),
+                    Err(NamespaceError::InvalidXmlnsPrefixBind(
+                        b"not_correct_namespace".to_vec()
+                    )),
+                );
                 assert_eq!(&resolver.buffer[s..], b"");
             }
 
@@ -1162,15 +1143,10 @@ mod namespaces {
             fn unbound() {
                 let mut resolver = NamespaceResolver::default();
                 let s = resolver.buffer.len();
-                match resolver.push(&BytesStart::from_content(" xmlns:xmlns=''", 0)) {
-                    Err(NamespaceError::InvalidXmlnsPrefixBind(namespace)) => {
-                        assert_eq!(namespace, b"");
-                    }
-                    x => panic!(
-                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
-                        x
-                    ),
-                }
+                assert_eq!(
+                    resolver.push(&BytesStart::from_content(" xmlns:xmlns=''", 0)),
+                    Err(NamespaceError::InvalidXmlnsPrefixBind(b"".to_vec())),
+                );
                 assert_eq!(&resolver.buffer[s..], b"");
             }
 
@@ -1179,18 +1155,13 @@ mod namespaces {
             fn other_prefix_bound_to_xmlns_namespace() {
                 let mut resolver = NamespaceResolver::default();
                 let s = resolver.buffer.len();
-                match resolver.push(&BytesStart::from_content(
-                    " xmlns:not_xmlns='http://www.w3.org/2000/xmlns/'",
-                    0,
-                )) {
-                    Err(NamespaceError::InvalidPrefixForXmlns(prefix)) => {
-                        assert_eq!(prefix, b"not_xmlns");
-                    }
-                    x => panic!(
-                        "Expected `Err(InvalidPrefixBind {{ .. }})`, but got `{:?}`",
-                        x
-                    ),
-                }
+                assert_eq!(
+                    resolver.push(&BytesStart::from_content(
+                        " xmlns:not_xmlns='http://www.w3.org/2000/xmlns/'",
+                        0,
+                    )),
+                    Err(NamespaceError::InvalidPrefixForXmlns(b"not_xmlns".to_vec())),
+                );
                 assert_eq!(&resolver.buffer[s..], b"");
             }
         }

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -192,7 +192,7 @@ macro_rules! impl_buffered_source {
             }
 
             *position += read;
-            Err(bang_type.to_err())
+            Err(bang_type.to_err().into())
         }
 
         #[inline]

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -316,7 +316,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         }
 
         *position += self.len() as u64;
-        Err(bang_type.to_err())
+        Err(bang_type.to_err().into())
     }
 
     #[inline]

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -233,7 +233,7 @@ impl<'a> Reader<&'a [u8]> {
         let len = span.end - span.start;
         // SAFETY: `span` can only contain indexes up to usize::MAX because it
         // was created from offsets from a single &[u8] slice
-        self.decoder().decode(&buffer[0..len as usize])
+        Ok(self.decoder().decode(&buffer[0..len as usize])?)
     }
 }
 

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -165,7 +165,7 @@ impl ReaderState {
                 //  ^^^^^ - `buf` does not contain `<` and `>`, but `self.offset` is after `>`.
                 // ^------- We report error at that position, so we need to subtract 2 and buf len
                 self.last_error_offset = self.offset - len as u64 - 2;
-                Err(bang_type.to_err())
+                Err(bang_type.to_err().into())
             }
         }
     }


### PR DESCRIPTION
This was discussed in #810 [here](https://github.com/tafia/quick-xml/issues/810#issuecomment-2381341534).

This splits up error types so that there is almost one type for each module, which narrows the amount of error variants that is returned from each function.

For the functions where two or more error types may be returned the new `combined_error!` macro is used to create a new error `enum` that holds these variants with most error `impl`'s automatically done. 

The old `errors::Error` is still present and public. All other new errors implement `From<_> for errors::Error` so that the provided `errors::Result` type can still be used to try (`?`) any function from this crate. 

I haven't spent much time adding/editing docs for these changes since most of them still apply without changes. Maybe the docs for `errors::Error` should be changed to make it clear that it will not be given out as an error from anywhere directly. There are also some names of the new error types that might need changing