### PR TITLE
Use std::str::from_utf8 consistently to fix compiling with Rust < 1.87

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -2120,12 +2120,12 @@ mod normalization {
             fn utf8_0xc2() {
                 // All possible characters encoded in 2 bytes in UTF-8 which first byte is 0xC2 (0b11000010)
                 // Second byte follows the pattern 10xxxxxx
-                let first = str::from_utf8(&[0b11000010, 0b10000000])
+                let first = std::str::from_utf8(&[0b11000010, 0b10000000])
                     .unwrap()
                     .chars()
                     .next()
                     .unwrap();
-                let last = str::from_utf8(&[0b11000010, 0b10111111])
+                let last = std::str::from_utf8(&[0b11000010, 0b10111111])
                     .unwrap()
                     .chars()
                     .next()
@@ -2134,7 +2134,7 @@ mod normalization {
                 for ch in first..=last {
                     ch.encode_utf8(&mut utf8);
                     let description = format!("UTF-8 [{:02x} {:02x}] = `{}`", utf8[0], utf8[1], ch);
-                    let input = str::from_utf8(&utf8).expect(&description);
+                    let input = std::str::from_utf8(&utf8).expect(&description);
 
                     dbg!((input, &description));
                     if ch == '\u{0085}' {
@@ -2150,12 +2150,12 @@ mod normalization {
             fn utf8_0x0d_0xc2() {
                 // All possible characters encoded in 2 bytes in UTF-8 which first byte is 0xC2 (0b11000010)
                 // Second byte follows the pattern 10xxxxxx
-                let first = str::from_utf8(&[0b11000010, 0b10000000])
+                let first = std::str::from_utf8(&[0b11000010, 0b10000000])
                     .unwrap()
                     .chars()
                     .next()
                     .unwrap();
-                let last = str::from_utf8(&[0b11000010, 0b10111111])
+                let last = std::str::from_utf8(&[0b11000010, 0b10111111])
                     .unwrap()
                     .chars()
                     .next()
@@ -2167,7 +2167,7 @@ mod normalization {
                         "UTF-8 [{:02x} {:02x} {:02x}] = `{}`",
                         utf8[0], utf8[1], utf8[2], ch
                     );
-                    let input = str::from_utf8(&utf8).expect(&description);
+                    let input = std::str::from_utf8(&utf8).expect(&description);
 
                     dbg!((input, &description));
                     if ch == '\u{0085}' {
@@ -2183,12 +2183,12 @@ mod normalization {
             fn utf8_0xe2() {
                 // All possible characters encoded in 3 bytes in UTF-8 which first byte is 0xE2 (0b11100010)
                 // Second and third bytes follows the pattern 10xxxxxx
-                let first = str::from_utf8(&[0b11100010, 0b10000000, 0b10000000])
+                let first = std::str::from_utf8(&[0b11100010, 0b10000000, 0b10000000])
                     .unwrap()
                     .chars()
                     .next()
                     .unwrap();
-                let last = str::from_utf8(&[0b11100010, 0b10111111, 0b10111111])
+                let last = std::str::from_utf8(&[0b11100010, 0b10111111, 0b10111111])
                     .unwrap()
                     .chars()
                     .next()

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -147,7 +147,6 @@ where
 /// # use serde::Serialize;
 /// # use pretty_assertions::assert_eq;
 /// # use std::io::BufWriter;
-/// # use std::str;
 /// #[derive(Serialize)]
 /// struct Root<'a> {
 ///     #[serde(rename = "@attribute")]
@@ -167,7 +166,7 @@ where
 /// to_utf8_io_writer(&mut BufWriter::new(&mut buffer), &data).unwrap();
 ///
 /// assert_eq!(
-///     str::from_utf8(&buffer).unwrap(),
+///     std::str::from_utf8(&buffer).unwrap(),
 ///     // The root tag name is automatically deduced from the struct name
 ///     // This will not work for other types or struct with #[serde(flatten)] fields
 ///     "<Root attribute=\"attribute content\">\


### PR DESCRIPTION
The `str::from_utf8` method on the `str` type was only stabilized in Rust 1.87. It looks like the method is used via this path accidentally in some places, because it is used via `std::str::from_utf8` in most other places (which has been available since Rust 1.0).

This should fix compiling (and running tests) with a Rust toolchain less recent than 1.87 :)
