### PR TITLE
Fix text in fixed seq

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@ XML specification. See the updated `custom_entities` example!
 
 - [#868]: Allow to have both `$text` and `$value` special fields in one struct. Previously
   any text will be recognized as `$value` field even when `$text` field is also presented.
+- [#868]: Skip text events when deserialize a sequence of items overlapped with text (including CDATA).
 
 ### Misc Changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,9 @@ XML specification. See the updated `custom_entities` example!
 
 ### Bug Fixes
 
+- [#868]: Allow to have both `$text` and `$value` special fields in one struct. Previously
+  any text will be recognized as `$value` field even when `$text` field is also presented.
+
 ### Misc Changes
 
 - [#863]: Remove `From<QName<'a>> for BytesStart<'a>` because now `BytesStart` stores the
@@ -42,6 +45,7 @@ XML specification. See the updated `custom_entities` example!
 
 [#766]: https://github.com/tafia/quick-xml/pull/766
 [#863]: https://github.com/tafia/quick-xml/pull/863
+[#868]: https://github.com/tafia/quick-xml/pull/868
 [general entity]: https://www.w3.org/TR/xml11/#gen-entity
 
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1506,6 +1506,28 @@
 //! The only difference is in how complex types and sequences are serialized.
 //! If you doubt which one you should select, begin with [`$value`](#value).
 //!
+//! If you have both `$text` and `$value` in you struct, then text events will be
+//! mapped to the `$text` field:
+//!
+//! ```
+//! # use serde::Deserialize;
+//! # use quick_xml::de::from_str;
+//! #[derive(Deserialize, PartialEq, Debug)]
+//! struct TextAndValue {
+//!     #[serde(rename = "$text")]
+//!     text: Option<String>,
+//!
+//!     #[serde(rename = "$value")]
+//!     value: Option<String>,
+//! }
+//!
+//! let object: TextAndValue = from_str("<AnyName>text <![CDATA[and CDATA]]></AnyName>").unwrap();
+//! assert_eq!(object, TextAndValue {
+//!     text: Some("text and CDATA".to_string()),
+//!     value: None,
+//! });
+//! ```
+//!
 //! ## `$text`
 //! `$text` is used when you want to write your XML as a text or a CDATA content.
 //! More formally, field with that name represents simple type definition with
@@ -1743,12 +1765,6 @@
 //! let object: AnyName = from_str(&xml).unwrap();
 //! assert_eq!(object, obj);
 //! ```
-//!
-//! ----------------------------------------------------------------------------
-//!
-//! You can have either `$text` or `$value` field in your structs. Unfortunately,
-//! that is not enforced, so you can theoretically have both, but you should
-//! avoid that.
 //!
 //!
 //!

--- a/tests/serde-de-seq.rs
+++ b/tests/serde-de-seq.rs
@@ -821,6 +821,28 @@ mod fixed_name {
             );
         }
 
+        #[test]
+        fn text_and_value() {
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                #[serde(rename = "$text")]
+                text: (),
+                item: [(); 2],
+            }
+
+            from_str::<List>(
+                r#"
+                <root>
+                    <item/>
+                    <item/>
+                    text
+                    <![CDATA[cdata]]>
+                </root>
+                "#,
+            )
+            .unwrap();
+        }
+
         /// Checks that sequences represented by elements can contain sequences,
         /// represented by [`xs:list`s](https://www.w3schools.com/xml/el_list.asp)
         mod xs_list {
@@ -1652,6 +1674,36 @@ mod fixed_name {
                             element: Some("value".to_string()),
                         },
                     ],
+                }
+            );
+        }
+
+        #[test]
+        fn text_and_value() {
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                #[serde(rename = "$text")]
+                text: (),
+                item: Vec<()>,
+            }
+
+            let data: List = from_str(
+                r#"
+                <root>
+                    <item/>
+                    <item/>
+                    text
+                    <![CDATA[cdata]]>
+                </root>
+                "#,
+            )
+            .unwrap();
+
+            assert_eq!(
+                data,
+                List {
+                    text: (),
+                    item: vec![(); 2],
                 }
             );
         }
@@ -2883,6 +2935,29 @@ mod variable_name {
             );
         }
 
+        #[test]
+        fn text_and_value() {
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                #[serde(rename = "$text")]
+                text: (),
+                #[serde(rename = "$value")]
+                value: [(); 2],
+            }
+
+            from_str::<List>(
+                r#"
+                <root>
+                    <item/>
+                    <item/>
+                    text
+                    <![CDATA[cdata]]>
+                </root>
+                "#,
+            )
+            .unwrap();
+        }
+
         /// Checks that sequences represented by elements can contain sequences,
         /// represented by `xs:list`s
         mod xs_list {
@@ -3927,6 +4002,37 @@ mod variable_name {
                 "#,
             )
             .unwrap_err();
+        }
+
+        #[test]
+        fn text_and_value() {
+            #[derive(Debug, PartialEq, Deserialize)]
+            struct List {
+                #[serde(rename = "$text")]
+                text: (),
+                #[serde(rename = "$value")]
+                value: Vec<()>,
+            }
+
+            let data: List = from_str(
+                r#"
+                <root>
+                    <item/>
+                    <item/>
+                    text
+                    <![CDATA[cdata]]>
+                </root>
+                "#,
+            )
+            .unwrap();
+
+            assert_eq!(
+                data,
+                List {
+                    text: (),
+                    value: vec![(); 2],
+                }
+            );
         }
 
         /// Checks that sequences represented by elements can contain sequences,


### PR DESCRIPTION
This PR fixes two problems:
- Text events (including CDATA) should be skipped if they is overlapped with elements with fixed name (as reported in #868)
- Related: if struct have both `$text` and `$value` special keys, text events should be mapped to the `$text` field

Fixes #868 