### PR TITLE
Add to_utf8_io_writer helper serializing into std::io::Write

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,13 @@
 
 ### New Features
 
+- [#836]: Add `se::to_utf8_io_writer()` helper compatible with `std::io::Write` and restricted to UTF-8 encoding.
+
 ### Bug Fixes
 
 ### Misc Changes
+
+[#836]: https://github.com/tafia/quick-xml/pull/836
 
 
 ## 0.37.1 -- 2024-11-17

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -577,7 +577,7 @@ impl<'a, W: Write> ElementWriter<'a, W> {
     }
 }
 #[cfg(feature = "serialize")]
-struct ToFmtWrite<T>(pub T);
+pub(crate) struct ToFmtWrite<T>(pub T);
 
 #[cfg(feature = "serialize")]
 impl<T> std::fmt::Write for ToFmtWrite<T>


### PR DESCRIPTION
This PR is related to #499 and adds a helper method to dump XML into `std::io::Write` restricted to utf-8 output. The name is a bit verbose trying to convey that a. it's utf-8 only b. it's `io::Write`r and not `fmt::Write` to avoid confusion