### PR TITLE
Allow attributes in the `xml` namespace to roundtrip with serde

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,7 @@ types should preserve whitespace, while all other primitives have collapse behav
 - [#868]: Allow to have both `$text` and `$value` special fields in one struct. Previously
   any text will be recognized as `$value` field even when `$text` field is also presented.
 - [#868]: Skip text events when deserialize a sequence of items overlapped with text (including CDATA).
+- [#841]: Do not strip `xml` prefix from the attributes when map them to struct fields in `Deserializer`.
 
 ### Misc Changes
 
@@ -50,6 +51,7 @@ types should preserve whitespace, while all other primitives have collapse behav
 
 [#285]: https://github.com/tafia/quick-xml/issues/285
 [#766]: https://github.com/tafia/quick-xml/pull/766
+[#841]: https://github.com/tafia/quick-xml/issues/841
 [#863]: https://github.com/tafia/quick-xml/pull/863
 [#868]: https://github.com/tafia/quick-xml/pull/868
 [general entity]: https://www.w3.org/TR/xml11/#gen-entity

--- a/src/name.rs
+++ b/src/name.rs
@@ -257,6 +257,18 @@ impl<'a> Prefix<'a> {
     pub const fn into_inner(self) -> &'a [u8] {
         self.0
     }
+
+    /// Checks if this prefix is a special prefix `xml`.
+    #[inline(always)]
+    pub const fn is_xml(&self) -> bool {
+        matches!(self.0, b"xml")
+    }
+
+    /// Checks if this prefix is a special prefix `xmlns`.
+    #[inline(always)]
+    pub const fn is_xmlns(&self) -> bool {
+        matches!(self.0, b"xmlns")
+    }
 }
 impl<'a> Debug for Prefix<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -571,6 +571,27 @@ fn issue683() {
     );
 }
 
+/// Regression test for https://github.com/tafia/quick-xml/issues/841.
+/// `xml:`-attributes should be able to roundtrip serialization - deserialization
+#[test]
+fn issue841() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct ElementWithXmlLang {
+        #[serde(rename = "$text")]
+        content: String,
+        #[serde(rename = "@xml:lang")]
+        language: String,
+    }
+
+    let value = ElementWithXmlLang {
+        content: "content".to_string(),
+        language: "en-US".to_string(),
+    };
+    let sr = to_string(&value).unwrap();
+    let ds: ElementWithXmlLang = from_str(&sr).unwrap();
+    assert_eq!(ds, value);
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/868.
 #[test]
 fn issue868() {


### PR DESCRIPTION
This fixes [#841](https://github.com/tafia/quick-xml/issues/841).

When deserializing attribute names, this version prevents the `xml:` namespace prefix to be split off.

I am admittedly not familiar with XML namespaces at all and have taken [this reasoning](https://github.com/tafia/quick-xml/issues/841#issuecomment-2600865912) at face value. If this is not a desirable feature after all, please let me know!