### PR TITLE
Do not allow consequent primitives in `$value` fields and top-level

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,12 +30,15 @@
 - [#811]: Narrow down error return type from `Error` where only one variant is ever returned:
   attribute related methods on `BytesStart` and `BytesDecl` returns `AttrError`
 - [#820]: Classify output of the `Serializer` by returning an enumeration with kind of written data
+- [#823]: Do not allow serialization of consequent primitives, for example `Vec<usize>` or
+  `Vec<String>` in `$value` fields. They cannot be deserialized back with the same result
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
 [#655]: https://github.com/tafia/quick-xml/issues/655
 [#810]: https://github.com/tafia/quick-xml/pull/810
 [#811]: https://github.com/tafia/quick-xml/pull/811
 [#820]: https://github.com/tafia/quick-xml/pull/820
+[#823]: https://github.com/tafia/quick-xml/pull/823
 
 
 ## 0.36.2 -- 2024-09-20

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -24,7 +24,7 @@
 //! - [Enum Representations](#enum-representations)
 //!   - [Normal enum variant](#normal-enum-variant)
 //!   - [`$text` enum variant](#text-enum-variant)
-//! - [Difference between `$text` and `$value` special names](#difference-between-text-and-value-special-names)
+//! - [`$text` and `$value` special names](#text-and-value-special-names)
 //!   - [`$text`](#text)
 //!   - [`$value`](#value)
 //!     - [Primitives and sequences of primitives](#primitives-and-sequences-of-primitives)
@@ -1421,8 +1421,8 @@
 //!
 //!
 //!
-//! Difference between `$text` and `$value` special names
-//! =====================================================
+//! `$text` and `$value` special names
+//! ==================================
 //!
 //! quick-xml supports two special names for fields -- `$text` and `$value`.
 //! Although they may seem the same, there is a distinction. Two different
@@ -1554,7 +1554,9 @@
 //! ### Primitives and sequences of primitives
 //!
 //! Sequences serialized to a list of elements. Note, that types that does not
-//! produce their own tag (i. e. primitives) are written as is, without delimiters:
+//! produce their own tag (i. e. primitives) will produce [`SeError::Unsupported`]
+//! if they contains more that one element, because such sequence cannot be
+//! deserialized to the same value:
 //!
 //! ```
 //! # use serde::{Deserialize, Serialize};
@@ -1568,9 +1570,8 @@
 //! }
 //!
 //! let obj = AnyName { field: vec![1, 2, 3] };
-//! let xml = to_string(&obj).unwrap();
-//! // Note, that types that does not produce their own tag are written as is!
-//! assert_eq!(xml, "<AnyName>123</AnyName>");
+//! // If this object were serialized, it would be represented as "<AnyName>123</AnyName>"
+//! to_string(&obj).unwrap_err();
 //!
 //! let object: AnyName = from_str("<AnyName>123</AnyName>").unwrap();
 //! assert_eq!(object, AnyName { field: vec![123] });
@@ -1822,6 +1823,7 @@
 //! [#497]: https://github.com/tafia/quick-xml/issues/497
 //! [`Serializer::serialize_unit_variant`]: serde::Serializer::serialize_unit_variant
 //! [`Deserializer::deserialize_enum`]: serde::Deserializer::deserialize_enum
+//! [`SeError::Unsupported`]: crate::errors::serialize::SeError::Unsupported
 //! [Tagged enums]: https://serde.rs/enum-representations.html#internally-tagged
 //! [serde#1183]: https://github.com/serde-rs/serde/issues/1183
 //! [serde#1495]: https://github.com/serde-rs/serde/issues/1495


### PR DESCRIPTION
This PR changes serialization of `$value` fields with types like `Vec<String>` or `(u32, u32, u32)`. Previously this fields would be serialized without delimiters between elements which is unlikely what you want. Now serialization of that types would return `SeError::Unsupported`.

Example:
```rust
struct Xml {
  #[serde(rename = "$value")]
  seq: Vec<String>,

  #[serde(rename = "$value")]
  tuple: (bool, usize, String),
}
```

Currently it is based on #820, only the last commit implements the change.

This also partially handle this https://github.com/tafia/quick-xml/issues/497#issuecomment-2393236747.