### PR TITLE
Make BytesCData decode method public

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,13 @@
 
 ### New Features
 
+- [#857]: Add `BytesCData::decode()`.
+
 ### Bug Fixes
 
 ### Misc Changes
+
+[#857]: https://github.com/tafia/quick-xml/pull/857
 
 
 ## 0.37.4 -- 2025-04-01

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -843,8 +843,13 @@ impl<'a> BytesCData<'a> {
         ))
     }
 
-    /// Gets content of this text buffer in the specified encoding
-    pub(crate) fn decode(&self) -> Result<Cow<'a, str>, EncodingError> {
+    /// Decodes the raw input byte content of the CDATA section into a string,
+    /// without performing XML entity escaping.
+    ///
+    /// When this event produced by the XML reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within this
+    /// CDATA event.
+    pub fn decode(&self) -> Result<Cow<'a, str>, EncodingError> {
         Ok(self.decoder.decode_cow(&self.content)?)
     }
 }


### PR DESCRIPTION
Currently, retrieving the decoded string content of a `quick_xml::events::Event::CData(cdata)` requires manually obtaining the Decoder instance from the Reader and calling `reader.decoder().decode(cdata.as_ref())`

This PR addresses this by changing the visibility of the internal decode method associated with BytesCData from `pub(crate)` to `pub`.

This enables users to directly call the decoding logic on the BytesCData instance itself:
```rust
match cdata.decode() {
    Ok(decoded_string) => { /* ... */ }
    Err(err) => { /* ... */ }
}
```