### PR TITLE
feat: Create a `Deserializer` from a custom `NsReader`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,9 +15,17 @@
 
 ### New Features
 
+- [#882]: Add new methods to create `Deserializer` from existing `NsReader`:
+  - `Deserializer::borrowing`
+  - `Deserializer::borrowing_with_resolver`
+  - `Deserializer::buffering`
+  - `Deserializer::buffering_with_resolver`
+
 ### Bug Fixes
 
 ### Misc Changes
+
+[#882]: https://github.com/tafia/quick-xml/pull/882
 
 
 ## 0.38.0 -- 2025-06-28


### PR DESCRIPTION
# Why?

Such as me, some users wants to be able to configure the `Reader` to match their needs. With the recent changes on the `trim_text` I wanted to find a way to satisfy everyone and also my needs.

# How?

Add a `From` implementation to create a `Deserializer` using a custom `NsReader`.