### PR TITLE
Add ability to deserialize from `Attributes`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,10 @@
 
 ### New Features
 
+- [#863]: Add `Attributes::into_map_access(&str)` and `Attributes::into_deserializer()` when `serialize`
+  feature is enabled. This will allow do deserialize serde types right from attributes. Both methods
+  returns the same type which implements serde's `Deserializer` and `MapAccess` traits.
+
 ### Bug Fixes
 
 ### Misc Changes

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,11 @@
 
 ### Misc Changes
 
+- [#863]: Remove `From<QName<'a>> for BytesStart<'a>` because now `BytesStart` stores the
+  encoding in which its data is encoded, but `QName` is a simple wrapper around byte slice.
+
+[#863]: https://github.com/tafia/quick-xml/pull/863
+
 
 ## 0.37.5 -- 2025-04-27
 

--- a/src/de/attributes.rs
+++ b/src/de/attributes.rs
@@ -1,0 +1,167 @@
+//! Implementation of the deserializer from attributes
+
+use std::borrow::Cow;
+
+use serde::de::{DeserializeSeed, Deserializer, Error, IntoDeserializer, MapAccess, Visitor};
+use serde::forward_to_deserialize_any;
+
+use crate::de::key::QNameDeserializer;
+use crate::de::SimpleTypeDeserializer;
+use crate::errors::serialize::DeError;
+use crate::events::attributes::Attributes;
+
+impl<'i> Attributes<'i> {
+    /// Converts this iterator into a serde's [`MapAccess`] trait to use with serde.
+    /// The returned object also implements the [`Deserializer`] trait.
+    ///
+    /// # Parameters
+    /// - `prefix`: a prefix of the field names in structs that should be stripped
+    ///   to get the local attribute name. The [`crate::de::Deserializer`] uses `"@"`
+    ///   as a prefix, but [`Self::into_deserializer()`] uses empy string, which mean
+    ///   that we do not strip anything.
+    ///
+    /// # Example
+    /// ```
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::events::BytesStart;
+    /// use serde::Deserialize;
+    /// use serde::de::IntoDeserializer;
+    ///
+    /// #[derive(Debug, PartialEq, Deserialize)]
+    /// struct MyData<'i> {
+    ///     question: &'i str,
+    ///     answer: u32,
+    /// }
+    ///
+    /// #[derive(Debug, PartialEq, Deserialize)]
+    /// struct MyDataPrefixed<'i> {
+    ///     #[serde(rename = "@question")] question: &'i str,
+    ///     #[serde(rename = "@answer")]   answer: u32,
+    /// }
+    ///
+    /// let tag = BytesStart::from_content(
+    ///     "tag
+    ///         question = 'The Ultimate Question of Life, the Universe, and Everything'
+    ///         answer = '42'",
+    ///     3
+    /// );
+    /// // Strip nothing from the field names
+    /// let de = tag.attributes().clone().into_deserializer();
+    /// assert_eq!(
+    ///     MyData::deserialize(de).unwrap(),
+    ///     MyData {
+    ///         question: "The Ultimate Question of Life, the Universe, and Everything",
+    ///         answer: 42,
+    ///     }
+    /// );
+    ///
+    /// // Strip "@" from the field name
+    /// let de = tag.attributes().into_map_access("@");
+    /// assert_eq!(
+    ///     MyDataPrefixed::deserialize(de).unwrap(),
+    ///     MyDataPrefixed {
+    ///         question: "The Ultimate Question of Life, the Universe, and Everything",
+    ///         answer: 42,
+    ///     }
+    /// );
+    /// ```
+    #[inline]
+    pub const fn into_map_access(self, prefix: &'static str) -> AttributesDeserializer<'i> {
+        AttributesDeserializer {
+            iter: self,
+            value: None,
+            prefix,
+            key_buf: String::new(),
+        }
+    }
+}
+
+impl<'de> IntoDeserializer<'de, DeError> for Attributes<'de> {
+    type Deserializer = AttributesDeserializer<'de>;
+
+    #[inline]
+    fn into_deserializer(self) -> Self::Deserializer {
+        self.into_map_access("")
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// A deserializer used to make possible to pack all attributes into a struct.
+/// It is created by [`Attributes::into_map_access`] or [`Attributes::into_deserializer`]
+/// methods.
+///
+/// This deserializer always call [`Visitor::visit_map`] with self as [`MapAccess`].
+///
+/// # Lifetime
+///
+/// `'i` is a lifetime of the original buffer from which attributes were parsed.
+/// In particular, when reader was created from a string, this is lifetime of the
+/// string.
+#[derive(Debug, Clone)]
+pub struct AttributesDeserializer<'i> {
+    iter: Attributes<'i>,
+    /// The value of the attribute, read in last call to `next_key_seed`.
+    value: Option<Cow<'i, [u8]>>,
+    /// This prefix will be stripped from struct fields before match against attribute name.
+    prefix: &'static str,
+    /// Buffer to store attribute name as a field name exposed to serde consumers.
+    /// Keeped in the serializer to avoid many small allocations
+    key_buf: String,
+}
+
+impl<'de> Deserializer<'de> for AttributesDeserializer<'de> {
+    type Error = DeError;
+
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(self)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'de> MapAccess<'de> for AttributesDeserializer<'de> {
+    type Error = DeError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        debug_assert_eq!(self.value, None);
+
+        match self.iter.next() {
+            None => Ok(None),
+            Some(Ok(attr)) => {
+                self.value = Some(attr.value);
+                self.key_buf.clear();
+                self.key_buf.push_str(self.prefix);
+                let de =
+                    QNameDeserializer::from_attr(attr.key, self.iter.decoder(), &mut self.key_buf)?;
+                seed.deserialize(de).map(Some)
+            }
+            Some(Err(err)) => Err(Error::custom(err)),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => {
+                let de =
+                    SimpleTypeDeserializer::from_part(&value, 0..value.len(), self.iter.decoder());
+                seed.deserialize(de)
+            }
+            None => Err(DeError::KeyNotRead),
+        }
+    }
+}

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -100,19 +100,13 @@ impl<'i, 'd> QNameDeserializer<'i, 'd> {
 
     /// Creates deserializer from name of an element
     pub fn from_elem(start: &'d BytesStart<'i>) -> Result<Self, DeError> {
-        let local = match start.raw_name() {
-            CowRef::Input(borrowed) => match decode_name(QName(borrowed), start.decoder())? {
+        let local = match start.buf {
+            Cow::Borrowed(b) => match decode_name(QName(&b[..start.name_len]), start.decoder())? {
                 Cow::Borrowed(borrowed) => CowRef::Input(borrowed),
                 Cow::Owned(owned) => CowRef::Owned(owned),
             },
-            CowRef::Slice(borrowed) => match decode_name(QName(borrowed), start.decoder())? {
+            Cow::Owned(ref o) => match decode_name(QName(&o[..start.name_len]), start.decoder())? {
                 Cow::Borrowed(borrowed) => CowRef::Slice(borrowed),
-                Cow::Owned(owned) => CowRef::Owned(owned),
-            },
-            CowRef::Owned(owned) => match decode_name(QName(&owned), start.decoder())? {
-                // SAFETY: Because result is borrowed, no changes was done
-                // and we can safely unwrap here
-                Cow::Borrowed(_) => CowRef::Owned(String::from_utf8(owned).unwrap()),
                 Cow::Owned(owned) => CowRef::Owned(owned),
             },
         };

--- a/src/de/key.rs
+++ b/src/de/key.rs
@@ -83,9 +83,6 @@ impl<'i, 'd> QNameDeserializer<'i, 'd> {
         decoder: Decoder,
         key_buf: &'d mut String,
     ) -> Result<Self, DeError> {
-        key_buf.clear();
-        key_buf.push('@');
-
         // https://github.com/tafia/quick-xml/issues/537
         // Namespace bindings (xmlns:xxx) map to `@xmlns:xxx` instead of `@xxx`
         if name.as_namespace_binding().is_some() {

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -308,7 +308,7 @@ where
                 DeEvent::Start(e) => {
                     self.source = ValueSource::Nested;
 
-                    let de = QNameDeserializer::from_elem(e.raw_name(), e.decoder())?;
+                    let de = QNameDeserializer::from_elem(e)?;
                     seed.deserialize(de).map(Some)
                 }
                 // Stop iteration after reaching a closing tag
@@ -689,10 +689,7 @@ where
         V: DeserializeSeed<'de>,
     {
         let (name, is_text) = match self.map.de.peek()? {
-            DeEvent::Start(e) => (
-                seed.deserialize(QNameDeserializer::from_elem(e.raw_name(), e.decoder())?)?,
-                false,
-            ),
+            DeEvent::Start(e) => (seed.deserialize(QNameDeserializer::from_elem(e)?)?, false),
             DeEvent::Text(_) => (
                 seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
                 true,
@@ -1152,10 +1149,7 @@ where
     where
         V: DeserializeSeed<'de>,
     {
-        let name = seed.deserialize(QNameDeserializer::from_elem(
-            self.start.raw_name(),
-            self.start.decoder(),
-        )?)?;
+        let name = seed.deserialize(QNameDeserializer::from_elem(&self.start)?)?;
         Ok((name, self))
     }
 }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -331,7 +331,6 @@ where
             ValueSource::Attribute(value) => seed.deserialize(SimpleTypeDeserializer::from_part(
                 &self.start.buf,
                 value,
-                true,
                 self.de.reader.decoder(),
             )),
             // This arm processes the following XML shape:

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -254,6 +254,11 @@ where
             let (key, value) = a.into();
             self.source = ValueSource::Attribute(value.unwrap_or_default());
 
+            // Attributes in mapping starts from @ prefix
+            // TODO: Customization point - may customize prefix
+            self.de.key_buf.clear();
+            self.de.key_buf.push('@');
+
             let de =
                 QNameDeserializer::from_attr(QName(&slice[key]), decoder, &mut self.de.key_buf)?;
             seed.deserialize(de).map(Some)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2072,6 +2072,7 @@ macro_rules! deserialize_primitives {
     };
 }
 
+mod attributes;
 mod key;
 mod map;
 mod resolver;
@@ -2079,6 +2080,7 @@ mod simple_type;
 mod text;
 mod var;
 
+pub use self::attributes::AttributesDeserializer;
 pub use self::resolver::{EntityResolver, PredefinedEntityResolver};
 pub use self::simple_type::SimpleTypeDeserializer;
 pub use crate::errors::serialize::DeError;

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -539,14 +539,13 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
     pub(crate) fn from_part(
         value: &'a Cow<'de, [u8]>,
         range: Range<usize>,
-        escaped: bool,
         decoder: Decoder,
     ) -> Self {
         let content = match value {
             Cow::Borrowed(slice) => CowRef::Input(&slice[range]),
             Cow::Owned(slice) => CowRef::Slice(&slice[range]),
         };
-        Self::new(content, escaped, decoder)
+        Self::new(content, true, decoder)
     }
 
     /// Constructor for tests

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -40,10 +40,9 @@ where
     where
         V: DeserializeSeed<'de>,
     {
-        let decoder = self.de.reader.decoder();
         let (name, is_text) = match self.de.peek()? {
             DeEvent::Start(e) => (
-                seed.deserialize(QNameDeserializer::from_elem(e.raw_name(), decoder)?)?,
+                seed.deserialize(QNameDeserializer::from_elem(e.raw_name(), e.decoder())?)?,
                 false,
             ),
             DeEvent::Text(_) => (

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -41,10 +41,7 @@ where
         V: DeserializeSeed<'de>,
     {
         let (name, is_text) = match self.de.peek()? {
-            DeEvent::Start(e) => (
-                seed.deserialize(QNameDeserializer::from_elem(e.raw_name(), e.decoder())?)?,
-                false,
-            ),
+            DeEvent::Start(e) => (seed.deserialize(QNameDeserializer::from_elem(e)?)?, false),
             DeEvent::Text(_) => (
                 seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
                 true,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -81,7 +81,7 @@ pub struct Decoder {
 }
 
 impl Decoder {
-    pub(crate) fn utf8() -> Self {
+    pub(crate) const fn utf8() -> Self {
         Decoder {
             #[cfg(feature = "encoding")]
             encoding: UTF_8,
@@ -89,7 +89,7 @@ impl Decoder {
     }
 
     #[cfg(all(test, feature = "encoding", feature = "serialize"))]
-    pub(crate) fn utf16() -> Self {
+    pub(crate) const fn utf16() -> Self {
         Decoder { encoding: UTF_16LE }
     }
 }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -256,12 +256,54 @@ impl<'a> Attributes<'a> {
         }
     }
 
-    /// Creates a new attribute iterator from a buffer.
+    /// Creates a new attribute iterator from a buffer, which recognizes only XML-style
+    /// attributes, i. e. those which in the form `name = "value"` or `name = 'value'`.
+    /// HTML style attributes (i. e. without quotes or only name) will return a error.
+    ///
+    /// # Parameters
+    /// - `buf`: a buffer with a tag name and attributes, usually this is the whole
+    ///   string between `<` and `>` (or `/>`) of a tag;
+    /// - `pos`: a position in the `buf` where tag name is finished and attributes
+    ///   is started. It is not necessary to point exactly to the end of a tag name,
+    ///   although that is usually that. If it will be more than the `buf` length,
+    ///   then the iterator will return `None`` immediately.
+    ///
+    /// # Example
+    /// ```
+    /// # use quick_xml::events::attributes::{Attribute, Attributes};
+    /// # use pretty_assertions::assert_eq;
+    /// #
+    /// let mut iter = Attributes::new("tag-name attr1 = 'value1' attr2='value2' ", 9);
+    /// //                              ^0       ^9
+    /// assert_eq!(iter.next(), Some(Ok(Attribute::from(("attr1", "value1")))));
+    /// assert_eq!(iter.next(), Some(Ok(Attribute::from(("attr2", "value2")))));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub const fn new(buf: &'a str, pos: usize) -> Self {
         Self::wrap(buf.as_bytes(), pos, false, Decoder::utf8())
     }
 
     /// Creates a new attribute iterator from a buffer, allowing HTML attribute syntax.
+    ///
+    /// # Parameters
+    /// - `buf`: a buffer with a tag name and attributes, usually this is the whole
+    ///   string between `<` and `>` (or `/>`) of a tag;
+    /// - `pos`: a position in the `buf` where tag name is finished and attributes
+    ///   is started. It is not necessary to point exactly to the end of a tag name,
+    ///   although that is usually that. If it will be more than the `buf` length,
+    ///   then the iterator will return `None`` immediately.
+    ///
+    /// # Example
+    /// ```
+    /// # use quick_xml::events::attributes::{Attribute, Attributes};
+    /// # use pretty_assertions::assert_eq;
+    /// #
+    /// let mut iter = Attributes::html("tag-name attr1 = value1 attr2 ", 9);
+    /// //                               ^0       ^9
+    /// assert_eq!(iter.next(), Some(Ok(Attribute::from(("attr1", "value1")))));
+    /// assert_eq!(iter.next(), Some(Ok(Attribute::from(("attr2", "")))));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub const fn html(buf: &'a str, pos: usize) -> Self {
         Self::wrap(buf.as_bytes(), pos, true, Decoder::utf8())
     }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -231,7 +231,10 @@ impl<'a> From<Attr<&'a [u8]>> for Attribute<'a> {
 /// Yields `Result<Attribute>`. An `Err` will be yielded if an attribute is malformed or duplicated.
 /// The duplicate check can be turned off by calling [`with_checks(false)`].
 ///
+/// When [`serialize`] feature is enabled, can be converted to serde's deserializer.
+///
 /// [`with_checks(false)`]: Self::with_checks
+/// [`serialize`]: ../../index.html#serialize
 #[derive(Clone)]
 pub struct Attributes<'a> {
     /// Slice of `BytesStart` corresponding to attributes

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -52,8 +52,6 @@ use crate::escape::{
     escape, minimal_escape, partial_escape, resolve_predefined_entity, unescape_with,
 };
 use crate::name::{LocalName, QName};
-#[cfg(feature = "serialize")]
-use crate::utils::CowRef;
 use crate::utils::{name_len, trim_xml_end, trim_xml_start, write_cow_string, Bytes};
 use attributes::{AttrError, Attribute, Attributes};
 
@@ -237,22 +235,6 @@ impl<'a> BytesStart<'a> {
         bytes.splice(..self.name_len, name.iter().cloned());
         self.name_len = name.len();
         self
-    }
-
-    /// Gets the undecoded raw tag name, as present in the input stream, which
-    /// is borrowed either to the input, or to the event.
-    ///
-    /// # Lifetimes
-    ///
-    /// - `'a`: Lifetime of the input data from which this event is borrow
-    /// - `'e`: Lifetime of the concrete event instance
-    // TODO: We should made this is a part of public API, but with safe wrapped for a name
-    #[cfg(feature = "serialize")]
-    pub(crate) fn raw_name<'e>(&'e self) -> CowRef<'a, 'e, [u8]> {
-        match self.buf {
-            Cow::Borrowed(b) => CowRef::Input(&b[..self.name_len]),
-            Cow::Owned(ref o) => CowRef::Slice(&o[..self.name_len]),
-        }
     }
 }
 


### PR DESCRIPTION
This PR adds ability to convert `Attributes` iterator into a serde's `MapAccess` and `Deserializer`, so it will be easely to mix serde-based and reader-based approaches.

The implementation will require to move `Decoder` into the `Attributes` and, as a consequence, to `BytesStart`. That is already was required for other purposes, but this will increase the size of both structs by 8 bytes. I still think it is a fair price for the benefits.