### PR TITLE
Fix boolean parsing and make `SimpleTypeSerializer` and `SimpleTypeDeserializer` public

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,9 @@
   `Vec<String>` in `$value` fields. They cannot be deserialized back with the same result
 - [#827]: Make `escape` and it variants take a `impl Into<Cow<str>>` argument and implement
   `From<(&'a str, Cow<'a, str>)>` on `Attribute`
+- [#826]: Removed `DeError::InvalidInt`, `DeError::InvalidFloat` and `DeError::InvalidBoolean`.
+  Now the responsibility for returning the error lies with the visitor of the type.
+  See rationale in https://github.com/serde-rs/serde/pull/2811
 
 [#227]: https://github.com/tafia/quick-xml/issues/227
 [#655]: https://github.com/tafia/quick-xml/issues/655

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@
 
 ### New Features
 
+- [#826]: Implement `From<String>` and `From<Cow<str>>` for `quick_xml::de::Text`.
+
 ### Bug Fixes
 
 - [#655]: Do not write indent before and after `$text` fields and those `$value` fields

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 ### New Features
 
 - [#826]: Implement `From<String>` and `From<Cow<str>>` for `quick_xml::de::Text`.
+- [#826]: Make `SimpleTypeDeserializer` and `SimpleTypeSerializer` public.
 
 ### Bug Fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 
 - [#826]: Implement `From<String>` and `From<Cow<str>>` for `quick_xml::de::Text`.
 - [#826]: Make `SimpleTypeDeserializer` and `SimpleTypeSerializer` public.
+- [#826]: Implement `IntoDeserializer` for `&mut Deserializer`.
 
 ### Bug Fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,13 @@
 
 - [#655]: Do not write indent before and after `$text` fields and those `$value` fields
   that are serialized as a text (for example, `usize` or `String`).
+- [#826]: Handle only those boolean representations that are allowed by [Xml Schema]
+  which is only `"true"`, `"1"`, `"false"`, and `"0"`. Previously the following values
+  also was accepted:
+  |`bool` |XML content
+  |-------|-------------------------------------------------------------
+  |`true` |`"True"`,  `"TRUE"`,  `"t"`, `"Yes"`, `"YES"`, `"yes"`, `"y"`
+  |`false`|`"False"`, `"FALSE"`, `"f"`, `"No"`,  `"NO"`,  `"no"`,  `"n"`
 
 ### Misc Changes
 
@@ -41,7 +48,9 @@
 [#811]: https://github.com/tafia/quick-xml/pull/811
 [#820]: https://github.com/tafia/quick-xml/pull/820
 [#823]: https://github.com/tafia/quick-xml/pull/823
+[#826]: https://github.com/tafia/quick-xml/pull/826
 [#827]: https://github.com/tafia/quick-xml/pull/827
+[Xml Schema]: https://www.w3.org/TR/xmlschema11-2/#boolean
 
 
 ## 0.36.2 -- 2024-09-20

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -134,12 +134,7 @@ impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'de, 'd> {
 
     /// According to the <https://www.w3.org/TR/xmlschema11-2/#boolean>,
     /// valid boolean representations are only `"true"`, `"false"`, `"1"`,
-    /// and `"0"`. But this method also handles following:
-    ///
-    /// |`bool` |XML content
-    /// |-------|-------------------------------------------------------------
-    /// |`true` |`"True"`,  `"TRUE"`,  `"t"`, `"Yes"`, `"YES"`, `"yes"`, `"y"`
-    /// |`false`|`"False"`, `"FALSE"`, `"f"`, `"No"`,  `"NO"`,  `"no"`,  `"n"`
+    /// and `"0"`.
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -1,5 +1,4 @@
 use crate::de::simple_type::UnitOnly;
-use crate::de::str2bool;
 use crate::encoding::Decoder;
 use crate::errors::serialize::DeError;
 use crate::name::QName;
@@ -14,7 +13,10 @@ macro_rules! deserialize_num {
         where
             V: Visitor<'de>,
         {
-            visitor.$visit(self.name.parse()?)
+            match self.name.parse() {
+                Ok(number) => visitor.$visit(number),
+                Err(_) => self.name.deserialize_str(visitor),
+            }
         }
     };
 }
@@ -139,7 +141,7 @@ impl<'de, 'd> Deserializer<'de> for QNameDeserializer<'de, 'd> {
     where
         V: Visitor<'de>,
     {
-        str2bool(self.name.as_ref(), visitor)
+        self.name.deserialize_bool(visitor)
     }
 
     deserialize_num!(deserialize_i8, visit_i8);

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -5,13 +5,14 @@ use crate::{
     de::resolver::EntityResolver,
     de::simple_type::SimpleTypeDeserializer,
     de::text::TextDeserializer,
-    de::{str2bool, DeEvent, Deserializer, XmlRead, TEXT_KEY, VALUE_KEY},
+    de::{DeEvent, Deserializer, XmlRead, TEXT_KEY, VALUE_KEY},
     encoding::Decoder,
     errors::serialize::DeError,
     errors::Error,
     events::attributes::IterState,
     events::BytesStart,
     name::QName,
+    utils::CowRef,
 };
 use serde::de::value::BorrowedStrDeserializer;
 use serde::de::{self, DeserializeSeed, Deserializer as _, MapAccess, SeqAccess, Visitor};

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2019,7 +2019,9 @@ use crate::{
     reader::Reader,
     utils::CowRef,
 };
-use serde::de::{self, Deserialize, DeserializeOwned, DeserializeSeed, SeqAccess, Visitor};
+use serde::de::{
+    self, Deserialize, DeserializeOwned, DeserializeSeed, IntoDeserializer, SeqAccess, Visitor,
+};
 use std::borrow::Cow;
 #[cfg(feature = "overlapped-lists")]
 use std::collections::VecDeque;
@@ -2987,6 +2989,19 @@ where
             // Start(tag), End(tag), Text
             _ => seed.deserialize(&mut **self).map(Some),
         }
+    }
+}
+
+impl<'de, 'a, R, E> IntoDeserializer<'de, DeError> for &'a mut Deserializer<'de, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    type Deserializer = Self;
+
+    #[inline]
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2067,6 +2067,22 @@ impl<'a> From<&'a str> for Text<'a> {
     }
 }
 
+impl<'a> From<String> for Text<'a> {
+    #[inline]
+    fn from(text: String) -> Self {
+        Self {
+            text: Cow::Owned(text),
+        }
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Text<'a> {
+    #[inline]
+    fn from(text: Cow<'a, str>) -> Self {
+        Self { text }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Simplified event which contains only these variants that used by deserializer

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2309,32 +2309,6 @@ where
     }
 }
 
-fn deserialize_bool<'de, V>(value: &[u8], decoder: Decoder, visitor: V) -> Result<V::Value, DeError>
-where
-    V: Visitor<'de>,
-{
-    #[cfg(feature = "encoding")]
-    {
-        let value = decoder.decode(value)?;
-        // No need to unescape because valid boolean representations cannot be escaped
-        str2bool(value.as_ref(), visitor)
-    }
-
-    #[cfg(not(feature = "encoding"))]
-    {
-        // No need to unescape because valid boolean representations cannot be escaped
-        match value {
-            b"true" | b"1" | b"True" | b"TRUE" | b"t" | b"Yes" | b"YES" | b"yes" | b"y" => {
-                visitor.visit_bool(true)
-            }
-            b"false" | b"0" | b"False" | b"FALSE" | b"f" | b"No" | b"NO" | b"no" | b"n" => {
-                visitor.visit_bool(false)
-            }
-            e => Err(DeError::InvalidBoolean(decoder.decode(e)?.into())),
-        }
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// A structure that deserializes XML into Rust values.

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1834,7 +1834,7 @@
 // Also, macros should be imported before using them
 use serde::serde_if_integer128;
 
-macro_rules! deserialize_type {
+macro_rules! deserialize_num {
     ($deserialize:ident => $visit:ident, $($mut:tt)?) => {
         fn $deserialize<V>($($mut)? self, visitor: V) -> Result<V::Value, DeError>
         where
@@ -1851,23 +1851,23 @@ macro_rules! deserialize_type {
 /// byte arrays, booleans and identifiers.
 macro_rules! deserialize_primitives {
     ($($mut:tt)?) => {
-        deserialize_type!(deserialize_i8 => visit_i8, $($mut)?);
-        deserialize_type!(deserialize_i16 => visit_i16, $($mut)?);
-        deserialize_type!(deserialize_i32 => visit_i32, $($mut)?);
-        deserialize_type!(deserialize_i64 => visit_i64, $($mut)?);
+        deserialize_num!(deserialize_i8 => visit_i8, $($mut)?);
+        deserialize_num!(deserialize_i16 => visit_i16, $($mut)?);
+        deserialize_num!(deserialize_i32 => visit_i32, $($mut)?);
+        deserialize_num!(deserialize_i64 => visit_i64, $($mut)?);
 
-        deserialize_type!(deserialize_u8 => visit_u8, $($mut)?);
-        deserialize_type!(deserialize_u16 => visit_u16, $($mut)?);
-        deserialize_type!(deserialize_u32 => visit_u32, $($mut)?);
-        deserialize_type!(deserialize_u64 => visit_u64, $($mut)?);
+        deserialize_num!(deserialize_u8 => visit_u8, $($mut)?);
+        deserialize_num!(deserialize_u16 => visit_u16, $($mut)?);
+        deserialize_num!(deserialize_u32 => visit_u32, $($mut)?);
+        deserialize_num!(deserialize_u64 => visit_u64, $($mut)?);
 
         serde_if_integer128! {
-            deserialize_type!(deserialize_i128 => visit_i128, $($mut)?);
-            deserialize_type!(deserialize_u128 => visit_u128, $($mut)?);
+            deserialize_num!(deserialize_i128 => visit_i128, $($mut)?);
+            deserialize_num!(deserialize_u128 => visit_u128, $($mut)?);
         }
 
-        deserialize_type!(deserialize_f32 => visit_f32, $($mut)?);
-        deserialize_type!(deserialize_f64 => visit_f64, $($mut)?);
+        deserialize_num!(deserialize_f32 => visit_f32, $($mut)?);
+        deserialize_num!(deserialize_f64 => visit_f64, $($mut)?);
 
         fn deserialize_bool<V>($($mut)? self, visitor: V) -> Result<V::Value, DeError>
         where

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2287,7 +2287,7 @@ where
 }
 
 /// Deserialize from a reader. This method will do internal copies of data
-/// readed from `reader`. If you want have a `&str` input and want to borrow
+/// read from `reader`. If you want have a `&str` input and want to borrow
 /// as much as possible, use [`from_str`].
 pub fn from_reader<R, T>(reader: R) -> Result<T, DeError>
 where
@@ -2298,19 +2298,13 @@ where
     T::deserialize(&mut de)
 }
 
-// TODO: According to the https://www.w3.org/TR/xmlschema11-2/#boolean,
-// valid boolean representations are only "true", "false", "1", and "0"
 fn str2bool<'de, V>(value: &str, visitor: V) -> Result<V::Value, DeError>
 where
     V: de::Visitor<'de>,
 {
     match value {
-        "true" | "1" | "True" | "TRUE" | "t" | "Yes" | "YES" | "yes" | "y" => {
-            visitor.visit_bool(true)
-        }
-        "false" | "0" | "False" | "FALSE" | "f" | "No" | "NO" | "no" | "n" => {
-            visitor.visit_bool(false)
-        }
+        "true" | "1" => visitor.visit_bool(true),
+        "false" | "0" => visitor.visit_bool(false),
         _ => Err(DeError::InvalidBoolean(value.into())),
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2006,8 +2006,9 @@ mod simple_type;
 mod text;
 mod var;
 
+pub use self::resolver::{EntityResolver, PredefinedEntityResolver};
+pub use self::simple_type::SimpleTypeDeserializer;
 pub use crate::errors::serialize::DeError;
-pub use resolver::{EntityResolver, PredefinedEntityResolver};
 
 use crate::{
     de::map::ElementMapAccess,

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -169,12 +169,7 @@ impl<'de, 'a> Deserializer<'de> for AtomicDeserializer<'de, 'a> {
 
     /// According to the <https://www.w3.org/TR/xmlschema11-2/#boolean>,
     /// valid boolean representations are only `"true"`, `"false"`, `"1"`,
-    /// and `"0"`. But this method also handles following:
-    ///
-    /// |`bool` |XML content
-    /// |-------|-------------------------------------------------------------
-    /// |`true` |`"True"`,  `"TRUE"`,  `"t"`, `"Yes"`, `"YES"`, `"yes"`, `"y"`
-    /// |`false`|`"False"`, `"FALSE"`, `"f"`, `"No"`,  `"NO"`,  `"no"`,  `"n"`
+    /// and `"0"`.
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -10,7 +10,9 @@ use crate::escape::unescape;
 use crate::utils::CowRef;
 use memchr::memchr;
 use serde::de::value::UnitDeserializer;
-use serde::de::{DeserializeSeed, Deserializer, EnumAccess, SeqAccess, VariantAccess, Visitor};
+use serde::de::{
+    DeserializeSeed, Deserializer, EnumAccess, IntoDeserializer, SeqAccess, VariantAccess, Visitor,
+};
 use serde::serde_if_integer128;
 use std::borrow::Cow;
 use std::ops::Range;
@@ -767,6 +769,15 @@ impl<'de, 'a> EnumAccess<'de> for SimpleTypeDeserializer<'de, 'a> {
     {
         let name = seed.deserialize(self)?;
         Ok((name, UnitOnly))
+    }
+}
+
+impl<'de, 'a> IntoDeserializer<'de, DeError> for SimpleTypeDeserializer<'de, 'a> {
+    type Deserializer = Self;
+
+    #[inline]
+    fn into_deserializer(self) -> Self {
+        self
     }
 }
 

--- a/src/de/text.rs
+++ b/src/de/text.rs
@@ -34,7 +34,7 @@ use std::borrow::Cow;
 /// - `Option`:
 ///   - empty text is deserialized as `None`;
 ///   - everything else is deserialized as `Some` using the same deserializer;
-/// - units (`()`) and unit structs always deserialized successfully;
+/// - units (`()`) and unit structs always deserialized successfully, the content is ignored;
 /// - newtype structs forwards deserialization to the inner type using the same
 ///   deserializer;
 /// - sequences, tuples and tuple structs are deserialized using [`SimpleTypeDeserializer`]

--- a/src/de/text.rs
+++ b/src/de/text.rs
@@ -1,7 +1,8 @@
 use crate::{
     de::simple_type::SimpleTypeDeserializer,
-    de::{str2bool, Text, TEXT_KEY},
+    de::{Text, TEXT_KEY},
     errors::serialize::DeError,
+    utils::CowRef,
 };
 use serde::de::value::BorrowedStrDeserializer;
 use serde::de::{DeserializeSeed, Deserializer, EnumAccess, VariantAccess, Visitor};
@@ -17,10 +18,16 @@ use std::borrow::Cow;
 /// over tags / text within it's parent tag.
 ///
 /// This deserializer processes items as following:
-/// - numbers are parsed from a text content using [`FromStr`];
+/// - numbers are parsed from a text content using [`FromStr`]; in case of error
+///   [`Visitor::visit_borrowed_str`], [`Visitor::visit_str`], or [`Visitor::visit_string`]
+///   is called; it is responsibility of the type to return an error if it does
+///   not able to process passed data;
 /// - booleans converted from the text according to the XML [specification]:
 ///   - `"true"` and `"1"` converted to `true`;
 ///   - `"false"` and `"0"` converted to `false`;
+///   - everything else calls [`Visitor::visit_borrowed_str`], [`Visitor::visit_str`],
+///     or [`Visitor::visit_string`]; it is responsibility of the type to return
+///     an error if it does not able to process passed data;
 /// - strings returned as is;
 /// - characters also returned as strings. If string contain more than one character
 ///   or empty, it is responsibility of a type to return an error;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -276,7 +276,6 @@ pub mod serialize {
     use std::borrow::Cow;
     #[cfg(feature = "overlapped-lists")]
     use std::num::NonZeroUsize;
-    use std::num::{ParseFloatError, ParseIntError};
     use std::str::Utf8Error;
 
     /// (De)serialization error
@@ -286,12 +285,6 @@ pub mod serialize {
         Custom(String),
         /// Xml parsing error
         InvalidXml(Error),
-        /// Cannot parse to integer
-        InvalidInt(ParseIntError),
-        /// Cannot parse to float
-        InvalidFloat(ParseFloatError),
-        /// Cannot parse specified value to boolean
-        InvalidBoolean(String),
         /// This error indicates an error in the [`Deserialize`](serde::Deserialize)
         /// implementation when read a map or a struct: `MapAccess::next_value[_seed]`
         /// was called before `MapAccess::next_key[_seed]`.
@@ -322,9 +315,6 @@ pub mod serialize {
             match self {
                 Self::Custom(s) => f.write_str(s),
                 Self::InvalidXml(e) => e.fmt(f),
-                Self::InvalidInt(e) => write!(f, "invalid integral value: {}", e),
-                Self::InvalidFloat(e) => write!(f, "invalid floating-point value: {}", e),
-                Self::InvalidBoolean(v) => write!(f, "invalid boolean value '{}'", v),
                 Self::KeyNotRead => f.write_str("invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
                 Self::UnexpectedStart(e) => {
                     f.write_str("unexpected `Event::Start(")?;
@@ -342,8 +332,6 @@ pub mod serialize {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match self {
                 Self::InvalidXml(e) => Some(e),
-                Self::InvalidInt(e) => Some(e),
-                Self::InvalidFloat(e) => Some(e),
                 _ => None,
             }
         }
@@ -380,20 +368,6 @@ pub mod serialize {
         #[inline]
         fn from(e: AttrError) -> Self {
             Self::InvalidXml(e.into())
-        }
-    }
-
-    impl From<ParseIntError> for DeError {
-        #[inline]
-        fn from(e: ParseIntError) -> Self {
-            Self::InvalidInt(e)
-        }
-    }
-
-    impl From<ParseFloatError> for DeError {
-        #[inline]
-        fn from(e: ParseFloatError) -> Self {
-            Self::InvalidFloat(e)
         }
     }
 

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -82,12 +82,14 @@ mod text;
 use self::content::ContentSerializer;
 use self::element::{ElementSerializer, Map, Struct, Tuple};
 use crate::de::TEXT_KEY;
-pub use crate::errors::serialize::SeError;
 use crate::writer::Indentation;
 use serde::ser::{self, Serialize};
 use serde::serde_if_integer128;
 use std::fmt::Write;
 use std::str::from_utf8;
+
+pub use self::simple_type::SimpleTypeSerializer;
+pub use crate::errors::serialize::SeError;
 
 /// Serialize struct into a `Write`r.
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,6 +92,29 @@ where
     }
 }
 
+impl<'i, 's> CowRef<'i, 's, str> {
+    /// Supply to the visitor a borrowed string, a string slice, or an owned
+    /// string depending on the kind of input. Unlike [`Self::deserialize_all`],
+    /// only part of [`Self::Owned`] string will be passed to the visitor.
+    ///
+    /// Calls
+    /// - `visitor.visit_borrowed_str` if data borrowed from the input
+    /// - `visitor.visit_str` if data borrowed from another source
+    /// - `visitor.visit_string` if data owned by this type
+    #[cfg(feature = "serialize")]
+    pub fn deserialize_str<V, E>(self, visitor: V) -> Result<V::Value, E>
+    where
+        V: Visitor<'i>,
+        E: Error,
+    {
+        match self {
+            Self::Input(s) => visitor.visit_borrowed_str(s),
+            Self::Slice(s) => visitor.visit_str(s),
+            Self::Owned(s) => visitor.visit_string(s),
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Wrapper around `Vec<u8>` that has a human-readable debug representation:

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -113,6 +113,25 @@ impl<'i, 's> CowRef<'i, 's, str> {
             Self::Owned(s) => visitor.visit_string(s),
         }
     }
+
+    /// Calls [`Visitor::visit_bool`] with `true` or `false` if text contains
+    /// [valid] boolean representation, otherwise calls [`Self::deserialize_str`].
+    ///
+    /// The valid boolean representations are only `"true"`, `"false"`, `"1"`, and `"0"`.
+    ///
+    /// [valid]: https://www.w3.org/TR/xmlschema11-2/#boolean
+    #[cfg(feature = "serialize")]
+    pub fn deserialize_bool<V, E>(self, visitor: V) -> Result<V::Value, E>
+    where
+        V: Visitor<'i>,
+        E: Error,
+    {
+        match self.as_ref() {
+            "1" | "true" => visitor.visit_bool(true),
+            "0" | "false" => visitor.visit_bool(false),
+            _ => self.deserialize_str(visitor),
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR makes `SimpleTypeSerializer` and `SimpleTypeDeserializer` public, as requested in #824. It also includes two other changes.

When checking documentation for the `SimpleTypeDeserializer` I noticed, that we parse more boolean representations than described in the XML Schema [specification](https://www.w3.org/TR/xmlschema11-2/#boolean). I do not see much reasons to keep that additional variants anymore, also because of the next implemented change. If you need more representations, you can use the wrapper type or `#[serde(deserialize_with)]` attribute.

The last change that this PR contains is final transfer of the responsibility of generating errors about mismatched types to the type being deserialized. That means that we no more need `DeError::InvalidInt`, `DeError::InvalidFloat` and `DeError::InvalidBoolean` errors, so their are removed. The changes can be notified in this code snippet:
```rust
#[test]
fn integer() {
    quick_xml::de::from_str::<usize>("string").unwrap();
}

#[test]
fn float() {
    quick_xml::de::from_str::<f64>("string").unwrap();
}

#[test]
fn boolean() {
    quick_xml::de::from_str::<bool>("trues").unwrap();
}
```

Before:
```
---- temp::integer stdout ----
thread 'temp::integer' panicked at tests/serde-issues.rs:560:48:
called `Result::unwrap()` on an `Err` value: InvalidInt(ParseIntError { kind: InvalidDigit })

---- temp::float stdout ----
thread 'temp::float' panicked at tests/serde-issues.rs:565:46:
called `Result::unwrap()` on an `Err` value: InvalidFloat(ParseFloatError { kind: Invalid })

---- temp::boolean stdout ----
thread 'temp::boolean' panicked at tests/serde-issues.rs:570:46:
called `Result::unwrap()` on an `Err` value: InvalidBoolean("trues")
```

After:
```
---- temp::integer stdout ----
thread 'temp::integer' panicked at tests/serde-issues.rs:560:48:
called `Result::unwrap()` on an `Err` value: Custom("invalid type: string \"string\", expected usize")

---- temp::float stdout ----
thread 'temp::float' panicked at tests/serde-issues.rs:565:46:
called `Result::unwrap()` on an `Err` value: Custom("invalid type: string \"string\", expected f64")

---- temp::boolean stdout ----
thread 'temp::boolean' panicked at tests/serde-issues.rs:570:46:
called `Result::unwrap()` on an `Err` value: Custom("invalid type: string \"trues\", expected a boolean")
```

Closes #824