### PR TITLE
Do not write excess indents arount text fields when serialize with serde

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,10 +26,12 @@
 - [#811]: Renamed `Error::EscapeError` to `Error::Escape` to match other variants.
 - [#811]: Narrow down error return type from `Error` where only one variant is ever returned:
   attribute related methods on `BytesStart` and `BytesDecl` returns `AttrError`
+- [#820]: Classify output of the `Serializer` by returning an enumeration with kind of written data
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
 [#810]: https://github.com/tafia/quick-xml/pull/810
 [#811]: https://github.com/tafia/quick-xml/pull/811
+[#820]: https://github.com/tafia/quick-xml/pull/820
 
 
 ## 0.36.2 -- 2024-09-20

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,9 @@
 
 ### Bug Fixes
 
+- [#655]: Do not write indent before and after `$text` fields and those `$value` fields
+  that are serialized as a text (for example, `usize` or `String`).
+
 ### Misc Changes
 
 - [#227]: Split `SeError` from `DeError` in the `serialize` feature.
@@ -29,6 +32,7 @@
 - [#820]: Classify output of the `Serializer` by returning an enumeration with kind of written data
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
+[#655]: https://github.com/tafia/quick-xml/issues/655
 [#810]: https://github.com/tafia/quick-xml/pull/810
 [#811]: https://github.com/tafia/quick-xml/pull/811
 [#820]: https://github.com/tafia/quick-xml/pull/820

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -791,7 +791,7 @@ impl<'de, 'a> EnumAccess<'de> for SimpleTypeDeserializer<'de, 'a> {
 mod tests {
     use super::*;
     use crate::se::simple_type::{QuoteTarget, SimpleTypeSerializer};
-    use crate::se::{Indent, QuoteLevel};
+    use crate::se::QuoteLevel;
     use crate::utils::{ByteBuf, Bytes};
     use serde::de::IgnoredAny;
     use serde::{Deserialize, Serialize};
@@ -828,7 +828,6 @@ mod tests {
                         writer: String::new(),
                         target: QuoteTarget::Text,
                         level: QuoteLevel::Full,
-                        indent: Indent::None,
                     })
                     .unwrap(),
                     xml
@@ -943,7 +942,7 @@ mod tests {
                             writer: &mut buffer,
                             target: QuoteTarget::Text,
                             level: QuoteLevel::Full,
-                            indent: Some(Indent::None),
+                            write_delimiter: false,
                         })
                         .unwrap();
                     assert_eq!(buffer, $input);

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -69,7 +69,7 @@ pub struct ContentSerializer<'w, 'i, W: Write> {
     /// child serializers should have access to the actual state of indentation.
     pub(super) indent: Indent<'i>,
     /// If `true`, then current indent will be written before writing the content,
-    /// but only if content is not empty.
+    /// but only if content is not empty. This flag is reset after writing indent.
     pub write_indent: bool,
     // If `true`, then empty elements will be serialized as `<element></element>`
     // instead of `<element/>`.
@@ -86,11 +86,7 @@ impl<'w, 'i, W: Write> ContentSerializer<'w, 'i, W> {
             writer: self.writer,
             target: QuoteTarget::Text,
             level: self.level,
-            indent: if self.write_indent {
-                self.indent
-            } else {
-                Indent::None
-            },
+            indent: Indent::None,
         }
     }
 
@@ -396,8 +392,8 @@ impl<'w, 'i, W: Write> SerializeSeq for Seq<'w, 'i, W> {
         T: ?Sized + Serialize,
     {
         self.last = value.serialize(self.ser.new_seq_element_serializer())?;
-        // Write indent for next element
-        self.ser.write_indent = true;
+        // Write indent for next element if indents are used
+        self.ser.write_indent = self.last.allow_indent();
         Ok(())
     }
 

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -80,13 +80,12 @@ pub struct ContentSerializer<'w, 'i, W: Write> {
 impl<'w, 'i, W: Write> ContentSerializer<'w, 'i, W> {
     /// Turns this serializer into serializer of a text content
     #[inline]
-    pub fn into_simple_type_serializer(self) -> SimpleTypeSerializer<'i, &'w mut W> {
+    pub fn into_simple_type_serializer(self) -> SimpleTypeSerializer<&'w mut W> {
         //TODO: Customization point: choose between CDATA and Text representation
         SimpleTypeSerializer {
             writer: self.writer,
             target: QuoteTarget::Text,
             level: self.level,
-            indent: Indent::None,
         }
     }
 
@@ -128,7 +127,7 @@ impl<'w, 'i, W: Write> ContentSerializer<'w, 'i, W> {
         serialize: S,
     ) -> Result<WriteResult, SeError>
     where
-        S: for<'a> FnOnce(SimpleTypeSerializer<'i, &'a mut W>) -> Result<&'a mut W, SeError>,
+        S: for<'a> FnOnce(SimpleTypeSerializer<&'a mut W>) -> Result<&'a mut W, SeError>,
     {
         self.write_indent()?;
         self.writer.write_char('<')?;

--- a/src/se/content.rs
+++ b/src/se/content.rs
@@ -651,8 +651,6 @@ pub(super) mod tests {
         serialize_as!(char_amp:  '&' => "&amp;", SensitiveText);
         serialize_as!(char_apos: '\'' => "&apos;", SensitiveText);
         serialize_as!(char_quot: '"' => "&quot;", SensitiveText);
-        //TODO: add a setting to escape leading/trailing spaces, in order to
-        // pretty-print does not change the content
         serialize_as!(char_space: ' ' => " ", SensitiveText);
 
         serialize_as!(str_non_escaped: "non-escaped string" => "non-escaped string", SensitiveText);
@@ -781,8 +779,6 @@ pub(super) mod tests {
             text!(char_amp:  '&' => "&amp;");
             text!(char_apos: '\'' => "&apos;");
             text!(char_quot: '"' => "&quot;");
-            //TODO: add a setting to escape leading/trailing spaces, in order to
-            // pretty-print does not change the content
             text!(char_space: ' ' => " ");
 
             text!(str_non_escaped: "non-escaped string" => "non-escaped string");
@@ -908,8 +904,6 @@ pub(super) mod tests {
             value!(char_amp:  '&' => "&amp;");
             value!(char_apos: '\'' => "&apos;");
             value!(char_quot: '"' => "&quot;");
-            //TODO: add a setting to escape leading/trailing spaces, in order to
-            // pretty-print does not change the content
             value!(char_space: ' ' => " ");
 
             value!(str_non_escaped: "non-escaped string" => "non-escaped string");
@@ -1094,8 +1088,6 @@ pub(super) mod tests {
         serialize_as!(char_amp:  '&' => "&amp;", SensitiveText);
         serialize_as!(char_apos: '\'' => "&apos;", SensitiveText);
         serialize_as!(char_quot: '"' => "&quot;", SensitiveText);
-        //TODO: add a setting to escape leading/trailing spaces, in order to
-        // pretty-print does not change the content
         serialize_as!(char_space: ' ' => " ", SensitiveText);
 
         serialize_as!(str_non_escaped: "non-escaped string" => "non-escaped string", SensitiveText);
@@ -1119,19 +1111,14 @@ pub(super) mod tests {
         serialize_as!(newtype: Newtype(42) => "42", Text);
         serialize_as!(enum_newtype: Enum::Newtype(42) => "<Newtype>42</Newtype>");
 
-        // Note that sequences of primitives serialized without delimiters other that indent!
-        serialize_as!(seq: vec![1, 2, 3]
-            => "1\n\
-                2\n\
-                3", Text);
+        // Note that sequences of primitives serialized without delimiters!
+        serialize_as!(seq: vec![1, 2, 3] => "123", Text);
         serialize_as!(seq_empty: Vec::<usize>::new() => "", SensitiveNothing);
         serialize_as!(tuple: ("<\"&'>", "with\t\r\n spaces", 3usize)
-            => "&lt;&quot;&amp;&apos;&gt;\n\
-                with\t\r\n spaces\n\
+            => "&lt;&quot;&amp;&apos;&gt;\
+                with\t\r\n spaces\
                 3", Text);
-        serialize_as!(tuple_struct: Tuple("first", 42)
-            => "first\n\
-                42", Text);
+        serialize_as!(tuple_struct: Tuple("first", 42) => "first42", Text);
         serialize_as!(enum_tuple: Enum::Tuple("first", 42)
             => "<Tuple>first</Tuple>\n\
                 <Tuple>42</Tuple>");
@@ -1170,9 +1157,7 @@ pub(super) mod tests {
                     after: "answer",
                 }
                 => "<Text>\n  \
-                        <before>answer</before>\n  \
-                        42 42\n  \
-                        <after>answer</after>\n\
+                        <before>answer</before>42 42<after>answer</after>\n\
                     </Text>");
         }
 
@@ -1182,18 +1167,6 @@ pub(super) mod tests {
             use pretty_assertions::assert_eq;
 
             macro_rules! text {
-                ($name:ident: $data:expr) => {
-                    serialize_as!($name:
-                        SpecialEnum::Text {
-                            before: "answer",
-                            content: $data,
-                            after: "answer",
-                        }
-                        => "<Text>\n  \
-                                <before>answer</before>\n  \
-                                <after>answer</after>\n\
-                            </Text>");
-                };
                 ($name:ident: $data:expr => $expected:literal) => {
                     serialize_as!($name:
                         SpecialEnum::Text {
@@ -1202,9 +1175,9 @@ pub(super) mod tests {
                             after: "answer",
                         }
                         => concat!(
-                            "<Text>\n  <before>answer</before>\n  ",
+                            "<Text>\n  <before>answer</before>",
                             $expected,
-                            "\n  <after>answer</after>\n</Text>",
+                            "<after>answer</after>\n</Text>",
                         ));
                 };
             }
@@ -1238,8 +1211,6 @@ pub(super) mod tests {
             text!(char_amp:  '&' => "&amp;");
             text!(char_apos: '\'' => "&apos;");
             text!(char_quot: '"' => "&quot;");
-            //TODO: add a setting to escape leading/trailing spaces, in order to
-            // pretty-print does not change the content
             text!(char_space: ' ' => " ");
 
             text!(str_non_escaped: "non-escaped string" => "non-escaped string");
@@ -1253,13 +1224,13 @@ pub(super) mod tests {
                 }
                 => Unsupported("`serialize_bytes` not supported yet"));
 
-            text!(option_none: Option::<&str>::None);
+            text!(option_none: Option::<&str>::None => "");
             text!(option_some: Some("non-escaped string") => "non-escaped string");
-            text!(option_some_empty_str: Some(""));
+            text!(option_some_empty_str: Some("") => "");
 
-            text!(unit: ());
-            text!(unit_struct: Unit);
-            text!(unit_struct_escaped: UnitEscaped);
+            text!(unit: () => "");
+            text!(unit_struct: Unit => "");
+            text!(unit_struct_escaped: UnitEscaped => "");
 
             text!(enum_unit: Enum::Unit => "Unit");
             text!(enum_unit_escaped: Enum::UnitEscaped => "&lt;&quot;&amp;&apos;&gt;");
@@ -1276,7 +1247,7 @@ pub(super) mod tests {
 
             // Sequences are serialized separated by spaces, all spaces inside are escaped
             text!(seq: vec![1, 2, 3] => "1 2 3");
-            text!(seq_empty: Vec::<usize>::new());
+            text!(seq_empty: Vec::<usize>::new() => "");
             text!(tuple: ("<\"&'>", "with\t\n\r spaces", 3usize)
                 => "&lt;&quot;&amp;&apos;&gt; \
                     with&#9;&#10;&#13;&#32;spaces \
@@ -1321,18 +1292,6 @@ pub(super) mod tests {
             use pretty_assertions::assert_eq;
 
             macro_rules! value {
-                ($name:ident: $data:expr) => {
-                    serialize_as!($name:
-                        SpecialEnum::Value {
-                            before: "answer",
-                            content: $data,
-                            after: "answer",
-                        }
-                        => "<Value>\n  \
-                                <before>answer</before>\n  \
-                                <after>answer</after>\n\
-                            </Value>");
-                };
                 ($name:ident: $data:expr => $expected:literal) => {
                     serialize_as!($name:
                         SpecialEnum::Value {
@@ -1341,9 +1300,9 @@ pub(super) mod tests {
                             after: "answer",
                         }
                         => concat!(
-                            "<Value>\n  <before>answer</before>\n  ",
+                            "<Value>\n  <before>answer</before>",
                             $expected,
-                            "\n  <after>answer</after>\n</Value>",
+                            "<after>answer</after>\n</Value>",
                         ));
                 };
             }
@@ -1377,8 +1336,6 @@ pub(super) mod tests {
             value!(char_amp:  '&' => "&amp;");
             value!(char_apos: '\'' => "&apos;");
             value!(char_quot: '"' => "&quot;");
-            //TODO: add a setting to escape leading/trailing spaces, in order to
-            // pretty-print does not change the content
             value!(char_space: ' ' => " ");
 
             value!(str_non_escaped: "non-escaped string" => "non-escaped string");
@@ -1392,15 +1349,15 @@ pub(super) mod tests {
                 }
                 => Unsupported("`serialize_bytes` not supported yet"));
 
-            value!(option_none: Option::<&str>::None);
+            value!(option_none: Option::<&str>::None => "");
             value!(option_some: Some("non-escaped string") => "non-escaped string");
-            value!(option_some_empty_str: Some(""));
+            value!(option_some_empty_str: Some("") => "");
 
-            value!(unit: ());
-            value!(unit_struct: Unit);
-            value!(unit_struct_escaped: UnitEscaped);
+            value!(unit: () => "\n  ");
+            value!(unit_struct: Unit => "\n  ");
+            value!(unit_struct_escaped: UnitEscaped => "\n  ");
 
-            value!(enum_unit: Enum::Unit => "<Unit/>");
+            value!(enum_unit: Enum::Unit => "\n  <Unit/>\n  ");
             err!(enum_unit_escaped:
                 SpecialEnum::Value {
                     before: "answer",
@@ -1410,19 +1367,20 @@ pub(super) mod tests {
                 => Unsupported("character `<` is not allowed at the start of an XML name `<\"&'>`"));
 
             value!(newtype: Newtype(42) => "42");
-            value!(enum_newtype: Enum::Newtype(42) => "<Newtype>42</Newtype>");
+            value!(enum_newtype: Enum::Newtype(42) => "\n  <Newtype>42</Newtype>\n  ");
 
             // Note that sequences of primitives serialized without delimiters!
-            value!(seq: vec![1, 2, 3] => "1\n  2\n  3");
-            value!(seq_empty: Vec::<usize>::new());
+            value!(seq: vec![1, 2, 3] => "123");
+            value!(seq_empty: Vec::<usize>::new() => "");
             value!(tuple: ("<\"&'>", "with\t\n\r spaces", 3usize)
-                => "&lt;&quot;&amp;&apos;&gt;\n  \
-                    with\t\n\r spaces\n  \
+                => "&lt;&quot;&amp;&apos;&gt;\
+                    with\t\n\r spaces\
                     3");
-            value!(tuple_struct: Tuple("first", 42) => "first\n  42");
+            value!(tuple_struct: Tuple("first", 42) => "first42");
             value!(enum_tuple: Enum::Tuple("first", 42)
-                => "<Tuple>first</Tuple>\n  \
-                    <Tuple>42</Tuple>");
+                => "\n  \
+                    <Tuple>first</Tuple>\n  \
+                    <Tuple>42</Tuple>\n  ");
 
             // We cannot wrap map or struct in any container and should not
             // flatten it, so it is impossible to serialize maps and structs
@@ -1442,11 +1400,12 @@ pub(super) mod tests {
                 => Unsupported("serialization of struct `Struct` is not supported in `$value` field"));
             value!(enum_struct:
                 Enum::Struct { key: "answer", val: (42, 42) }
-                => "<Struct>\n    \
+                => "\n  \
+                    <Struct>\n    \
                         <key>answer</key>\n    \
                         <val>42</val>\n    \
                         <val>42</val>\n  \
-                    </Struct>");
+                    </Struct>\n  ");
         }
 
         mod attributes {

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -5,7 +5,7 @@ use crate::se::content::ContentSerializer;
 use crate::se::key::QNameSerializer;
 use crate::se::simple_type::{QuoteTarget, SimpleSeq, SimpleTypeSerializer};
 use crate::se::text::TextSerializer;
-use crate::se::{Indent, SeError, WriteResult, XmlName};
+use crate::se::{SeError, WriteResult, XmlName};
 use serde::ser::{
     Impossible, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
     SerializeTuple, SerializeTupleStruct, SerializeTupleVariant, Serializer,
@@ -333,7 +333,7 @@ pub enum Tuple<'w, 'k, W: Write> {
     /// Serialize each tuple field as an element
     Element(ElementSerializer<'w, 'k, W>),
     /// Serialize tuple as an `xs:list`: space-delimited content of fields
-    Text(SimpleSeq<'k, &'w mut W>),
+    Text(SimpleSeq<&'w mut W>),
 }
 
 impl<'w, 'k, W: Write> SerializeTupleVariant for Tuple<'w, 'k, W> {
@@ -416,7 +416,6 @@ impl<'w, 'k, W: Write> Struct<'w, 'k, W> {
             writer: &mut self.ser.ser.writer,
             target: QuoteTarget::DoubleQAttr,
             level: self.ser.ser.level,
-            indent: Indent::None,
         })?;
         self.ser.ser.writer.write_char('"')?;
 

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -337,6 +337,14 @@ pub enum WriteResult {
     SensitiveNothing,
 }
 
+impl WriteResult {
+    /// Returns `true` if indent should be written after the object (if configured) and `false` otherwise.
+    #[inline]
+    pub fn allow_indent(&self) -> bool {
+        matches!(self, Self::Element | Self::Nothing)
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Implements serialization method by forwarding it to the serializer created by

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -91,6 +91,8 @@ use std::str::from_utf8;
 
 /// Serialize struct into a `Write`r.
 ///
+/// Returns the classification of the last written type.
+///
 /// # Examples
 ///
 /// ```
@@ -124,7 +126,7 @@ use std::str::from_utf8;
 ///     </Root>"
 /// );
 /// ```
-pub fn to_writer<W, T>(mut writer: W, value: &T) -> Result<(), SeError>
+pub fn to_writer<W, T>(mut writer: W, value: &T) -> Result<WriteResult, SeError>
 where
     W: Write,
     T: ?Sized + Serialize,
@@ -177,6 +179,8 @@ where
 /// Serialize struct into a `Write`r using specified root tag name.
 /// `root_tag` should be valid [XML name], otherwise error is returned.
 ///
+/// Returns the classification of the last written type.
+///
 /// # Examples
 ///
 /// ```
@@ -210,7 +214,11 @@ where
 /// ```
 ///
 /// [XML name]: https://www.w3.org/TR/xml11/#NT-Name
-pub fn to_writer_with_root<W, T>(mut writer: W, root_tag: &str, value: &T) -> Result<(), SeError>
+pub fn to_writer_with_root<W, T>(
+    mut writer: W,
+    root_tag: &str,
+    value: &T,
+) -> Result<WriteResult, SeError>
 where
     W: Write,
     T: ?Sized + Serialize,
@@ -307,6 +315,26 @@ pub enum QuoteLevel {
     /// `<`      | `&lt;`
     /// `&`      | `&amp;`
     Minimal,
+}
+
+/// Classification of the type written by the serializer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteResult {
+    /// Text with insignificant spaces was written, for example a number. Adding indent to the
+    /// serialized data does not change meaning of the data.
+    Text,
+    /// The XML tag was written. Adding indent to the serialized data does not change meaning of the data.
+    Element,
+    /// Nothing was written (i. e. serialized type not represented in XML a all). Adding indent to the
+    /// serialized data does not change meaning of the data. This is returned for units, unit structs
+    /// and unit variants.
+    Nothing,
+    /// Text with significant spaces was written, for example a string. Adding indent to the
+    /// serialized data may change meaning of the data.
+    SensitiveText,
+    /// `None` was serialized and nothing was written. `None` does not represented in XML,
+    /// but adding indent after it may change meaning of the data.
+    SensitiveNothing,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -444,7 +472,9 @@ impl<'i> Indent<'i> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// A Serializer
+/// A Serializer.
+///
+/// Returns the classification of the last written type.
 pub struct Serializer<'w, 'r, W: Write> {
     ser: ContentSerializer<'w, 'r, W>,
     /// Name of the root tag. If not specified, deduced from the structure name
@@ -615,7 +645,7 @@ impl<'w, 'r, W: Write> Serializer<'w, 'r, W> {
 }
 
 impl<'w, 'r, W: Write> ser::Serializer for Serializer<'w, 'r, W> {
-    type Ok = ();
+    type Ok = WriteResult;
     type Error = SeError;
 
     type SerializeSeq = ElementSerializer<'w, 'r, W>;
@@ -651,7 +681,11 @@ impl<'w, 'r, W: Write> ser::Serializer for Serializer<'w, 'r, W> {
     forward!(serialize_bytes(&[u8]));
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Ok(())
+        // Do not write indent after `Option` field with `None` value, because
+        // this can be `Option<String>`. Unfortunately, we do not known what the
+        // type the option contains, so have no chance to adapt our behavior to it.
+        // The safe variant is not to write indent
+        Ok(WriteResult::SensitiveNothing)
     }
 
     fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, Self::Error> {
@@ -704,7 +738,9 @@ impl<'w, 'r, W: Write> ser::Serializer for Serializer<'w, 'r, W> {
     ) -> Result<Self::Ok, Self::Error> {
         if variant == TEXT_KEY {
             value.serialize(self.ser.into_simple_type_serializer())?;
-            Ok(())
+            // Do not write indent after `$text` variant because it may be interpreted as
+            // part of content when deserialize
+            Ok(WriteResult::SensitiveText)
         } else {
             let ser = ElementSerializer {
                 ser: self.ser,

--- a/src/se/text.rs
+++ b/src/se/text.rs
@@ -23,16 +23,16 @@ macro_rules! write_primitive {
 /// This serializer a very similar to [`SimpleTypeSerializer`], but different
 /// from it in how it processes unit enum variants. Unlike [`SimpleTypeSerializer`]
 /// this serializer does not write anything for the unit variant.
-pub struct TextSerializer<'i, W: Write>(pub SimpleTypeSerializer<'i, W>);
+pub struct TextSerializer<W: Write>(pub SimpleTypeSerializer<W>);
 
-impl<'i, W: Write> Serializer for TextSerializer<'i, W> {
+impl<W: Write> Serializer for TextSerializer<W> {
     type Ok = W;
     type Error = SeError;
 
-    type SerializeSeq = SimpleSeq<'i, W>;
-    type SerializeTuple = SimpleSeq<'i, W>;
-    type SerializeTupleStruct = SimpleSeq<'i, W>;
-    type SerializeTupleVariant = SimpleSeq<'i, W>;
+    type SerializeSeq = SimpleSeq<W>;
+    type SerializeTuple = SimpleSeq<W>;
+    type SerializeTupleStruct = SimpleSeq<W>;
+    type SerializeTupleVariant = SimpleSeq<W>;
     type SerializeMap = Impossible<Self::Ok, Self::Error>;
     type SerializeStruct = Impossible<Self::Ok, Self::Error>;
     type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -1380,9 +1380,7 @@ mod without_root {
                 float: 42.0,
                 string: "answer"
             }
-            => "<Text>\n  \
-                    42\n  \
-                    <string>answer</string>\n\
+            => "<Text>42<string>answer</string>\n\
                 </Text>");
 
         mod enum_ {
@@ -1439,9 +1437,7 @@ mod without_root {
                         float: 42.0,
                         string: "answer"
                     }
-                    => "<Text>\n  \
-                            42\n  \
-                            <string>answer</string>\n\
+                    => "<Text>42<string>answer</string>\n\
                         </Text>");
 
                 /// Test serialization of the specially named variant `$text`
@@ -1544,9 +1540,7 @@ mod without_root {
                         string: "answer"
                     }
                     => "<InternallyTagged>\n  \
-                            <tag>Text</tag>\n  \
-                            42\n  \
-                            <string>answer</string>\n\
+                            <tag>Text</tag>42<string>answer</string>\n\
                         </InternallyTagged>");
             }
 
@@ -1624,9 +1618,7 @@ mod without_root {
                     }
                     => "<AdjacentlyTagged>\n  \
                             <tag>Text</tag>\n  \
-                            <content>\n    \
-                                42\n    \
-                                <string>answer</string>\n  \
+                            <content>42<string>answer</string>\n  \
                             </content>\n\
                         </AdjacentlyTagged>");
             }
@@ -1676,9 +1668,7 @@ mod without_root {
                         float: 42.0,
                         string: "answer"
                     }
-                    => "<Untagged>\n  \
-                            42\n  \
-                            <string>answer</string>\n\
+                    => "<Untagged>42<string>answer</string>\n\
                         </Untagged>");
             }
         }

--- a/tests/writer-indentation.rs
+++ b/tests/writer-indentation.rs
@@ -222,9 +222,7 @@ fn serializable() {
             <bat>43</bat>
         </element>
         <list>first element</list>
-        <list>second element</list>
-        text
-        <val>foo</val>
+        <list>second element</list>text<val>foo</val>
     </foo_element>
 </paired>"#
     );


### PR DESCRIPTION
This PR alternative and more full implementation of the fix for excess indents around text fields. It implements the [Python](https://github.com/tafia/quick-xml/issues/655#issuecomment-2395506831) scheme of writing indents:
```rust
struct Xml {
  before: String,// = "value1"
  #[serde(rename = "$text")] // or $value
  text: String,// = "text"
  after: String,// = "value2"
}
```
`before`, `$text` and `after`
```xml
<Xml>
  <before>value1</before>text<after>value2</after>
</Xml>
```
`$text` and `after`
```xml
<Xml>text<after>value2</after>
</Xml>
```
`before` and `$text`
```xml
<Xml>
  <before>value1</before>text</Xml>
```
`$text` only
```xml
<Xml>text</Xml>
```
The implementation never write indent after `Option` fields, because `Option` can contain a type that is sensible to the surrounding text content, for example `Option<String>`. Because serde does not provide the type of `None` when serialize it, it is impossible to be smart here and write indent in one cases but not other, so I choosed the safe variant.

As a side effect, `to_writer`, `to_writer_with_root` and `Serializer` not returns `bool` on success. The `true` means that is will be safe to write text (in particular, indent) after the serialized object, it will not be interpreted as a part of content during deserialization. If `false` will be returned, then writing additional text content may change data what deserializer will see.

Closes #655, closes #814