### PR TITLE
Bump `criterion` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,12 @@ tokio = { version = "1.10", optional = true, default-features = false, features 
 memchr = "2.1"
 
 [dev-dependencies]
-criterion = "0.4"
+# msrv workflow uses `cargo check` which triesto resolvee all dependencies, even
+# not used (for example, when calling `cargo check --lib` only `dependencies` is
+# required, `dev-dependencies` are no used). `criterion` 0.6 has msrv = 1.80, so
+# we cannot check minimal versions with it. We allow to use `criterion` 0.4 for that
+# See https://github.com/rust-lang/cargo/issues/10958
+criterion = ">=0.4,<0.7"
 pretty_assertions = "1.4"
 regex = "1"
 # https://github.com/serde-rs/serde/issues/1904 is fixed since 1.0.206

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -2,6 +2,7 @@ use criterion::{self, criterion_group, criterion_main, Criterion, Throughput};
 use quick_xml::events::Event;
 use quick_xml::reader::{NsReader, Reader};
 use quick_xml::Result as XmlResult;
+use std::hint::black_box;
 
 static RPM_PRIMARY: &str = include_str!("../tests/documents/rpm_primary.xml");
 static RPM_PRIMARY2: &str = include_str!("../tests/documents/rpm_primary2.xml");
@@ -47,17 +48,17 @@ static INPUTS: &[(&str, &str)] = &[
 fn parse_document_from_str(doc: &str) -> XmlResult<()> {
     let mut r = Reader::from_str(doc);
     loop {
-        match criterion::black_box(r.read_event()?) {
+        match black_box(r.read_event()?) {
             Event::Start(e) | Event::Empty(e) => {
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
+                    black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             Event::Text(e) => {
-                criterion::black_box(e.decode()?);
+                black_box(e.decode()?);
             }
             Event::CData(e) => {
-                criterion::black_box(e.into_inner());
+                black_box(e.into_inner());
             }
             Event::End(_) => (),
             Event::Eof => break,
@@ -72,17 +73,17 @@ fn parse_document_from_bytes(doc: &[u8]) -> XmlResult<()> {
     let mut r = Reader::from_reader(doc);
     let mut buf = Vec::new();
     loop {
-        match criterion::black_box(r.read_event_into(&mut buf)?) {
+        match black_box(r.read_event_into(&mut buf)?) {
             Event::Start(e) | Event::Empty(e) => {
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
+                    black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             Event::Text(e) => {
-                criterion::black_box(e.decode()?);
+                black_box(e.decode()?);
             }
             Event::CData(e) => {
-                criterion::black_box(e.into_inner());
+                black_box(e.into_inner());
             }
             Event::End(_) => (),
             Event::Eof => break,
@@ -97,20 +98,20 @@ fn parse_document_from_bytes(doc: &[u8]) -> XmlResult<()> {
 fn parse_document_from_str_with_namespaces(doc: &str) -> XmlResult<()> {
     let mut r = NsReader::from_str(doc);
     loop {
-        match criterion::black_box(r.read_resolved_event()?) {
+        match black_box(r.read_resolved_event()?) {
             (resolved_ns, Event::Start(e) | Event::Empty(e)) => {
-                criterion::black_box(resolved_ns);
+                black_box(resolved_ns);
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
+                    black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             (resolved_ns, Event::Text(e)) => {
-                criterion::black_box(e.decode()?);
-                criterion::black_box(resolved_ns);
+                black_box(e.decode()?);
+                black_box(resolved_ns);
             }
             (resolved_ns, Event::CData(e)) => {
-                criterion::black_box(e.into_inner());
-                criterion::black_box(resolved_ns);
+                black_box(e.into_inner());
+                black_box(resolved_ns);
             }
             (_, Event::End(_)) => (),
             (_, Event::Eof) => break,
@@ -125,20 +126,20 @@ fn parse_document_from_bytes_with_namespaces(doc: &[u8]) -> XmlResult<()> {
     let mut r = NsReader::from_reader(doc);
     let mut buf = Vec::new();
     loop {
-        match criterion::black_box(r.read_resolved_event_into(&mut buf)?) {
+        match black_box(r.read_resolved_event_into(&mut buf)?) {
             (resolved_ns, Event::Start(e) | Event::Empty(e)) => {
-                criterion::black_box(resolved_ns);
+                black_box(resolved_ns);
                 for attr in e.attributes() {
-                    criterion::black_box(attr?.decode_and_unescape_value(r.decoder())?);
+                    black_box(attr?.decode_and_unescape_value(r.decoder())?);
                 }
             }
             (resolved_ns, Event::Text(e)) => {
-                criterion::black_box(e.decode()?);
-                criterion::black_box(resolved_ns);
+                black_box(e.decode()?);
+                black_box(resolved_ns);
             }
             (resolved_ns, Event::CData(e)) => {
-                criterion::black_box(e.into_inner());
-                criterion::black_box(resolved_ns);
+                black_box(e.into_inner());
+                black_box(resolved_ns);
             }
             (_, Event::End(_)) => (),
             (_, Event::Eof) => break,

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -4,6 +4,7 @@ use quick_xml::escape::{escape, unescape};
 use quick_xml::events::Event;
 use quick_xml::name::QName;
 use quick_xml::reader::{NsReader, Reader};
+use std::hint::black_box;
 
 static SAMPLE: &str = include_str!("../tests/documents/sample_rss.xml");
 static PLAYERS: &str = include_str!("../tests/documents/players.xml");
@@ -31,7 +32,7 @@ fn read_event(c: &mut Criterion) {
         b.iter(|| {
             let mut r = Reader::from_str(SAMPLE);
             r.config_mut().check_end_names = false;
-            let mut count = criterion::black_box(0);
+            let mut count = black_box(0);
             loop {
                 match r.read_event() {
                     Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
@@ -52,7 +53,7 @@ fn read_event(c: &mut Criterion) {
             let config = r.config_mut();
             config.trim_text(true);
             config.check_end_names = false;
-            let mut count = criterion::black_box(0);
+            let mut count = black_box(0);
             loop {
                 match r.read_event() {
                     Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
@@ -77,7 +78,7 @@ fn read_resolved_event_into(c: &mut Criterion) {
         b.iter(|| {
             let mut r = NsReader::from_str(SAMPLE);
             r.config_mut().check_end_names = false;
-            let mut count = criterion::black_box(0);
+            let mut count = black_box(0);
             loop {
                 match r.read_resolved_event() {
                     Ok((_, Event::Start(_))) | Ok((_, Event::Empty(_))) => count += 1,
@@ -98,7 +99,7 @@ fn read_resolved_event_into(c: &mut Criterion) {
             let config = r.config_mut();
             config.trim_text(true);
             config.check_end_names = false;
-            let mut count = criterion::black_box(0);
+            let mut count = black_box(0);
             loop {
                 match r.read_resolved_event() {
                     Ok((_, Event::Start(_))) | Ok((_, Event::Empty(_))) => count += 1,
@@ -123,7 +124,7 @@ fn one_event(c: &mut Criterion) {
         let src = format!(r#"<hello target="{}">"#, "world".repeat(512 / 5));
         b.iter(|| {
             let mut r = Reader::from_str(&src);
-            let mut nbtxt = criterion::black_box(0);
+            let mut nbtxt = black_box(0);
             let config = r.config_mut();
             config.trim_text(true);
             config.check_end_names = false;
@@ -140,7 +141,7 @@ fn one_event(c: &mut Criterion) {
         let src = format!(r#"<!-- hello "{}" -->"#, "world".repeat(512 / 5));
         b.iter(|| {
             let mut r = Reader::from_str(&src);
-            let mut nbtxt = criterion::black_box(0);
+            let mut nbtxt = black_box(0);
             let config = r.config_mut();
             config.trim_text(true);
             config.check_end_names = false;
@@ -157,7 +158,7 @@ fn one_event(c: &mut Criterion) {
         let src = format!(r#"<![CDATA[hello "{}"]]>"#, "world".repeat(512 / 5));
         b.iter(|| {
             let mut r = Reader::from_str(&src);
-            let mut nbtxt = criterion::black_box(0);
+            let mut nbtxt = black_box(0);
             let config = r.config_mut();
             config.trim_text(true);
             config.check_end_names = false;
@@ -179,7 +180,7 @@ fn attributes(c: &mut Criterion) {
         b.iter(|| {
             let mut r = Reader::from_str(PLAYERS);
             r.config_mut().check_end_names = false;
-            let mut count = criterion::black_box(0);
+            let mut count = black_box(0);
             loop {
                 match r.read_event() {
                     Ok(Event::Empty(e)) => {
@@ -200,7 +201,7 @@ fn attributes(c: &mut Criterion) {
         b.iter(|| {
             let mut r = Reader::from_str(PLAYERS);
             r.config_mut().check_end_names = false;
-            let mut count = criterion::black_box(0);
+            let mut count = black_box(0);
             loop {
                 match r.read_event() {
                     Ok(Event::Empty(e)) => {
@@ -221,7 +222,7 @@ fn attributes(c: &mut Criterion) {
         b.iter(|| {
             let mut r = Reader::from_str(PLAYERS);
             r.config_mut().check_end_names = false;
-            let mut count = criterion::black_box(0);
+            let mut count = black_box(0);
             loop {
                 match r.read_event() {
                     Ok(Event::Empty(e)) if e.name() == QName(b"player") => {
@@ -251,20 +252,20 @@ fn escaping(c: &mut Criterion) {
 
     group.bench_function("no_chars_to_escape_long", |b| {
         b.iter(|| {
-            criterion::black_box(escape(LOREM_IPSUM_TEXT));
+            black_box(escape(LOREM_IPSUM_TEXT));
         })
     });
 
     group.bench_function("no_chars_to_escape_short", |b| {
         b.iter(|| {
-            criterion::black_box(escape("just bit of text"));
+            black_box(escape("just bit of text"));
         })
     });
 
     group.bench_function("escaped_chars_short", |b| {
         b.iter(|| {
-            criterion::black_box(escape("age > 72 && age < 21"));
-            criterion::black_box(escape("\"what's that?\""));
+            black_box(escape("age > 72 && age < 21"));
+            black_box(escape("\"what's that?\""));
         })
     });
 
@@ -285,7 +286,7 @@ volutpat sed cras ornare arcu dui vivamus arcu. Cursus in hac habitasse platea d
 purus. Consequat id porta nibh venenatis cras sed felis.";
 
         b.iter(|| {
-            criterion::black_box(escape(lorem_ipsum_with_escape_chars));
+            black_box(escape(lorem_ipsum_with_escape_chars));
         })
     });
     group.finish();
@@ -297,31 +298,31 @@ fn unescaping(c: &mut Criterion) {
 
     group.bench_function("no_chars_to_unescape_long", |b| {
         b.iter(|| {
-            criterion::black_box(unescape(LOREM_IPSUM_TEXT)).unwrap();
+            black_box(unescape(LOREM_IPSUM_TEXT)).unwrap();
         })
     });
 
     group.bench_function("no_chars_to_unescape_short", |b| {
         b.iter(|| {
-            criterion::black_box(unescape("just a bit of text")).unwrap();
+            black_box(unescape("just a bit of text")).unwrap();
         })
     });
 
     group.bench_function("char_reference", |b| {
         b.iter(|| {
             let text = "prefix &#34;some stuff&#34;,&#x22;more stuff&#x22;";
-            criterion::black_box(unescape(text)).unwrap();
+            black_box(unescape(text)).unwrap();
             let text = "&#38;&#60;";
-            criterion::black_box(unescape(text)).unwrap();
+            black_box(unescape(text)).unwrap();
         })
     });
 
     group.bench_function("entity_reference", |b| {
         b.iter(|| {
             let text = "age &gt; 72 &amp;&amp; age &lt; 21";
-            criterion::black_box(unescape(text)).unwrap();
+            black_box(unescape(text)).unwrap();
             let text = "&quot;what&apos;s that?&quot;";
-            criterion::black_box(unescape(text)).unwrap();
+            black_box(unescape(text)).unwrap();
         })
     });
 
@@ -342,7 +343,7 @@ volutpat sed cras ornare arcu dui vivamus arcu. Cursus in hac habitasse platea d
 purus. Consequat id porta nibh venenatis cras sed felis.";
 
         b.iter(|| {
-            criterion::black_box(unescape(text)).unwrap();
+            black_box(unescape(text)).unwrap();
         })
     });
     group.finish();


### PR DESCRIPTION
Built and tested, 

please note: I haven't run benches or MSRV check locally

`criterion::black_box` is replaced to follow directions in deprecation message `Deprecated: use std::hint::black_box() instead`