### PR TITLE
feat: support serializing structs into `$value`-named fields

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1577,15 +1577,24 @@
 //! uses that name. This will allow you to switch XML crates more smoothly if required.
 //! </div>
 //!
-//! Representation of primitive types in `$value` does not differ from their
-//! representation in `$text` field. The difference is how sequences are serialized.
-//! `$value` serializes each sequence item as a separate XML element. The name
-//! of that element is taken from serialized type, and because only `enum`s provide
-//! such name (their variant name), only they should be used for such fields.
+//! The representation of primitive types in `$value` does not differ from their
+//! representation in `$text` fields. The difference is how sequences are serialized
+//! and deserialized. `$value` serializes each sequence item as a separate XML element.
+//! How the name of the XML element is chosen depends on the field's type. For
+//! `enum`s, the variant name is used. For `struct`s, the name of the `struct`
+//! is used.
 //!
-//! `$value` fields does not support `struct` types with fields, the serialization
-//! of such types would end with an `Err(Unsupported)`. Unit structs and unit
-//! type `()` serializing to nothing and can be deserialized from any content.
+//! During deserialization, if the `$value` field is an enum, then the variant's
+//! name is matched against. That's **not** the case with structs, however, since
+//! `serde` does not expose type names of nested fields. This does mean that **any**
+//! type could be deserialized into a `$value` struct-type field, so long as the
+//! struct's fields have compatible types (or are captured as text by `String`
+//! or similar-behaving types). This can be handy when using generic types in fields
+//! where one knows in advance what to expect. If you do not know what to expect,
+//! however, prefer an enum with all possible variants.
+//!
+//! Unit structs and unit type `()` serialize to nothing and can be deserialized
+//! from any content.
 //!
 //! Serialization and deserialization of `$value` field performed as usual, except
 //! that name for an XML element will be given by the serialized type, instead of
@@ -1644,6 +1653,38 @@
 //! #     AnyName { field: Enum::B },
 //! #     quick_xml::de::from_str("<root><B/></root>").unwrap(),
 //! # );
+//! ```
+//!
+//! The next example demonstrates how generic types can be used in conjunction
+//! with `$value`-named fields to allow the reuse of wrapping structs. A common
+//! example use case for this feature is SOAP messages, which can be commmonly
+//! found wrapped around `<soapenv:Envelope> ... </soapenv:Envelope>`.
+//!
+//! ```rust
+//! # use serde::Serialize;
+//! # use pretty_assertions::assert_eq;
+//! #
+//! #[derive(Serialize)]
+//! struct Envelope<T> {
+//!     body: Body<T>,
+//! }
+//!
+//! #[derive(Serialize)]
+//! struct Body<T> {
+//!     #[serde(rename = "$value")]
+//!     inner: T,
+//! }
+//!
+//! #[derive(Serialize)]
+//! struct Example {
+//!     a: i32,
+//! }
+//!
+//! assert_eq!(
+//!     quick_xml::se::to_string(&Envelope { body: Body { inner: Example { a: 42 } } }).unwrap(),
+//!     // Notice how `inner` is not present in the XML
+//!     "<Envelope><body><Example><a>42</a></Example></body></Envelope>",
+//! );
 //! ```
 //!
 //! ### Primitives and sequences of primitives

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -1107,14 +1107,18 @@ mod tests {
                     => "<Tuple>first</Tuple>\
                         <Tuple>42</Tuple>");
 
-                // We cannot wrap map or struct in any container and should not
-                // flatten it, so it is impossible to serialize maps and structs
+                // We cannot wrap map in any container and should not
+                // flatten it, so it is impossible to serialize maps
                 err!(map:
                     BTreeMap::from([("$value", BTreeMap::from([("_1", 2), ("_3", 4)]))])
                     => Unsupported("serialization of map types is not supported in `$value` field"));
-                err!(struct_:
-                    BTreeMap::from([("$value", Struct { key: "answer", val: (42, 42) })])
-                    => Unsupported("serialization of struct `Struct` is not supported in `$value` field"));
+                value!(struct_:
+                    Struct { key: "answer", val: (42, 42) }
+                    => "<Struct>\
+                            <key>answer</key>\
+                            <val>42</val>\
+                            <val>42</val>\
+                        </Struct>");
                 value!(enum_struct:
                     Enum::Struct { key: "answer", val: (42, 42) }
                     => "<Struct>\
@@ -1234,8 +1238,8 @@ mod tests {
                     => "<Tuple>first</Tuple>\
                         <Tuple>42</Tuple>");
 
-                // We cannot wrap map or struct in any container and should not
-                // flatten it, so it is impossible to serialize maps and structs
+                // We cannot wrap map in any container and should not
+                // flatten it, so it is impossible to serialize maps
                 err!(map:
                     Value {
                         before: "answer",
@@ -1243,13 +1247,13 @@ mod tests {
                         after: "answer",
                     }
                     => Unsupported("serialization of map types is not supported in `$value` field"));
-                err!(struct_:
-                    Value {
-                        before: "answer",
-                        content: Struct { key: "answer", val: (42, 42) },
-                        after: "answer",
-                    }
-                    => Unsupported("serialization of struct `Struct` is not supported in `$value` field"));
+                value!(struct_:
+                    Struct { key: "answer", val: (42, 42) }
+                    => "<Struct>\
+                            <key>answer</key>\
+                            <val>42</val>\
+                            <val>42</val>\
+                        </Struct>");
                 value!(enum_struct:
                     Enum::Struct { key: "answer", val: (42, 42) }
                     => "<Struct>\
@@ -1830,14 +1834,19 @@ mod tests {
                         <Tuple>first</Tuple>\n  \
                         <Tuple>42</Tuple>\n");
 
-                // We cannot wrap map or struct in any container and should not
-                // flatten it, so it is impossible to serialize maps and structs
+                // We cannot wrap map in any container and should not
+                // flatten it, so it is impossible to serialize maps
                 err!(map:
                     BTreeMap::from([("$value", BTreeMap::from([("_1", 2), ("_3", 4)]))])
                     => Unsupported("serialization of map types is not supported in `$value` field"));
-                err!(struct_:
-                    BTreeMap::from([("$value", Struct { key: "answer", val: (42, 42) })])
-                    => Unsupported("serialization of struct `Struct` is not supported in `$value` field"));
+                value!(struct_:
+                    Struct { key: "answer", val: (42, 42) }
+                    => "\n  \
+                        <Struct>\n    \
+                            <key>answer</key>\n    \
+                            <val>42</val>\n    \
+                            <val>42</val>\n  \
+                        </Struct>\n");
                 value!(enum_struct:
                     Enum::Struct { key: "answer", val: (42, 42) }
                     => "\n  \
@@ -1959,8 +1968,8 @@ mod tests {
                         <Tuple>first</Tuple>\n  \
                         <Tuple>42</Tuple>\n  ");
 
-                // We cannot wrap map or struct in any container and should not
-                // flatten it, so it is impossible to serialize maps and structs
+                // We cannot wrap map in any container and should not
+                // flatten it, so it is impossible to serialize maps
                 err!(map:
                     Value {
                         before: "answer",
@@ -1968,13 +1977,22 @@ mod tests {
                         after: "answer",
                     }
                     => Unsupported("serialization of map types is not supported in `$value` field"));
-                err!(struct_:
+                value!(struct_:
                     Value {
                         before: "answer",
                         content: Struct { key: "answer", val: (42, 42) },
                         after: "answer",
                     }
-                    => Unsupported("serialization of struct `Struct` is not supported in `$value` field"));
+                    => "\n  \
+                        <Value>\n    \
+                            <before>answer</before>\n    \
+                            <Struct>\n      \
+                                <key>answer</key>\n      \
+                                <val>42</val>\n      \
+                                <val>42</val>\n    \
+                            </Struct>\n    \
+                            <after>answer</after>\n  \
+                        </Value>\n  ");
                 value!(enum_struct:
                     Enum::Struct { key: "answer", val: (42, 42) }
                     => "\n  \


### PR DESCRIPTION
## About this PR

This PR implemensts support for serializing `$value`-named struct fields. These fields can already be correctly deserialized, but causes this runtime error when attempted to be serialized:

```
serialization of struct `StructName` is not supported in `$value` field
```

## Rationale

For an integration I'm working on, I've got to consume a relatively slim SOAP API. All requests are expected to be wrapped around `<soapenv:Envelope><soapenv:Body> ... </soapenv:Body></soapenv:Envelope>`. 

This is very similar to the issue in #654, but that could be solved by using enums. However, for various reasons, my specific use case would benefit from using a generic field inside the `SoapEnvBody` struct, like so:

```rust
#[derive(Serialize)]
#[serde(rename = "soapenv:Envelope")]
struct SoapEnvEnvelope<T> {
    #[serde(rename = "soapenv:Body")]
    body: SoapEnvBody<T>,
}

#[derive(Serialize)]
struct SoapEnvBody<T> {
    body: T,
}
```

However, that would produce an unwanted `<body>` tag. To get rid of it, I attempted to use `#[serde(flatten)]`, but that unexpectedly gets rid of one of the inner tags as well. To add to the previous example:

<details>
<summary>Long example</summary>

```rust
#[derive(Serialize)]
#[serde(rename = "soapenv:Envelope")]
struct SoapEnvEnvelope<T> {
    #[serde(rename = "soapenv:Body")]
    body: SoapEnvBody<T>,
}

#[derive(Serialize)]
struct SoapEnvBody<T> {
    #[serde(flatten)]
    body: T,
}

#[derive(Serialize)]
struct A {
    b: B,
}

#[derive(Serialize)]
struct B {
    field: &'static str,
}

println!(
    "{}",
    to_string(&SoapEnvEnvelope {
        body: SoapEnvBody {
            body: A {
                b: B { field: "my string" }
            }
        }
    })
    .unwrap()
);
```
</details>

The output of that example is:
```xml
<soapenv:Envelope><soapenv:Body><b><field>my string</field></b></soapenv:Body></soapenv:Envelope>
```

This output is missing `A`'s tag. With the implementation provided in this PR for `$value`, the above example can be modified like so:

<details>
<summary>Previous example, swapping `flatten` for `rename = "$value"`</summary>

```rust
#[derive(Serialize)]
#[serde(rename = "soapenv:Envelope")]
struct SoapEnvEnvelope<T> {
    #[serde(rename = "soapenv:Body")]
    body: SoapEnvBody<T>,
}

#[derive(Serialize)]
struct SoapEnvBody<T> {
    #[serde(rename = "$value")]
    body: T,
}

#[derive(Serialize)]
struct A {
    b: B,
}

#[derive(Serialize)]
struct B {
    field: &'static str,
}

println!(
    "{}",
    to_string(&SoapEnvEnvelope {
        body: SoapEnvBody {
            body: A {
                b: B { field: "my string" }
            }
        }
    })
    .unwrap()
);
```

</details>

To produce the desired output (notice the `<A>` tag):
```xml
<soapenv:Envelope><soapenv:Body><A><b><field>my string</field></b></A></soapenv:Body></soapenv:Envelope>
```

## Closing thoughts

Admittedly, this is a very simple solution, which just reuses what's already implemented. A lot of test comments mention how we "cannot" and "should not" wrap structs in this way, and that got me wondering if the comment was just referring to the current state, or if I'm missing any specific reason this should not be implemented. Considering the only tests that failed are exactly the tests that expect this behavior not to be implemented, I believe it's the former, but I'm open to hearing otherwise.

Also, some test modules include both `err!` and `serialize_as!` macros which acutally behave differently, usually with `serialize_as!` wrapping the input around a struct, map or something else, while the corresponding `err!` macro does not. This looks silly when reviewing the code changes, as it almost looks like I removed some tests and replaced them with completely different tests. That's not the case.

## Regarding Documentation

I have not updated the repository's documentation. I'd first like to see whether this is a wanted feature or not, before investing time into rewriting the docs. I'm fully open to updating them before merging this PR, though, I just wanted to get a general review first.