### PR TITLE
Yet another approach to disable trim

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,9 @@ Now references to entities (as predefined, such as `&lt;`, as user-defined) repo
 Caller can parse the content of the entity and stream events from it as it is required by the
 XML specification. See the updated `custom_entities` example!
 
+Implement whitespace behavior in the standard in `Deserializer`, which says string primitive
+types should preserve whitespace, while all other primitives have collapse behavior.
+
 ### New Features
 
 - [#863]: Add `Attributes::into_map_access(&str)` and `Attributes::into_deserializer()` when `serialize`

--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@ XML specification. See the updated `custom_entities` example!
 - [#766]: Added new configuration option `allow_dangling_amp` which allows to have
   a `&` not followed by `;` in the textual data which is required for some applications
   for compatibility reasons.
+- [#285]: Add ability to `quick_xml::de::Text` to access text with trimmed spaces
 
 ### Bug Fixes
 
@@ -40,6 +41,7 @@ XML specification. See the updated `custom_entities` example!
 - [#766]: `BytesText::unescape` and `BytesText::unescape_with` replaced by `BytesText::decode`.
   Now Text events does not contain escaped parts which are reported as `Event::GeneralRef`.
 
+[#285]: https://github.com/tafia/quick-xml/issues/285
 [#766]: https://github.com/tafia/quick-xml/pull/766
 [#863]: https://github.com/tafia/quick-xml/pull/863
 [general entity]: https://www.w3.org/TR/xml11/#gen-entity

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2881,6 +2881,19 @@ where
         let name = start.name();
         self.read_to_end(name)
     }
+
+    /// Method for testing Deserializer implementation. Checks that all events was consumed during
+    /// deserialization. Panics if the next event will not be [`DeEvent::Eof`].
+    #[doc(hidden)]
+    #[track_caller]
+    pub fn check_eof_reached(&mut self) {
+        let event = self.peek().expect("cannot peek event");
+        assert_eq!(
+            *event,
+            DeEvent::Eof,
+            "the whole XML document should be consumed, expected `Eof`",
+        );
+    }
 }
 
 impl<'de> Deserializer<'de, SliceReader<'de>> {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2786,7 +2786,7 @@ where
             DeEvent::Start(e) if allow_start => self.read_text(e.name()),
             DeEvent::Start(e) => Err(DeError::UnexpectedStart(e.name().as_ref().to_owned())),
             // SAFETY: The reader is guaranteed that we don't have unmatched tags
-            // If we here, then out deserializer has a bug
+            // If we here, then our deserializer has a bug
             DeEvent::End(e) => unreachable!("{:?}", e),
             DeEvent::Eof => Err(DeError::UnexpectedEof),
         }
@@ -2978,7 +2978,7 @@ where
         match self.next()? {
             DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self, e, fields)?),
             // SAFETY: The reader is guaranteed that we don't have unmatched tags
-            // If we here, then out deserializer has a bug
+            // If we here, then our deserializer has a bug
             DeEvent::End(e) => unreachable!("{:?}", e),
             // Deserializer methods are only hints, if deserializer could not satisfy
             // request, it should return the data that it has. It is responsibility
@@ -3019,7 +3019,7 @@ where
             }
             DeEvent::Text(_) => visitor.visit_unit(),
             // SAFETY: The reader is guaranteed that we don't have unmatched tags
-            // If we here, then out deserializer has a bug
+            // If we here, then our deserializer has a bug
             DeEvent::End(e) => unreachable!("{:?}", e),
             DeEvent::Eof => Err(DeError::UnexpectedEof),
         }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3428,16 +3428,16 @@ mod tests {
         #[test]
         fn read_and_peek() {
             let mut de = make_de(
-                r#"
-                <root>
-                    <inner>
-                        text
-                        <inner/>
-                    </inner>
-                    <next/>
-                    <target/>
-                </root>
-                "#,
+                "\
+                <root>\
+                    <inner>\
+                        text\
+                        <inner/>\
+                    </inner>\
+                    <next/>\
+                    <target/>\
+                </root>\
+                ",
             );
 
             // Initial conditions - both are empty
@@ -3559,17 +3559,17 @@ mod tests {
         #[test]
         fn read_to_end() {
             let mut de = make_de(
-                r#"
-                <root>
-                    <skip>
-                        text
-                        <skip/>
-                    </skip>
-                    <target>
-                        <target/>
-                    </target>
-                </root>
-                "#,
+                "\
+                <root>\
+                    <skip>\
+                        text\
+                        <skip/>\
+                    </skip>\
+                    <target>\
+                        <target/>\
+                    </target>\
+                </root>\
+                ",
             );
 
             // Initial conditions - both are empty
@@ -3652,18 +3652,18 @@ mod tests {
         #[test]
         fn partial_replay() {
             let mut de = make_de(
-                r#"
-                <root>
-                    <skipped-1/>
-                    <skipped-2/>
-                    <inner>
-                        <skipped-3/>
-                        <skipped-4/>
-                        <target-2/>
-                    </inner>
-                    <target-1/>
-                </root>
-                "#,
+                "\
+                <root>\
+                    <skipped-1/>\
+                    <skipped-2/>\
+                    <inner>\
+                        <skipped-3/>\
+                        <skipped-4/>\
+                        <target-2/>\
+                    </inner>\
+                    <target-1/>\
+                </root>\
+                ",
             );
 
             // Initial conditions - both are empty
@@ -3858,17 +3858,17 @@ mod tests {
             }
 
             let mut de = make_de(
-                r#"
-                <any-name>
-                    <item/>
-                    <another-item>
-                        <some-element>with text</some-element>
-                        <yet-another-element/>
-                    </another-item>
-                    <item/>
-                    <item/>
-                </any-name>
-                "#,
+                "\
+                <any-name>\
+                    <item/>\
+                    <another-item>\
+                        <some-element>with text</some-element>\
+                        <yet-another-element/>\
+                    </another-item>\
+                    <item/>\
+                    <item/>\
+                </any-name>\
+                ",
             );
             de.event_buffer_size(NonZeroUsize::new(3));
 
@@ -3910,14 +3910,17 @@ mod tests {
                 "#,
             );
 
+            assert_eq!(de.next().unwrap(), Text("\n                ".into()));
             assert_eq!(de.next().unwrap(), Start(BytesStart::new("root")));
 
+            assert_eq!(de.next().unwrap(), Text("\n                    ".into()));
             assert_eq!(
                 de.next().unwrap(),
                 Start(BytesStart::from_content(r#"tag a="1""#, 3))
             );
             assert_eq!(de.read_to_end(QName(b"tag")).unwrap(), ());
 
+            assert_eq!(de.next().unwrap(), Text("\n                    ".into()));
             assert_eq!(
                 de.next().unwrap(),
                 Start(BytesStart::from_content(r#"tag a="2""#, 3))
@@ -3925,10 +3928,13 @@ mod tests {
             assert_eq!(de.next().unwrap(), Text("cdata content".into()));
             assert_eq!(de.next().unwrap(), End(BytesEnd::new("tag")));
 
+            assert_eq!(de.next().unwrap(), Text("\n                    ".into()));
             assert_eq!(de.next().unwrap(), Start(BytesStart::new("self-closed")));
             assert_eq!(de.read_to_end(QName(b"self-closed")).unwrap(), ());
 
+            assert_eq!(de.next().unwrap(), Text("\n                ".into()));
             assert_eq!(de.next().unwrap(), End(BytesEnd::new("root")));
+            assert_eq!(de.next().unwrap(), Text("\n                ".into()));
             assert_eq!(de.next().unwrap(), Eof);
         }
 
@@ -4033,18 +4039,23 @@ mod tests {
         assert_eq!(
             events,
             vec![
+                Text(BytesText::from_escaped("\n            ")),
                 Start(BytesStart::from_content(
                     r#"item name="hello" source="world.rs""#,
                     4
                 )),
                 Text(BytesText::from_escaped("Some text")),
                 End(BytesEnd::new("item")),
+                Text(BytesText::from_escaped("\n            ")),
                 Start(BytesStart::from_content("item2", 5)),
                 End(BytesEnd::new("item2")),
+                Text(BytesText::from_escaped("\n            ")),
                 Start(BytesStart::from_content("item3", 5)),
                 End(BytesEnd::new("item3")),
+                Text(BytesText::from_escaped("\n            ")),
                 Start(BytesStart::from_content(r#"item4 value="world" "#, 5)),
                 End(BytesEnd::new("item4")),
+                Text(BytesText::from_escaped("\n        ")),
             ]
         )
     }
@@ -4194,7 +4205,7 @@ mod tests {
                         text \
                     ",
                 );
-                assert_eq!(de.next().unwrap(), DeEvent::Text("cdata  text".into()));
+                assert_eq!(de.next().unwrap(), DeEvent::Text("cdata  text ".into()));
             }
 
             #[test]
@@ -4206,7 +4217,7 @@ mod tests {
                         text \
                     ",
                 );
-                assert_eq!(de.next().unwrap(), DeEvent::Text(" text".into()));
+                assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
             }
 
             #[test]
@@ -4283,7 +4294,7 @@ mod tests {
                         text \
                     ",
                 );
-                assert_eq!(de.next().unwrap(), DeEvent::Text("cdata  text".into()));
+                assert_eq!(de.next().unwrap(), DeEvent::Text("cdata  text ".into()));
             }
 
             #[test]
@@ -4295,7 +4306,7 @@ mod tests {
                         text \
                     ",
                 );
-                assert_eq!(de.next().unwrap(), DeEvent::Text(" text".into()));
+                assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
             }
 
             #[test]
@@ -4352,8 +4363,7 @@ mod tests {
                     let mut de = make_de("<tag1><tag2> text ");
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag1")));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag2")));
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
 
@@ -4412,8 +4422,7 @@ mod tests {
                     let mut de = make_de("<tag></tag> text ");
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
 
@@ -4445,8 +4454,7 @@ mod tests {
                 fn start() {
                     let mut de = make_de("<tag> text <tag2>");
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag2")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4455,8 +4463,7 @@ mod tests {
                 fn end() {
                     let mut de = make_de("<tag> text </tag>");
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4467,8 +4474,7 @@ mod tests {
                 fn cdata() {
                     let mut de = make_de("<tag> text <![CDATA[ cdata ]]>");
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
-                    // Text is trimmed from the start
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text  cdata ".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text  cdata ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
 
@@ -4476,8 +4482,7 @@ mod tests {
                 fn eof() {
                     let mut de = make_de("<tag> text ");
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4510,8 +4515,7 @@ mod tests {
                 fn text() {
                     let mut de = make_de("<tag><![CDATA[ cdata ]]> text ");
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
-                    // Text is trimmed from the end
-                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
 
@@ -4561,8 +4565,7 @@ mod tests {
                 #[test]
                 fn start() {
                     let mut de = make_de(" text <tag1><tag2>");
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag1")));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag2")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
@@ -4572,8 +4575,7 @@ mod tests {
                 #[test]
                 fn end() {
                     let mut de = make_de(" text <tag></tag>");
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
@@ -4582,19 +4584,16 @@ mod tests {
                 #[test]
                 fn text() {
                     let mut de = make_de(" text <tag> text2 ");
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text2".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text2 ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
 
                 #[test]
                 fn cdata() {
                     let mut de = make_de(" text <tag><![CDATA[ cdata ]]>");
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
@@ -4602,9 +4601,8 @@ mod tests {
 
                 #[test]
                 fn eof() {
-                    // Text is trimmed from both sides
                     let mut de = make_de(" text <tag>");
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
@@ -4615,8 +4613,7 @@ mod tests {
             #[test]
             fn end() {
                 let mut de = make_de(" text </tag>");
-                // Text is trimmed from both sides
-                assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                 match de.next() {
                     Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
                         assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
@@ -4638,8 +4635,7 @@ mod tests {
                 #[test]
                 fn start() {
                     let mut de = make_de(" text <![CDATA[ cdata ]]><tag>");
-                    // Text is trimmed from the start
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text  cdata ".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text  cdata ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4647,8 +4643,7 @@ mod tests {
                 #[test]
                 fn end() {
                     let mut de = make_de(" text <![CDATA[ cdata ]]></tag>");
-                    // Text is trimmed from the start
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text  cdata ".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text  cdata ".into()));
                     match de.next() {
                         Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
                             assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
@@ -4664,10 +4659,9 @@ mod tests {
                 #[test]
                 fn text() {
                     let mut de = make_de(" text <![CDATA[ cdata ]]> text2 ");
-                    // Text is trimmed from the start and from the end
                     assert_eq!(
                         de.next().unwrap(),
-                        DeEvent::Text("text  cdata  text2".into())
+                        DeEvent::Text(" text  cdata  text2 ".into())
                     );
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4675,10 +4669,9 @@ mod tests {
                 #[test]
                 fn cdata() {
                     let mut de = make_de(" text <![CDATA[ cdata ]]><![CDATA[ cdata2 ]]>");
-                    // Text is trimmed from the start
                     assert_eq!(
                         de.next().unwrap(),
-                        DeEvent::Text("text  cdata  cdata2 ".into())
+                        DeEvent::Text(" text  cdata  cdata2 ".into())
                     );
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4686,8 +4679,7 @@ mod tests {
                 #[test]
                 fn eof() {
                     let mut de = make_de(" text <![CDATA[ cdata ]]>");
-                    // Text is trimmed from the start
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text  cdata ".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text  cdata ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4726,8 +4718,7 @@ mod tests {
                     let mut de = make_de("<![CDATA[ cdata ]]><tag> text ");
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
-                    // Text is trimmed from both sides
-                    assert_eq!(de.next().unwrap(), DeEvent::Text("text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
 
@@ -4774,8 +4765,7 @@ mod tests {
                 #[test]
                 fn start() {
                     let mut de = make_de("<![CDATA[ cdata ]]> text <tag>");
-                    // Text is trimmed from the end
-                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4783,8 +4773,7 @@ mod tests {
                 #[test]
                 fn end() {
                     let mut de = make_de("<![CDATA[ cdata ]]> text </tag>");
-                    // Text is trimmed from the end
-                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text ".into()));
                     match de.next() {
                         Err(DeError::InvalidXml(Error::IllFormed(cause))) => {
                             assert_eq!(cause, IllFormedError::UnmatchedEndTag("tag".into()));
@@ -4812,8 +4801,7 @@ mod tests {
                 #[test]
                 fn eof() {
                     let mut de = make_de("<![CDATA[ cdata ]]> text ");
-                    // Text is trimmed from the end
-                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" cdata  text ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
@@ -4850,10 +4838,9 @@ mod tests {
                 #[test]
                 fn text() {
                     let mut de = make_de("<![CDATA[ cdata ]]><![CDATA[ cdata2 ]]> text ");
-                    // Text is trimmed from the end
                     assert_eq!(
                         de.next().unwrap(),
-                        DeEvent::Text(" cdata  cdata2  text".into())
+                        DeEvent::Text(" cdata  cdata2  text ".into())
                     );
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -47,7 +47,7 @@ where
                 true,
             ),
             // SAFETY: The reader is guaranteed that we don't have unmatched tags
-            // If we here, then out deserializer has a bug
+            // If we here, then our deserializer has a bug
             DeEvent::End(e) => unreachable!("{:?}", e),
             DeEvent::Eof => return Err(DeError::UnexpectedEof),
         };

--- a/tests/serde-de-enum.rs
+++ b/tests/serde-de-enum.rs
@@ -267,7 +267,7 @@ mod externally_tagged {
             #[test]
             fn text() {
                 let data: Text = from_str(" text ").unwrap();
-                assert_eq!(data, Text::Newtype("text".into()));
+                assert_eq!(data, Text::Newtype(" text ".into()));
             }
 
             #[test]
@@ -279,7 +279,7 @@ mod externally_tagged {
             #[test]
             fn mixed() {
                 let data: Text = from_str(" te <![CDATA[ cdata ]]> xt ").unwrap();
-                assert_eq!(data, Text::Newtype("te  cdata  xt".into()));
+                assert_eq!(data, Text::Newtype(" te  cdata  xt ".into()));
             }
         }
 
@@ -330,10 +330,10 @@ mod externally_tagged {
                 match from_str::<Text>(" text ") {
                     Err(DeError::Custom(reason)) => assert_eq!(
                         reason,
-                        "invalid type: string \"text\", expected struct variant Text::Struct"
+                        "invalid type: string \" text \", expected struct variant Text::Struct"
                     ),
                     x => panic!(
-                        r#"Expected `Err(Custom("invalid type: string \"text\", expected struct variant Text::Struct"))`, but got `{:?}`"#,
+                        r#"Expected `Err(Custom("invalid type: string \" text \", expected struct variant Text::Struct"))`, but got `{:?}`"#,
                         x
                     ),
                 }
@@ -358,10 +358,10 @@ mod externally_tagged {
                 match from_str::<Text>(" te <![CDATA[ cdata ]]> xt ") {
                     Err(DeError::Custom(reason)) => assert_eq!(
                         reason,
-                        "invalid type: string \"te  cdata  xt\", expected struct variant Text::Struct"
+                        "invalid type: string \" te  cdata  xt \", expected struct variant Text::Struct"
                     ),
                     x => panic!(
-                        r#"Expected `Err(Custom("invalid type: string \"te  cdata  xt\", expected struct variant Text::Struct"))`, but got `{:?}`"#,
+                        r#"Expected `Err(Custom("invalid type: string \" te  cdata  xt \", expected struct variant Text::Struct"))`, but got `{:?}`"#,
                         x
                     ),
                 }

--- a/tests/serde-de-enum.rs
+++ b/tests/serde-de-enum.rs
@@ -248,7 +248,6 @@ mod externally_tagged {
             }
 
             #[test]
-            #[ignore = "awaiting fix of https://github.com/tafia/quick-xml/issues/474"]
             fn mixed() {
                 let data: Text = from_str(" te <![CDATA[ cdata ]]> xt ").unwrap();
                 assert_eq!(data, Text::Unit);
@@ -278,7 +277,6 @@ mod externally_tagged {
             }
 
             #[test]
-            #[ignore = "awaiting fix of https://github.com/tafia/quick-xml/issues/474"]
             fn mixed() {
                 let data: Text = from_str(" te <![CDATA[ cdata ]]> xt ").unwrap();
                 assert_eq!(data, Text::Newtype("te  cdata  xt".into()));
@@ -310,7 +308,6 @@ mod externally_tagged {
             }
 
             #[test]
-            #[ignore = "awaiting fix of https://github.com/tafia/quick-xml/issues/474"]
             fn mixed() {
                 let data: Text = from_str(" 4.2 <![CDATA[ cdata ]]>").unwrap();
                 assert_eq!(data, Text::Tuple(4.2, "cdata".into()));

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -967,10 +967,10 @@ mod struct_ {
             ) {
                 Err(DeError::Custom(reason)) => assert_eq!(
                     reason,
-                    "invalid type: string \"excess text\", expected struct Elements",
+                    "invalid type: string \"\\nexcess text\\t\", expected struct Elements",
                 ),
                 x => panic!(
-                    r#"Expected `Err(Custom("invalid type: string \"excess text\", expected struct Elements"))`, but got `{:?}`"#,
+                    r#"Expected `Err(Custom("invalid type: string \"\\nexcess text\\t\", expected struct Elements"))`, but got `{:?}`"#,
                     x
                 ),
             };
@@ -1491,7 +1491,7 @@ mod borrow {
             BTreeMap::from_iter([
                 // Comment to prevent formatting in one line
                 ("element", "element content"),
-                ("$text", "text content"),
+                ("$text", "\n                text content\n            "),
             ])
         );
     }

--- a/tests/serde-migrated.rs
+++ b/tests/serde-migrated.rs
@@ -100,7 +100,7 @@ fn test_parse_string() {
             "This is a String".to_string(),
         ),
         ("<bla></bla>", "".to_string()),
-        ("<bla>     </bla>", "".to_string()),
+        ("<bla>     </bla>", "     ".to_string()),
         ("<bla>&lt;boom/&gt;</bla>", "<boom/>".to_string()),
         ("<bla>&#9835;</bla>", "♫".to_string()),
         ("<bla>&#x266B;</bla>", "♫".to_string()),
@@ -122,7 +122,7 @@ fn test_option() {
     test_parse_ok(&[
         ("<a/>", Some("".to_string())),
         ("<a></a>", Some("".to_string())),
-        ("<a> </a>", Some("".to_string())),
+        ("<a> </a>", Some(" ".to_string())),
         ("<a>42</a>", Some("42".to_string())),
     ]);
 }

--- a/tests/serde_helpers/mod.rs
+++ b/tests/serde_helpers/mod.rs
@@ -18,7 +18,7 @@ where
 
     // If type was deserialized, the whole XML document should be consumed
     if let Ok(_) = result {
-        assert!(de.is_empty(), "the whole XML document should be consumed");
+        de.check_eof_reached();
     }
 
     result

--- a/tests/serde_helpers/mod.rs
+++ b/tests/serde_helpers/mod.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 /// Deserialize an instance of type T from a string of XML text.
 /// If deserialization was succeeded checks that all XML events was consumed
+#[track_caller]
 pub fn from_str<'de, T>(source: &'de str) -> Result<T, DeError>
 where
     T: Deserialize<'de>,


### PR DESCRIPTION
I implemented disabling trim by modifying Text struct.
See: https://github.com/tafia/quick-xml/issues/285#issuecomment-2863592598

I need this for parsing `.odt` files.
Can anybody give me some feedback? This issue is 4 years old and I'm willing to fix it if possible.