### PR TITLE
Proper EOL normalization

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,11 +22,16 @@
   - `Deserializer::buffering_with_resolver`
 - [#878]: Add ability to serialize structs in `$value` fields. The struct name will
   be used as a tag name. Previously only enums was allowed there.
+- [#806]: Add `BytesText::xml_content`, `BytesCData::xml_content` and `BytesRef::xml_content`
+  methods which returns XML EOL normalized strings.
+- [#806]: Add `BytesText::html_content`, `BytesCData::html_content` and `BytesRef::html_content`
+  methods which returns HTML EOL normalized strings.
 
 ### Bug Fixes
 
 ### Misc Changes
 
+[#806]: https://github.com/tafia/quick-xml/issues/806
 [#878]: https://github.com/tafia/quick-xml/pull/878
 [#882]: https://github.com/tafia/quick-xml/pull/882
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,8 @@
 
 ### Bug Fixes
 
+- [#806]: Properly normalize EOL characters in `Deserializer`.
+
 ### Misc Changes
 
 [#806]: https://github.com/tafia/quick-xml/issues/806

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -55,7 +55,7 @@ fn parse_document_from_str(doc: &str) -> XmlResult<()> {
                 }
             }
             Event::Text(e) => {
-                black_box(e.decode()?);
+                black_box(e.xml_content()?);
             }
             Event::CData(e) => {
                 black_box(e.into_inner());
@@ -80,7 +80,7 @@ fn parse_document_from_bytes(doc: &[u8]) -> XmlResult<()> {
                 }
             }
             Event::Text(e) => {
-                black_box(e.decode()?);
+                black_box(e.xml_content()?);
             }
             Event::CData(e) => {
                 black_box(e.into_inner());
@@ -106,7 +106,7 @@ fn parse_document_from_str_with_namespaces(doc: &str) -> XmlResult<()> {
                 }
             }
             (resolved_ns, Event::Text(e)) => {
-                black_box(e.decode()?);
+                black_box(e.xml_content()?);
                 black_box(resolved_ns);
             }
             (resolved_ns, Event::CData(e)) => {
@@ -134,7 +134,7 @@ fn parse_document_from_bytes_with_namespaces(doc: &[u8]) -> XmlResult<()> {
                 }
             }
             (resolved_ns, Event::Text(e)) => {
-                black_box(e.decode()?);
+                black_box(e.xml_content()?);
                 black_box(resolved_ns);
             }
             (resolved_ns, Event::CData(e)) => {

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -146,7 +146,7 @@ fn one_event(c: &mut Criterion) {
             config.trim_text(true);
             config.check_end_names = false;
             match r.read_event() {
-                Ok(Event::Comment(e)) => nbtxt += e.decode().unwrap().len(),
+                Ok(Event::Comment(e)) => nbtxt += e.xml_content().unwrap().len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2439,8 +2439,8 @@ impl<'i, R: XmlRead<'i>, E: EntityResolver> XmlReader<'i, R, E> {
             }
 
             match self.next_impl()? {
-                PayloadEvent::Text(e) => result.to_mut().push_str(&e.decode()?),
-                PayloadEvent::CData(e) => result.to_mut().push_str(&e.decode()?),
+                PayloadEvent::Text(e) => result.to_mut().push_str(&e.xml_content()?),
+                PayloadEvent::CData(e) => result.to_mut().push_str(&e.xml_content()?),
                 PayloadEvent::GeneralRef(e) => self.resolve_reference(result.to_mut(), e)?,
 
                 // SAFETY: current_event_is_last_text checks that event is Text, CData or GeneralRef
@@ -2456,8 +2456,8 @@ impl<'i, R: XmlRead<'i>, E: EntityResolver> XmlReader<'i, R, E> {
             return match self.next_impl()? {
                 PayloadEvent::Start(e) => Ok(DeEvent::Start(e)),
                 PayloadEvent::End(e) => Ok(DeEvent::End(e)),
-                PayloadEvent::Text(e) => self.drain_text(e.decode()?),
-                PayloadEvent::CData(e) => self.drain_text(e.decode()?),
+                PayloadEvent::Text(e) => self.drain_text(e.xml_content()?),
+                PayloadEvent::CData(e) => self.drain_text(e.xml_content()?),
                 PayloadEvent::DocType(e) => {
                     self.entity_resolver
                         .capture(e)

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -583,6 +583,46 @@ impl<'a> BytesText<'a> {
         self.decoder.decode_cow(&self.content)
     }
 
+    /// Decodes the content of the XML event.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this text event.
+    ///
+    /// This will allocate if the value contains any escape sequences or in non-UTF-8
+    /// encoding, or EOL normalization is required.
+    ///
+    /// Note, that this method should be used only if event represents XML content,
+    /// because rules for normalizing EOLs for [XML] and [HTML] differs.
+    ///
+    /// To get HTML content use [`html_content()`](Self::html_content).
+    ///
+    /// [XML]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    pub fn xml_content(&self) -> Result<Cow<'a, str>, EncodingError> {
+        self.decoder.xml_content(&self.content)
+    }
+
+    /// Decodes the content of the HTML event.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this text event.
+    ///
+    /// This will allocate if the value contains any escape sequences or in non-UTF-8
+    /// encoding, or EOL normalization is required.
+    ///
+    /// Note, that this method should be used only if event represents HTML content,
+    /// because rules for normalizing EOLs for [XML] and [HTML] differs.
+    ///
+    /// To get XML content use [`xml_content()`](Self::xml_content).
+    ///
+    /// [XML]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    pub fn html_content(&self) -> Result<Cow<'a, str>, EncodingError> {
+        self.decoder.html_content(&self.content)
+    }
+
     /// Removes leading XML whitespace bytes from text content.
     ///
     /// Returns `true` if content is empty after that
@@ -828,7 +868,49 @@ impl<'a> BytesCData<'a> {
     /// associated with that reader to interpret the raw bytes contained within this
     /// CDATA event.
     pub fn decode(&self) -> Result<Cow<'a, str>, EncodingError> {
-        Ok(self.decoder.decode_cow(&self.content)?)
+        self.decoder.decode_cow(&self.content)
+    }
+
+    /// Decodes the raw input byte content of the CDATA section of the XML event
+    /// into a string.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this CDATA event.
+    ///
+    /// This will allocate if the value in non-UTF-8 encoding, or EOL normalization
+    /// is required.
+    ///
+    /// Note, that this method should be used only if event represents XML content,
+    /// because rules for normalizing EOLs for [XML] and [HTML] differs.
+    ///
+    /// To get HTML content use [`html_content()`](Self::html_content).
+    ///
+    /// [XML]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    pub fn xml_content(&self) -> Result<Cow<'a, str>, EncodingError> {
+        self.decoder.xml_content(&self.content)
+    }
+
+    /// Decodes the raw input byte content of the CDATA section of the HTML event
+    /// into a string.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this CDATA event.
+    ///
+    /// This will allocate if the value in non-UTF-8 encoding, or EOL normalization
+    /// is required.
+    ///
+    /// Note, that this method should be used only if event represents HTML content,
+    /// because rules for normalizing EOLs for [XML] and [HTML] differs.
+    ///
+    /// To get XML content use [`xml_content()`](Self::xml_content).
+    ///
+    /// [XML]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    pub fn html_content(&self) -> Result<Cow<'a, str>, EncodingError> {
+        self.decoder.html_content(&self.content)
     }
 }
 
@@ -1441,6 +1523,46 @@ impl<'a> BytesRef<'a> {
     /// non-UTF-8 encoding.
     pub fn decode(&self) -> Result<Cow<'a, str>, EncodingError> {
         self.decoder.decode_cow(&self.content)
+    }
+
+    /// Decodes the content of the XML event.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this general reference event.
+    ///
+    /// This will allocate if the value in non-UTF-8 encoding, or EOL normalization
+    /// is required.
+    ///
+    /// Note, that this method should be used only if event represents XML content,
+    /// because rules for normalizing EOLs for [XML] and [HTML] differs.
+    ///
+    /// To get HTML content use [`html_content()`](Self::html_content).
+    ///
+    /// [XML]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    pub fn xml_content(&self) -> Result<Cow<'a, str>, EncodingError> {
+        self.decoder.xml_content(&self.content)
+    }
+
+    /// Decodes the content of the HTML event.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this general reference event.
+    ///
+    /// This will allocate if the value in non-UTF-8 encoding, or EOL normalization
+    /// is required.
+    ///
+    /// Note, that this method should be used only if event represents HTML content,
+    /// because rules for normalizing EOLs for [XML] and [HTML] differs.
+    ///
+    /// To get XML content use [`xml_content()`](Self::xml_content).
+    ///
+    /// [XML]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    pub fn html_content(&self) -> Result<Cow<'a, str>, EncodingError> {
+        self.decoder.html_content(&self.content)
     }
 
     /// Returns `true` if the specified reference represents the character reference

--- a/tests/encodings.rs
+++ b/tests/encodings.rs
@@ -37,7 +37,7 @@ fn test_koi8_r_encoding() {
     loop {
         match r.read_event_into(&mut buf) {
             Ok(Text(e)) => {
-                e.decode().unwrap();
+                e.xml_content().unwrap();
             }
             Ok(Eof) => break,
             _ => (),

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -38,7 +38,7 @@ fn fuzz_101() {
                 }
             }
             Ok(Event::Text(e)) => {
-                if e.decode().is_err() {
+                if e.xml_content().is_err() {
                     break;
                 }
             }

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -172,7 +172,7 @@ fn test_escaped_content() {
                 "content unexpected: expecting 'test', got '{:?}'",
                 from_utf8(&e)
             );
-            match e.decode() {
+            match e.xml_content() {
                 Ok(c) => assert_eq!(c, "test"),
                 Err(e) => panic!(
                     "cannot escape content at position {}: {:?}",

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -236,7 +236,7 @@ fn reescape_text() {
         match reader.read_event().unwrap() {
             Eof => break,
             Text(e) => {
-                let t = e.decode().unwrap();
+                let t = e.xml_content().unwrap();
                 assert!(writer.write_event(Text(BytesText::new(&t))).is_ok());
             }
             e => assert!(writer.write_event(e).is_ok()),

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -1897,9 +1897,11 @@ mod with_root {
             <root>3</root>");
     serialize_as!(tuple:
         // Use to_string() to get owned type that is required for deserialization
-        ("<\"&'>".to_string(), "with\t\r\n spaces", 3usize)
+        // NOTE: do not use \r, because it normalized to \n during deserialziation
+        // but writes as is during serialization
+        ("<\"&'>".to_string(), "with\t\n spaces", 3usize)
         => "<root>&lt;\"&amp;'&gt;</root>\
-            <root>with\t\r\n spaces</root>\
+            <root>with\t\n spaces</root>\
             <root>3</root>");
     serialize_as!(tuple_struct:
         Tuple(42.0, "answer")


### PR DESCRIPTION
Because we support XML and HTML parsing and the rules for EOL normalization is differs between them, this PR introduces two new methods for `BytesText`, `BytesCData` and `BytesRef` in addition to `decode`:
- `xml_content()`
- `html_content()`

XML rules: https://www.w3.org/TR/xml11/#sec-line-ends
HTML rules: https://infra.spec.whatwg.org/#normalize-newlines

The new methods does not apply to attribute value normalization, this is left for 379.

Closes #806 (when use `xml_content()`)