### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ loop {
                 _ => (),
             }
         }
-        Ok(Event::Text(e)) => txt.push(e.unescape().unwrap().into_owned()),
+        Ok(Event::Text(e)) => txt.push(e.decode().unwrap().into_owned()),
 
         // There are several other `Event`s we do not consider here
         _ => (),


### PR DESCRIPTION
Hi, thank you for creating the crate.
It looks like unescape has been replaced with decode in the latest version 0.38.0, 
- https://github.com/tafia/quick-xml/pull/766
  - https://github.com/tafia/quick-xml/commit/4c8100d1c45d06b92c8df2f36ea06062ab77197d

so I’ve updated the README example accordingly.
Thank you for your time.