### PR TITLE
Update `compare` project to latest versions

### DIFF
--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -29,5 +29,9 @@ serde_derive = "1.0"
 pretty_assertions = "1.4"
 
 [[bench]]
-name = "bench"
+name = "low-level"
+harness = false
+
+[[bench]]
+name = "serde"
 harness = false

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -13,11 +13,11 @@ maybe_xml = "0.10.1"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
 rusty_xml = { version = "0.3", package = "RustyXML" }
+serde-xml-rs = "0.8"
 xml_oxide = "0.3"
 xml-rs = "0.8"
 xml5ever = "0.17"
 xmlparser = "0.13"
-serde-xml-rs = "0.6"
 # Do not use "derive" feature, because it slowdown compilation
 # See https://github.com/serde-rs/serde/pull/2588
 serde = "1.0"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.6", features = ["html_reports"] }
 maybe_xml = "0.10.1"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -10,7 +10,10 @@ edition = "2021"
 [dev-dependencies]
 criterion = { version = "0.6", features = ["html_reports"] }
 markup5ever = "0.16"
-maybe_xml = "0.10.1"
+# maybe_xml 0.11 regressed perfomance by x2, and because this was the fastest
+# XML parser, we keep benchmarking version 0.10 as well
+maybe_xml_0_10 = { version = "0.10", package = "maybe_xml" }
+maybe_xml = "0.11"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
 rusty_xml = { version = "0.3", package = "RustyXML" }

--- a/compare/Cargo.toml
+++ b/compare/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [dev-dependencies]
 criterion = { version = "0.6", features = ["html_reports"] }
+markup5ever = "0.16"
 maybe_xml = "0.10.1"
 quick-xml = { path = "..", features = ["serialize"] }
 rapid-xml = "0.2"
@@ -16,7 +17,7 @@ rusty_xml = { version = "0.3", package = "RustyXML" }
 serde-xml-rs = "0.8"
 xml_oxide = "0.3"
 xml-rs = "0.8"
-xml5ever = "0.17"
+xml5ever = "0.22"
 xmlparser = "0.13"
 # Do not use "derive" feature, because it slowdown compilation
 # See https://github.com/serde-rs/serde/pull/2588

--- a/compare/README.md
+++ b/compare/README.md
@@ -1,0 +1,11 @@
+# XML libraries benchmark suite
+
+Standalone project to benchmark different implementations of XML parser. To run benchmark
+(assuming we are in `quick_xml` checkout directory):
+
+```
+cd compare
+cargo bench
+```
+
+The results can be obserded in HTML at `./compare/target/criterion/report/index.html`.

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -274,24 +274,24 @@ fn serde_comparison(c: &mut Criterion) {
         enclosure: Option<E>,
     }
 
+    #[derive(Debug, Deserialize)]
+    struct Enclosure {
+        #[serde(rename = "@url")]
+        url: String,
+
+        #[serde(rename = "@length")]
+        length: String,
+
+        #[serde(rename = "@type")]
+        typ: String,
+    }
+
     group.throughput(Throughput::Bytes(SAMPLE_RSS.len() as u64));
 
     group.bench_with_input(
         BenchmarkId::new("quick_xml", "sample_rss.xml"),
         SAMPLE_RSS,
         |b, input| {
-            #[derive(Debug, Deserialize)]
-            struct Enclosure {
-                #[serde(rename = "@url")]
-                url: String,
-
-                #[serde(rename = "@length")]
-                length: String,
-
-                #[serde(rename = "@type")]
-                typ: String,
-            }
-
             b.iter(|| {
                 let rss: Rss<Enclosure> = black_box(quick_xml::de::from_str(input).unwrap());
                 assert_eq!(rss.channel.items.len(), 99);
@@ -316,17 +316,6 @@ fn serde_comparison(c: &mut Criterion) {
         BenchmarkId::new("xml_rs", "sample_rss.xml"),
         SAMPLE_RSS,
         |b, input| {
-            // serde_xml_rs supports @-notation for attributes, but applies it only
-            // for serialization
-            #[derive(Debug, Deserialize)]
-            struct Enclosure {
-                url: String,
-                length: String,
-
-                #[serde(rename = "type")]
-                typ: String,
-            }
-
             b.iter(|| {
                 let rss: Rss<Enclosure> = black_box(serde_xml_rs::from_str(input).unwrap());
                 assert_eq!(rss.channel.items.len(), 99);

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -97,7 +97,29 @@ fn low_level_comparison(c: &mut Criterion) {
         );
 
         group.bench_with_input(
-            BenchmarkId::new("maybe_xml", filename),
+            BenchmarkId::new("maybe_xml:0.10", filename),
+            *data,
+            |b, input| {
+                use maybe_xml_0_10::token::Ty;
+                use maybe_xml_0_10::Reader;
+
+                b.iter(|| {
+                    let reader = Reader::from_str(input);
+
+                    let mut count = black_box(0);
+                    for token in reader.into_iter() {
+                        match token.ty() {
+                            Ty::StartTag(_) | Ty::EmptyElementTag(_) => count += 1,
+                            _ => (),
+                        }
+                    }
+                    assert_eq!(count, total_tags, "Overall tag count in {}", filename);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("maybe_xml:0.11", filename),
             *data,
             |b, input| {
                 use maybe_xml::token::Ty;

--- a/compare/benches/bench.rs
+++ b/compare/benches/bench.rs
@@ -4,6 +4,7 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 use serde::Deserialize;
 use serde_xml_rs;
+use std::hint::black_box;
 use xml::reader::{EventReader, XmlEvent};
 
 static RPM_PRIMARY: &str = include_str!("../../tests/documents/rpm_primary.xml");
@@ -60,7 +61,7 @@ fn low_level_comparison(c: &mut Criterion) {
                 b.iter(|| {
                     let mut reader = Reader::from_str(input);
                     reader.config_mut().check_end_names = false;
-                    let mut count = criterion::black_box(0);
+                    let mut count = black_box(0);
                     loop {
                         match reader.read_event() {
                             Ok(Event::Start(_)) | Ok(Event::Empty(_)) => count += 1,
@@ -80,7 +81,7 @@ fn low_level_comparison(c: &mut Criterion) {
                 b.iter(|| {
                     let mut reader = Reader::from_reader(input.as_bytes());
                     reader.config_mut().check_end_names = false;
-                    let mut count = criterion::black_box(0);
+                    let mut count = black_box(0);
                     let mut buf = Vec::new();
                     loop {
                         match reader.read_event_into(&mut buf) {
@@ -105,7 +106,7 @@ fn low_level_comparison(c: &mut Criterion) {
                 b.iter(|| {
                     let reader = Reader::from_str(input);
 
-                    let mut count = criterion::black_box(0);
+                    let mut count = black_box(0);
                     for token in reader.into_iter() {
                         match token.ty() {
                             Ty::StartTag(_) | Ty::EmptyElementTag(_) => count += 1,
@@ -124,7 +125,7 @@ fn low_level_comparison(c: &mut Criterion) {
         //     b.iter(|| {
         //         let mut r = Parser::new(input.as_bytes());
 
-        //         let mut count = criterion::black_box(0);
+        //         let mut count = black_box(0);
         //         loop {
         //             // Makes no progress if error is returned, so need unwrap()
         //             match r.next().unwrap().code() {
@@ -147,7 +148,7 @@ fn low_level_comparison(c: &mut Criterion) {
                 use xmlparser::{Token, Tokenizer};
 
                 b.iter(|| {
-                    let mut count = criterion::black_box(0);
+                    let mut count = black_box(0);
                     for token in Tokenizer::from(input) {
                         match token {
                             Ok(Token::ElementStart { .. }) => count += 1,
@@ -166,7 +167,7 @@ fn low_level_comparison(c: &mut Criterion) {
                 let mut r = Parser::new();
                 r.feed_str(input);
 
-                let mut count = criterion::black_box(0);
+                let mut count = black_box(0);
                 for event in r {
                     match event.unwrap() {
                         Event::ElementStart(_) => count += 1,
@@ -187,7 +188,7 @@ fn low_level_comparison(c: &mut Criterion) {
                 b.iter(|| {
                     let mut r = Parser::from_reader(input.as_bytes());
 
-                    let mut count = criterion::black_box(0);
+                    let mut count = black_box(0);
                     loop {
                         // Makes no progress if error is returned, so need unwrap()
                         match r.read_event().unwrap() {
@@ -219,7 +220,7 @@ fn low_level_comparison(c: &mut Criterion) {
             // Copied from xml5ever benchmarks
             // https://github.com/servo/html5ever/blob/429f23943b24f739b78f4d703620d7b1b526475b/xml5ever/benches/xml5ever.rs
             b.iter(|| {
-                let sink = criterion::black_box(Sink(0));
+                let sink = black_box(Sink(0));
                 let mut tok = XmlTokenizer::new(sink, Default::default());
                 let mut buffer = BufferQueue::new();
                 buffer.push_back(input.into());
@@ -233,7 +234,7 @@ fn low_level_comparison(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("xml_rs", filename), *data, |b, input| {
             b.iter(|| {
                 let r = EventReader::new(input.as_bytes());
-                let mut count = criterion::black_box(0);
+                let mut count = black_box(0);
                 for e in r {
                     if let Ok(XmlEvent::StartElement { .. }) = e {
                         count += 1;
@@ -292,8 +293,7 @@ fn serde_comparison(c: &mut Criterion) {
             }
 
             b.iter(|| {
-                let rss: Rss<Enclosure> =
-                    criterion::black_box(quick_xml::de::from_str(input).unwrap());
+                let rss: Rss<Enclosure> = black_box(quick_xml::de::from_str(input).unwrap());
                 assert_eq!(rss.channel.items.len(), 99);
             })
         },
@@ -307,7 +307,7 @@ fn serde_comparison(c: &mut Criterion) {
         b.iter(|| {
             let mut r = Parser::new(input.as_bytes());
             let mut de = Deserializer::new(&mut r).unwrap();
-            let rss = criterion::black_box(Rss::deserialize(&mut de).unwrap());
+            let rss = black_box(Rss::deserialize(&mut de).unwrap());
             assert_eq!(rss.channel.items.len(), 99);
         });
     });*/
@@ -328,8 +328,7 @@ fn serde_comparison(c: &mut Criterion) {
             }
 
             b.iter(|| {
-                let rss: Rss<Enclosure> =
-                    criterion::black_box(serde_xml_rs::from_str(input).unwrap());
+                let rss: Rss<Enclosure> = black_box(serde_xml_rs::from_str(input).unwrap());
                 assert_eq!(rss.channel.items.len(), 99);
             })
         },

--- a/compare/benches/low-level.rs
+++ b/compare/benches/low-level.rs
@@ -2,8 +2,6 @@ use criterion::{self, criterion_group, criterion_main, BenchmarkId, Criterion, T
 use pretty_assertions::assert_eq;
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
-use serde::Deserialize;
-use serde_xml_rs;
 use std::hint::black_box;
 use xml::reader::{EventReader, XmlEvent};
 
@@ -283,83 +281,5 @@ fn low_level_comparison(c: &mut Criterion) {
     group.finish();
 }
 
-/// Runs benchmarks for several XML libraries using serde deserialization
-#[allow(dead_code)] // We do not use structs
-fn serde_comparison(c: &mut Criterion) {
-    let mut group = c.benchmark_group("serde");
-
-    #[derive(Debug, Deserialize)]
-    struct Rss<E> {
-        channel: Channel<E>,
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct Channel<E> {
-        title: String,
-        #[serde(rename = "item", default = "Vec::new")]
-        items: Vec<Item<E>>,
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct Item<E> {
-        title: String,
-        link: String,
-        #[serde(rename = "pubDate")]
-        pub_date: String,
-        enclosure: Option<E>,
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct Enclosure {
-        #[serde(rename = "@url")]
-        url: String,
-
-        #[serde(rename = "@length")]
-        length: String,
-
-        #[serde(rename = "@type")]
-        typ: String,
-    }
-
-    group.throughput(Throughput::Bytes(SAMPLE_RSS.len() as u64));
-
-    group.bench_with_input(
-        BenchmarkId::new("quick_xml", "sample_rss.xml"),
-        SAMPLE_RSS,
-        |b, input| {
-            b.iter(|| {
-                let rss: Rss<Enclosure> = black_box(quick_xml::de::from_str(input).unwrap());
-                assert_eq!(rss.channel.items.len(), 99);
-            })
-        },
-    );
-
-    /* NOTE: Most parts of deserializer are not implemented yet, so benchmark failed
-    group.bench_with_input(BenchmarkId::new("rapid-xml", "sample_rss.xml"), SAMPLE_RSS, |b, input| {
-        use rapid_xml::de::Deserializer;
-        use rapid_xml::parser::Parser;
-
-        b.iter(|| {
-            let mut r = Parser::new(input.as_bytes());
-            let mut de = Deserializer::new(&mut r).unwrap();
-            let rss = black_box(Rss::deserialize(&mut de).unwrap());
-            assert_eq!(rss.channel.items.len(), 99);
-        });
-    });*/
-
-    group.bench_with_input(
-        BenchmarkId::new("xml_rs", "sample_rss.xml"),
-        SAMPLE_RSS,
-        |b, input| {
-            b.iter(|| {
-                let rss: Rss<Enclosure> = black_box(serde_xml_rs::from_str(input).unwrap());
-                assert_eq!(rss.channel.items.len(), 99);
-            })
-        },
-    );
-
-    group.finish();
-}
-
-criterion_group!(benches, low_level_comparison, serde_comparison);
+criterion_group!(benches, low_level_comparison);
 criterion_main!(benches);

--- a/compare/benches/serde.rs
+++ b/compare/benches/serde.rs
@@ -1,0 +1,89 @@
+use criterion::{self, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use pretty_assertions::assert_eq;
+use serde::Deserialize;
+use serde_xml_rs;
+use std::hint::black_box;
+
+static SAMPLE_RSS: &str = include_str!("../../tests/documents/sample_rss.xml");
+
+/// Runs benchmarks for several XML libraries using serde deserialization
+#[allow(dead_code)] // We do not use structs
+fn serde_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("serde");
+
+    #[derive(Debug, Deserialize)]
+    struct Rss<E> {
+        channel: Channel<E>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Channel<E> {
+        title: String,
+        #[serde(rename = "item", default = "Vec::new")]
+        items: Vec<Item<E>>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Item<E> {
+        title: String,
+        link: String,
+        #[serde(rename = "pubDate")]
+        pub_date: String,
+        enclosure: Option<E>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Enclosure {
+        #[serde(rename = "@url")]
+        url: String,
+
+        #[serde(rename = "@length")]
+        length: String,
+
+        #[serde(rename = "@type")]
+        typ: String,
+    }
+
+    group.throughput(Throughput::Bytes(SAMPLE_RSS.len() as u64));
+
+    group.bench_with_input(
+        BenchmarkId::new("quick_xml", "sample_rss.xml"),
+        SAMPLE_RSS,
+        |b, input| {
+
+            b.iter(|| {
+                let rss: Rss<Enclosure> = black_box(quick_xml::de::from_str(input).unwrap());
+                assert_eq!(rss.channel.items.len(), 99);
+            })
+        },
+    );
+
+    /* NOTE: Most parts of deserializer are not implemented yet, so benchmark failed
+    group.bench_with_input(BenchmarkId::new("rapid-xml", "sample_rss.xml"), SAMPLE_RSS, |b, input| {
+        use rapid_xml::de::Deserializer;
+        use rapid_xml::parser::Parser;
+
+        b.iter(|| {
+            let mut r = Parser::new(input.as_bytes());
+            let mut de = Deserializer::new(&mut r).unwrap();
+            let rss = black_box(Rss::deserialize(&mut de).unwrap());
+            assert_eq!(rss.channel.items.len(), 99);
+        });
+    });*/
+
+    group.bench_with_input(
+        BenchmarkId::new("xml_rs", "sample_rss.xml"),
+        SAMPLE_RSS,
+        |b, input| {
+            b.iter(|| {
+                let rss: Rss<Enclosure> = black_box(serde_xml_rs::from_str(input).unwrap());
+                assert_eq!(rss.channel.items.len(), 99);
+            })
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, serde_comparison);
+criterion_main!(benches);

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -220,8 +220,8 @@ where
     /// Used to map elements with `xsi:nil` attribute set to true to `None` in optional contexts.
     ///
     /// We need to handle two attributes:
-    /// - on parent element: <map xsi:nil="true"><foo/></map>
-    /// - on this element:   <map><foo xsi:nil="true"/></map>
+    /// - on parent element: `<map xsi:nil="true"><foo/></map>`
+    /// - on this element:   `<map><foo xsi:nil="true"/></map>`
     ///
     /// We check parent element too because `xsi:nil` affects only nested elements of the
     /// tag where it is defined. We can map structure with fields mapped to attributes to


### PR DESCRIPTION
Allow to benchmarking latest available versions. Because performance of maybe_xml degraded by 2 times, I kept version 0.10 which was (and still is) the fastest XML parser.