### PR TITLE
Implement `BytesCData::escaped()` fn

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,13 @@
 
 ### New Features
 
+- [#831]: Add `BytesCData::escaped()` fn to construct CDATA events from arbitrary user input.
+
 ### Bug Fixes
 
 ### Misc Changes
+
+[#831]: https://github.com/tafia/quick-xml/issues/831
 
 
 ## 0.37.0 -- 2024-10-27


### PR DESCRIPTION
This PR should resolve https://github.com/tafia/quick-xml/issues/831 by implementing an `escaped()` fn on the `BytesCData` struct as suggested in https://github.com/tafia/quick-xml/issues/831#issuecomment-2481236477.

I opted for keeping the `new()` fn around and introducing another function instead because the `new()` fn is used in various places in the `quick-xml` test suite and I didn't want to break anything. This should also allow us to ship this PR in a non-breaking version release since the existing `new()` fn keeps working as-is. We could consider deprecating the `new()` fn though to make it easier for users to understand that they should use `escaped()` instead. We could also add a `raw()` fn as an alias for `new()` if we would like to keep the behavior for some users while still deprecating `new()`.

Related:

- https://github.com/tafia/quick-xml/issues/831
- https://github.com/rust-syndication/rss/issues/173
- https://github.com/rust-syndication/rss/pull/174
- https://github.com/tafia/quick-xml/pull/374

/cc @Mingun 

