### PR TITLE
XML signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ encoding_rs = { version = "0.8", optional = true }
 serde = { version = ">=1.0.139", optional = true }
 tokio = { version = "1.10", optional = true, default-features = false, features = ["io-util"] }
 memchr = "2.1"
+base64 = { version = "0.22", optional = true }
+sha2 = { version = "0.10", optional = true }
+signature = { version = "2", optional = true }
 
 [dev-dependencies]
 # msrv workflow uses `cargo check` which triesto resolvee all dependencies, even
@@ -41,6 +44,7 @@ serde_derive = { version = "1.0.206" }
 serde-value = "0.7"
 tokio = { version = "1.21", default-features = false, features = ["macros", "rt"] }
 tokio-test = "0.4"
+rsa = { version = "0.9", default-features = false, features = ["sha2"] }
 
 [lib]
 bench = false
@@ -63,6 +67,7 @@ default = []
 ##
 ## [reading events]: crate::reader::Reader::read_event_into_async
 async-tokio = ["tokio"]
+crypto = ["base64", "sha2", "signature"]
 
 ## Enables support of non-UTF-8 encoded documents. Encoding will be inferred from
 ## the XML declaration if it is found, otherwise UTF-8 is assumed.
@@ -255,6 +260,11 @@ path = "tests/serde-migrated.rs"
 name = "serde-issues"
 required-features = ["serialize"]
 path = "tests/serde-issues.rs"
+
+[[test]]
+name = "crypto"
+required-features = ["crypto"]
+path = "tests/crypto.rs"
 
 [[example]]
 name = "read_nodes_serde"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,132 @@
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use sha2::{Digest as ShaDigest, Sha256, Sha512};
+use signature::Signer;
+use std::io::Cursor;
+
+use crate::events::Event;
+use crate::{Reader, Writer};
+
+/// Supported digest algorithms.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DigestMethod {
+    /// SHA256 digest
+    Sha256,
+    /// SHA512 digest
+    Sha512,
+}
+
+/// Trait describing digest capabilities for signers.
+pub trait Digest {
+    /// Returns the digest algorithm used when signing.
+    fn digest_method(&self) -> DigestMethod;
+}
+
+#[doc(hidden)]
+pub fn canonicalize(xml: &str) -> crate::Result<String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf)? {
+            Event::Start(e) => {
+                let mut elem = e.into_owned();
+                let mut attrs: Vec<(Vec<u8>, Vec<u8>)> = elem
+                    .attributes()
+                    .map(|a| {
+                        let a = a?;
+                        Ok((a.key.as_ref().to_vec(), a.value.into_owned()))
+                    })
+                    .collect::<crate::Result<_>>()?;
+                attrs.sort_by(|a, b| a.0.cmp(&b.0));
+                elem.clear_attributes();
+                for (k, v) in attrs {
+                    elem.push_attribute((k.as_slice(), v.as_slice()));
+                }
+                writer.write_event(Event::Start(elem))?;
+            }
+            Event::Empty(e) => {
+                let mut elem = e.into_owned();
+                let mut attrs: Vec<(Vec<u8>, Vec<u8>)> = elem
+                    .attributes()
+                    .map(|a| {
+                        let a = a?;
+                        Ok((a.key.as_ref().to_vec(), a.value.into_owned()))
+                    })
+                    .collect::<crate::Result<_>>()?;
+                attrs.sort_by(|a, b| a.0.cmp(&b.0));
+                elem.clear_attributes();
+                for (k, v) in attrs {
+                    elem.push_attribute((k.as_slice(), v.as_slice()));
+                }
+                writer.write_event(Event::Empty(elem))?;
+            }
+            Event::End(e) => {
+                writer.write_event(Event::End(e))?;
+            }
+            Event::Text(e) => {
+                writer.write_event(Event::Text(e))?;
+            }
+            Event::CData(e) => {
+                writer.write_event(Event::CData(e))?;
+            }
+            Event::Comment(_) => {}
+            Event::Eof => break,
+            evt => writer.write_event(evt)?,
+        }
+        buf.clear();
+    }
+    let vec = writer.into_inner().into_inner();
+    Ok(String::from_utf8(vec).expect("canonicalized xml is valid utf-8"))
+}
+
+/// Sign the provided XML document using the given signer.
+pub fn sign_document<S>(xml: &str, signer: S) -> crate::Result<String>
+where
+    S: Signer<Vec<u8>> + Digest,
+{
+    let canonical = canonicalize(xml)?;
+    let digest = match signer.digest_method() {
+        DigestMethod::Sha256 => Sha256::digest(canonical.as_bytes()).to_vec(),
+        DigestMethod::Sha512 => Sha512::digest(canonical.as_bytes()).to_vec(),
+    };
+    let digest_b64 = BASE64.encode(&digest);
+
+    let (sig_method, dig_method) = match signer.digest_method() {
+        DigestMethod::Sha256 => (
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+            "http://www.w3.org/2001/04/xmlenc#sha256",
+        ),
+        DigestMethod::Sha512 => (
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512",
+            "http://www.w3.org/2001/04/xmlenc#sha512",
+        ),
+    };
+
+    let signed_info = format!(
+        "<SignedInfo>\
+            <CanonicalizationMethod Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/>\
+            <SignatureMethod Algorithm=\"{}\"/>\
+            <Reference URI=\"\">\
+                <Transforms>\
+                    <Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/>\
+                    <Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/>\
+                </Transforms>\
+                <DigestMethod Algorithm=\"{}\"/>\
+                <DigestValue>{}</DigestValue>\
+            </Reference>\
+        </SignedInfo>",
+        sig_method, dig_method, digest_b64
+    );
+    let canonical_info = canonicalize(&signed_info)?;
+    let signature = signer.sign(canonical_info.as_bytes());
+    let signature_b64 = BASE64.encode(signature);
+
+    let result = format!(
+        "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\">{}<SignatureValue>{}</SignatureValue></Signature>",
+        signed_info, signature_b64
+    );
+
+    Ok(result)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@
 // docs.rs defines `docsrs` when building documentation
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(feature = "crypto")]
+pub mod crypto;
 #[cfg(feature = "serialize")]
 pub mod de;
 pub mod encoding;
@@ -71,9 +73,13 @@ pub mod utils;
 pub mod writer;
 
 // reexports
+#[cfg(feature = "crypto")]
+pub use crate::crypto::{sign_document, Digest, DigestMethod};
 pub use crate::encoding::Decoder;
 #[cfg(feature = "serialize")]
 pub use crate::errors::serialize::{DeError, SeError};
 pub use crate::errors::{Error, Result};
 pub use crate::reader::{NsReader, Reader};
 pub use crate::writer::{ElementWriter, Writer};
+#[cfg(feature = "crypto")]
+pub use signature::Signer;

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -1,0 +1,63 @@
+use quick_xml::crypto::canonicalize;
+use quick_xml::crypto::{sign_document, Digest, DigestMethod};
+use quick_xml::Signer;
+use rand_core::OsRng;
+use rsa::pkcs1v15::SigningKey;
+use rsa::RsaPrivateKey;
+use sha2::{Sha256, Sha512};
+
+struct Sha256Signer(SigningKey<Sha256>);
+
+impl Digest for Sha256Signer {
+    fn digest_method(&self) -> DigestMethod {
+        DigestMethod::Sha256
+    }
+}
+
+impl Signer<Vec<u8>> for Sha256Signer {
+    fn try_sign(&self, msg: &[u8]) -> signature::Result<Vec<u8>> {
+        Ok(self.0.sign(msg).as_ref().to_vec())
+    }
+}
+
+struct Sha512Signer(SigningKey<Sha512>);
+
+impl Digest for Sha512Signer {
+    fn digest_method(&self) -> DigestMethod {
+        DigestMethod::Sha512
+    }
+}
+
+impl Signer<Vec<u8>> for Sha512Signer {
+    fn try_sign(&self, msg: &[u8]) -> signature::Result<Vec<u8>> {
+        Ok(self.0.sign(msg).as_ref().to_vec())
+    }
+}
+
+#[test]
+fn sign_sha256() {
+    let mut rng = OsRng;
+    let key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+    let signer = Sha256Signer(SigningKey::<Sha256>::new(key));
+    let xml = "<test>hello</test>";
+    let sig = sign_document(xml, signer).unwrap();
+    assert!(sig.contains("SignatureValue"));
+}
+
+#[test]
+fn sign_sha512() {
+    let mut rng = OsRng;
+    let key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+    let signer = Sha512Signer(SigningKey::<Sha512>::new(key));
+    let xml = "<test>hello</test>";
+    let sig = sign_document(xml, signer).unwrap();
+    assert!(sig.contains("rsa-sha512"));
+}
+
+#[test]
+fn canonicalization_sorts_attrs_and_removes_comments() {
+    let xml = r#"<e b="2" a="1"><!--c--><child/></e>"#;
+    let expected = r#"<e a="1" b="2"><child/></e>"#;
+    let out = canonicalize(xml).unwrap();
+    assert_eq!(out, expected);
+}


### PR DESCRIPTION
I wrote a minimal implementation of XML DSIG and wondering if I could get comments or possibly merge this upstream. Full transparency, I used Codex to write this, but have had a few people including myself check it over. 

We've used the Signer trait from RustCrypto to keep the crypto engine as agile as possible. Overall I think it made the implementation flexible but also easy to use. 

Wondering if you see crypto as a part of the quick-xml library, or if this would be something better as its own crate that depended upon quick-xml?