### PR TITLE
Make `NamespaceResolver` public

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@
 ### New Features
 
 - [#893]: Implement `FusedIterator` for `NamespaceBindingsIter`.
+- [#893]: Make `NamespaceResolver` public.
+- [#893]: Add `NsReader::resolver()` for access to namespace resolver.
 
 ### Bug Fixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,10 @@
 
 ### Misc Changes
 
+- [#893]: Rename `PrefixIter` to `NamespaceBindingsIter`, `PrefixIter` is deprecated.
+
+[#893]: https://github.com/tafia/quick-xml/pull/893
+
 
 ## 0.38.1 -- 2025-08-03
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@
 
 ### New Features
 
+- [#893]: Implement `FusedIterator` for `NamespaceBindingsIter`.
+
 ### Bug Fixes
 
 ### Misc Changes

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -399,7 +399,7 @@ impl<'a> Attributes<'a> {
 
         self.any(|attr| {
             if let Ok(attr) = attr {
-                match reader.resolve_attribute(attr.key) {
+                match reader.resolver().resolve_attribute(attr.key) {
                     (
                         Bound(Namespace(b"http://www.w3.org/2001/XMLSchema-instance")),
                         LocalName(b"nil"),

--- a/src/name.rs
+++ b/src/name.rs
@@ -8,6 +8,7 @@ use crate::events::BytesStart;
 use crate::utils::write_byte_string;
 use memchr::memchr;
 use std::fmt::{self, Debug, Formatter};
+use std::iter::FusedIterator;
 
 /// Some namespace was invalid
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -748,6 +749,8 @@ impl<'a> Iterator for NamespaceBindingsIter<'a> {
         (0, Some(self.resolver.bindings.len() - self.bindings_cursor))
     }
 }
+
+impl<'a> FusedIterator for NamespaceBindingsIter<'a> {}
 
 /// The previous name for [`NamespaceBindingsIter`].
 #[deprecated = "Use NamespaceBindingsIter instead"]

--- a/src/name.rs
+++ b/src/name.rs
@@ -414,7 +414,7 @@ impl<'ns> TryFrom<ResolveResult<'ns>> for Option<Namespace<'ns>> {
 /// [namespace prefix]: https://www.w3.org/TR/xml-names11/#dt-prefix
 /// [namespace name]: https://www.w3.org/TR/xml-names11/#dt-NSName
 #[derive(Debug, Clone)]
-struct NamespaceEntry {
+struct NamespaceBinding {
     /// Index of the namespace in the buffer
     start: usize,
     /// Length of the prefix
@@ -438,7 +438,7 @@ struct NamespaceEntry {
     level: i32,
 }
 
-impl NamespaceEntry {
+impl NamespaceBinding {
     /// Get the namespace prefix, bound to this namespace declaration, or `None`,
     /// if this declaration is for default namespace (`xmlns="..."`).
     #[inline]
@@ -474,7 +474,7 @@ pub(crate) struct NamespaceResolver {
     /// and an `=`) and namespace values.
     buffer: Vec<u8>,
     /// A stack of namespace bindings to prefixes that currently in scope
-    bindings: Vec<NamespaceEntry>,
+    bindings: Vec<NamespaceBinding>,
     /// The number of open tags at the moment. We need to keep track of this to know which namespace
     /// declarations to remove when we encounter an `End` event.
     nesting_level: i32,
@@ -512,7 +512,7 @@ impl Default for NamespaceResolver {
         for ent in &[RESERVED_NAMESPACE_XML, RESERVED_NAMESPACE_XMLNS] {
             let prefix = ent.0.into_inner();
             let uri = ent.1.into_inner();
-            bindings.push(NamespaceEntry {
+            bindings.push(NamespaceBinding {
                 start: buffer.len(),
                 prefix_len: prefix.len(),
                 value_len: uri.len(),
@@ -546,7 +546,7 @@ impl NamespaceResolver {
                     Some(PrefixDeclaration::Default) => {
                         let start = self.buffer.len();
                         self.buffer.extend_from_slice(&v);
-                        self.bindings.push(NamespaceEntry {
+                        self.bindings.push(NamespaceBinding {
                             start,
                             prefix_len: 0,
                             value_len: v.len(),
@@ -578,7 +578,7 @@ impl NamespaceResolver {
                         let start = self.buffer.len();
                         self.buffer.extend_from_slice(prefix);
                         self.buffer.extend_from_slice(&v);
-                        self.bindings.push(NamespaceEntry {
+                        self.bindings.push(NamespaceBinding {
                             start,
                             prefix_len: prefix.len(),
                             value_len: v.len(),

--- a/src/name.rs
+++ b/src/name.rs
@@ -289,13 +289,25 @@ impl<'a> AsRef<[u8]> for Prefix<'a> {
 
 /// A namespace prefix declaration, `xmlns` or `xmlns:<name>`, as defined in
 /// [XML Schema specification](https://www.w3.org/TR/xml-names11/#ns-decl)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PrefixDeclaration<'a> {
     /// XML attribute binds a default namespace. Corresponds to `xmlns` in `xmlns="..."`
     Default,
     /// XML attribute binds a specified prefix to a namespace. Corresponds to a
     /// `prefix` in `xmlns:prefix="..."`, which is stored as payload of this variant.
     Named(&'a [u8]),
+}
+impl<'a> Debug for PrefixDeclaration<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Default => f.write_str("PrefixDeclaration::Default"),
+            Self::Named(prefix) => {
+                f.write_str("PrefixDeclaration::Named(")?;
+                write_byte_string(f, prefix)?;
+                f.write_str(")")
+            }
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/name.rs
+++ b/src/name.rs
@@ -675,6 +675,20 @@ impl NamespaceResolver {
         (self.resolve_prefix(prefix, use_default), local_name)
     }
 
+    /// Convenient method to call `resolve(name, true)`. May be used to clearly
+    /// express that we want to resolve an element name, and not an attribute name.
+    #[inline]
+    pub fn resolve_element<'n>(&self, name: QName<'n>) -> (ResolveResult<'_>, LocalName<'n>) {
+        self.resolve(name, true)
+    }
+
+    /// Convenient method to call `resolve(name, false)`. May be used to clearly
+    /// express that we want to resolve an attribute name, and not an element name.
+    #[inline]
+    pub fn resolve_attribute<'n>(&self, name: QName<'n>) -> (ResolveResult<'_>, LocalName<'n>) {
+        self.resolve(name, false)
+    }
+
     /// Finds a [namespace name] for a given qualified **element name**, borrow
     /// it from the internal buffer.
     ///

--- a/src/name.rs
+++ b/src/name.rs
@@ -690,8 +690,8 @@ impl NamespaceResolver {
     }
 
     #[inline]
-    pub const fn iter(&self) -> PrefixIter<'_> {
-        PrefixIter {
+    pub const fn bindings(&self) -> NamespaceBindingsIter<'_> {
+        NamespaceBindingsIter {
             resolver: self,
             // We initialize the cursor to 2 to skip the two default namespaces xml: and xmlns:
             bindings_cursor: 2,
@@ -701,16 +701,16 @@ impl NamespaceResolver {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Iterator on the current declared prefixes.
+/// Iterator on the current declared namespace bindings. Returns pairs of the _(prefix, namespace)_.
 ///
 /// See [`NsReader::prefixes`](crate::NsReader::prefixes) for documentation.
 #[derive(Debug, Clone)]
-pub struct PrefixIter<'a> {
+pub struct NamespaceBindingsIter<'a> {
     resolver: &'a NamespaceResolver,
     bindings_cursor: usize,
 }
 
-impl<'a> Iterator for PrefixIter<'a> {
+impl<'a> Iterator for NamespaceBindingsIter<'a> {
     type Item = (PrefixDeclaration<'a>, Namespace<'a>);
 
     fn next(&mut self) -> Option<(PrefixDeclaration<'a>, Namespace<'a>)> {
@@ -748,6 +748,10 @@ impl<'a> Iterator for PrefixIter<'a> {
         (0, Some(self.resolver.bindings.len() - self.bindings_cursor))
     }
 }
+
+/// The previous name for [`NamespaceBindingsIter`].
+#[deprecated = "Use NamespaceBindingsIter instead"]
+pub type PrefixIter<'a> = NamespaceBindingsIter<'a>;
 
 #[cfg(test)]
 mod namespaces {

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -210,7 +210,7 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     /// given buffer.
     ///
     /// This method manages namespaces but doesn't resolve them automatically.
-    /// You should call [`resolve_element()`] if you want to get a namespace.
+    /// You should call [`resolver().resolve_element()`] if you want to get a namespace.
     ///
     /// You also can use [`read_resolved_event_into_async()`] instead if you want
     /// to resolve namespace as soon as you get an event.
@@ -239,7 +239,7 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     ///     match reader.read_event_into_async(&mut buf).await.unwrap() {
     ///         Event::Start(e) => {
     ///             count += 1;
-    ///             let (ns, local) = reader.resolve_element(e.name());
+    ///             let (ns, local) = reader.resolver().resolve_element(e.name());
     ///             match local.as_ref() {
     ///                 b"tag1" => assert_eq!(ns, Bound(Namespace(b"www.xxxx"))),
     ///                 b"tag2" => assert_eq!(ns, Bound(Namespace(b"www.yyyy"))),
@@ -260,7 +260,7 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
     /// ```
     ///
     /// [`read_event_into()`]: NsReader::read_event_into
-    /// [`resolve_element()`]: Self::resolve_element
+    /// [`resolver().resolve_element()`]: crate::name::NamespaceResolver::resolve_element
     /// [`read_resolved_event_into_async()`]: Self::read_resolved_event_into_async
     pub async fn read_event_into_async<'b>(&mut self, buf: &'b mut Vec<u8>) -> Result<Event<'b>> {
         self.pop();

--- a/src/reader/async_tokio.rs
+++ b/src/reader/async_tokio.rs
@@ -406,8 +406,8 @@ impl<R: AsyncBufRead + Unpin> NsReader<R> {
         &'ns mut self,
         buf: &'b mut Vec<u8>,
     ) -> Result<(ResolveResult<'ns>, Event<'b>)> {
-        let event = self.read_event_into_async(buf).await;
-        self.resolve_event(event)
+        let event = self.read_event_into_async(buf).await?;
+        Ok(self.resolver().resolve_event(event))
     }
 }
 

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -214,24 +214,29 @@ impl<R> NsReader<R> {
         self.reader.get_mut()
     }
 
+    /// Returns a storage of namespace bindings associated with this reader.
+    #[inline]
+    pub const fn resolver(&self) -> &NamespaceResolver {
+        &self.ns_resolver
+    }
+
     /// Resolves a potentially qualified **element name** or **attribute name**
     /// into _(namespace name, local name)_.
     ///
-    /// _Qualified_ names have the form `prefix:local-name` where the `prefix`
+    /// _Qualified_ names have the form `local-name` or `prefix:local-name` where the `prefix`
     /// is defined on any containing XML element via `xmlns:prefix="the:namespace:uri"`.
     /// The namespace prefix can be defined on the same element as the name in question.
     ///
-    /// The method returns following results depending on the `name` shape,
-    /// `attribute` flag and the presence of the default namespace:
+    /// The method returns following results depending on the `name` shape, `attribute` flag
+    /// and the presence of the default namespace on element or any of its parents:
     ///
     /// |attribute|`xmlns="..."`|QName              |ResolveResult          |LocalName
     /// |---------|-------------|-------------------|-----------------------|------------
-    /// |`true`   |Not defined  |`local-name`       |[`Unbound`]            |`local-name`
-    /// |`true`   |Defined      |`local-name`       |[`Unbound`]            |`local-name`
-    /// |`true`   |_any_        |`prefix:local-name`|[`Bound`] / [`Unknown`]|`local-name`
+    /// |`true`   |_(any)_      |`local-name`       |[`Unbound`]            |`local-name`
+    /// |`true`   |_(any)_      |`prefix:local-name`|[`Bound`] / [`Unknown`]|`local-name`
     /// |`false`  |Not defined  |`local-name`       |[`Unbound`]            |`local-name`
-    /// |`false`  |Defined      |`local-name`       |[`Bound`] (default)    |`local-name`
-    /// |`false`  |_any_        |`prefix:local-name`|[`Bound`] / [`Unknown`]|`local-name`
+    /// |`false`  |Defined      |`local-name`       |[`Bound`] (to `xmlns`) |`local-name`
+    /// |`false`  |_(any)_      |`prefix:local-name`|[`Bound`] / [`Unknown`]|`local-name`
     ///
     /// If you want to clearly indicate that name that you resolve is an element
     /// or an attribute name, you could use [`resolve_attribute()`] or [`resolve_element()`]

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -315,7 +315,7 @@ impl<R> NsReader<R> {
     /// [`read_resolved_event()`]: Self::read_resolved_event
     #[inline]
     pub fn resolve_element<'n>(&self, name: QName<'n>) -> (ResolveResult<'_>, LocalName<'n>) {
-        self.ns_resolver.resolve(name, true)
+        self.ns_resolver.resolve_element(name)
     }
 
     /// Resolves a potentially qualified **attribute name** into _(namespace name, local name)_.
@@ -385,7 +385,7 @@ impl<R> NsReader<R> {
     /// [`Unknown`]: ResolveResult::Unknown
     #[inline]
     pub fn resolve_attribute<'n>(&self, name: QName<'n>) -> (ResolveResult<'_>, LocalName<'n>) {
-        self.ns_resolver.resolve(name, false)
+        self.ns_resolver.resolve_attribute(name)
     }
 }
 

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 use crate::errors::Result;
 use crate::events::Event;
-use crate::name::{LocalName, NamespaceResolver, PrefixIter, QName, ResolveResult};
+use crate::name::{LocalName, NamespaceBindingsIter, NamespaceResolver, QName, ResolveResult};
 use crate::reader::{Config, Reader, Span, XmlSource};
 
 /// A low level encoding-agnostic XML event reader that performs namespace resolution.
@@ -130,8 +130,8 @@ impl<R> NsReader<R> {
     /// # quick_xml::Result::Ok(())
     /// ```
     #[inline]
-    pub const fn prefixes(&self) -> PrefixIter<'_> {
-        self.ns_resolver.iter()
+    pub const fn prefixes(&self) -> NamespaceBindingsIter<'_> {
+        self.ns_resolver.bindings()
     }
 }
 

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -184,19 +184,6 @@ impl<R> NsReader<R> {
             e => e,
         }
     }
-
-    pub(super) fn resolve_event<'i>(
-        &mut self,
-        event: Result<Event<'i>>,
-    ) -> Result<(ResolveResult<'_>, Event<'i>)> {
-        match event {
-            Ok(Event::Start(e)) => Ok((self.ns_resolver.find(e.name()), Event::Start(e))),
-            Ok(Event::Empty(e)) => Ok((self.ns_resolver.find(e.name()), Event::Empty(e))),
-            Ok(Event::End(e)) => Ok((self.ns_resolver.find(e.name()), Event::End(e))),
-            Ok(e) => Ok((ResolveResult::Unbound, e)),
-            Err(e) => Err(e),
-        }
-    }
 }
 
 /// Getters
@@ -508,8 +495,8 @@ impl<R: BufRead> NsReader<R> {
         &mut self,
         buf: &'b mut Vec<u8>,
     ) -> Result<(ResolveResult<'_>, Event<'b>)> {
-        let event = self.read_event_impl(buf);
-        self.resolve_event(event)
+        let event = self.read_event_impl(buf)?;
+        Ok(self.ns_resolver.resolve_event(event))
     }
 
     /// Reads until end element is found using provided buffer as intermediate
@@ -752,8 +739,8 @@ impl<'i> NsReader<&'i [u8]> {
     /// [`read_event()`]: Self::read_event
     #[inline]
     pub fn read_resolved_event(&mut self) -> Result<(ResolveResult<'_>, Event<'i>)> {
-        let event = self.read_event_impl(());
-        self.resolve_event(event)
+        let event = self.read_event_impl(())?;
+        Ok(self.ns_resolver.resolve_event(event))
     }
 
     /// Reads until end element is found. This function is supposed to be called

--- a/src/reader/ns_reader.rs
+++ b/src/reader/ns_reader.rs
@@ -380,7 +380,7 @@ impl<R: BufRead> NsReader<R> {
     /// Reads the next event into given buffer.
     ///
     /// This method manages namespaces but doesn't resolve them automatically.
-    /// You should call [`resolve_element()`] if you want to get a namespace.
+    /// You should call [`resolver().resolve_element()`] if you want to get a namespace.
     ///
     /// You also can use [`read_resolved_event_into()`] instead if you want to resolve
     /// namespace as soon as you get an event.
@@ -408,7 +408,7 @@ impl<R: BufRead> NsReader<R> {
     ///     match reader.read_event_into(&mut buf).unwrap() {
     ///         Event::Start(e) => {
     ///             count += 1;
-    ///             let (ns, local) = reader.resolve_element(e.name());
+    ///             let (ns, local) = reader.resolver().resolve_element(e.name());
     ///             match local.as_ref() {
     ///                 b"tag1" => assert_eq!(ns, Bound(Namespace(b"www.xxxx"))),
     ///                 b"tag2" => assert_eq!(ns, Bound(Namespace(b"www.yyyy"))),
@@ -427,7 +427,7 @@ impl<R: BufRead> NsReader<R> {
     /// assert_eq!(txt, vec!["Test".to_string(), "Test 2".to_string()]);
     /// ```
     ///
-    /// [`resolve_element()`]: Self::resolve_element
+    /// [`resolver().resolve_element()`]: NamespaceResolver::resolve_element
     /// [`read_resolved_event_into()`]: Self::read_resolved_event_into
     #[inline]
     pub fn read_event_into<'b>(&mut self, buf: &'b mut Vec<u8>) -> Result<Event<'b>> {
@@ -622,7 +622,7 @@ impl<'i> NsReader<&'i [u8]> {
     /// Reads the next event, borrow its content from the input buffer.
     ///
     /// This method manages namespaces but doesn't resolve them automatically.
-    /// You should call [`resolve_element()`] if you want to get a namespace.
+    /// You should call [`resolver().resolve_element()`] if you want to get a namespace.
     ///
     /// You also can use [`read_resolved_event()`] instead if you want to resolve namespace
     /// as soon as you get an event.
@@ -653,7 +653,7 @@ impl<'i> NsReader<&'i [u8]> {
     ///     match reader.read_event().unwrap() {
     ///         Event::Start(e) => {
     ///             count += 1;
-    ///             let (ns, local) = reader.resolve_element(e.name());
+    ///             let (ns, local) = reader.resolver().resolve_element(e.name());
     ///             match local.as_ref() {
     ///                 b"tag1" => assert_eq!(ns, Bound(Namespace(b"www.xxxx"))),
     ///                 b"tag2" => assert_eq!(ns, Bound(Namespace(b"www.yyyy"))),
@@ -671,7 +671,7 @@ impl<'i> NsReader<&'i [u8]> {
     /// assert_eq!(txt, vec!["Test".to_string(), "Test 2".to_string()]);
     /// ```
     ///
-    /// [`resolve_element()`]: Self::resolve_element
+    /// [`resolver().resolve_element()`]: NamespaceResolver::resolve_element
     /// [`read_resolved_event()`]: Self::read_resolved_event
     #[inline]
     pub fn read_event(&mut self) -> Result<Event<'i>> {

--- a/tests/reader-namespaces.rs
+++ b/tests/reader-namespaces.rs
@@ -18,7 +18,7 @@ fn namespace() {
             e
         ),
     }
-    let it1 = r.prefixes();
+    let it1 = r.resolver().bindings();
     let it2 = it1.clone();
     assert_eq!(it1.size_hint(), (0, Some(1)));
     assert_eq!(
@@ -40,7 +40,7 @@ fn namespace() {
             e
         ),
     }
-    let it = r.prefixes();
+    let it = r.resolver().bindings();
     assert_eq!(it.size_hint(), (0, Some(1)));
     assert_eq!(
         it.collect::<Vec<_>>(),
@@ -52,7 +52,7 @@ fn namespace() {
         Ok((ns, Text(_))) => assert_eq!(ns, Unbound),
         e => panic!("expecting text content with no namespace, got {:?}", e),
     }
-    let it = r.prefixes();
+    let it = r.resolver().bindings();
     assert_eq!(it.size_hint(), (0, Some(1)));
     assert_eq!(
         it.collect::<Vec<_>>(),
@@ -67,7 +67,7 @@ fn namespace() {
             e
         ),
     }
-    let it = r.prefixes();
+    let it = r.resolver().bindings();
     assert_eq!(it.size_hint(), (0, Some(1)));
     assert_eq!(
         it.collect::<Vec<_>>(),
@@ -79,7 +79,7 @@ fn namespace() {
         Ok((ns, End(_))) => assert_eq!(ns, Unbound),
         e => panic!("expecting outer end element with no namespace, got {:?}", e),
     }
-    let it = r.prefixes();
+    let it = r.resolver().bindings();
     assert_eq!(it.size_hint(), (0, Some(1)));
     assert_eq!(
         it.collect::<Vec<_>>(),
@@ -109,7 +109,7 @@ mod default_namespace {
             // we don't care about xmlns attributes for this test
             .filter(|kv| kv.key.as_namespace_binding().is_none())
             .map(|Attribute { key: name, value }| {
-                let (opt_ns, local_name) = r.resolve_attribute(name);
+                let (opt_ns, local_name) = r.resolver().resolve_attribute(name);
                 (opt_ns, local_name.into_inner(), value)
             });
         assert_eq!(
@@ -118,7 +118,7 @@ mod default_namespace {
         );
         assert_eq!(attrs.next(), None);
 
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(1)));
         assert_eq!(
             it.collect::<Vec<_>>(),
@@ -138,7 +138,7 @@ mod default_namespace {
                 e
             ),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(0)));
         assert_eq!(it.collect::<Vec<_>>(), vec![]);
 
@@ -150,7 +150,7 @@ mod default_namespace {
                 e
             ),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(1)));
         assert_eq!(
             it.collect::<Vec<_>>(),
@@ -165,7 +165,7 @@ mod default_namespace {
                 e
             ),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(1)));
         assert_eq!(
             it.collect::<Vec<_>>(),
@@ -178,7 +178,7 @@ mod default_namespace {
             Ok((ns, End(_))) => assert_eq!(ns, Unbound),
             e => panic!("expecting outer end element with no namespace, got {:?}", e),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(0)));
         assert_eq!(it.collect::<Vec<_>>(), vec![]);
     }
@@ -195,7 +195,7 @@ mod default_namespace {
                 e
             ),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(1)));
         assert_eq!(
             it.collect::<Vec<_>>(),
@@ -210,7 +210,7 @@ mod default_namespace {
                 e
             ),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(2)));
         assert_eq!(it.collect::<Vec<_>>(), vec![]);
 
@@ -219,7 +219,7 @@ mod default_namespace {
             Ok((ns, End(_))) => assert_eq!(ns, Unbound),
             e => panic!("expecting inner end element with no namespace, got {:?}", e),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(2)));
         assert_eq!(it.collect::<Vec<_>>(), vec![]);
 
@@ -231,7 +231,7 @@ mod default_namespace {
                 e
             ),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(1)));
         assert_eq!(
             it.collect::<Vec<_>>(),
@@ -255,7 +255,7 @@ mod default_namespace {
                 e => panic!("Expected Start event (<outer>), got {:?}", e),
             }
 
-            let it = r.prefixes();
+            let it = r.resolver().bindings();
             assert_eq!(it.size_hint(), (0, Some(1)));
             assert_eq!(
                 it.collect::<Vec<_>>(),
@@ -280,7 +280,7 @@ mod default_namespace {
                 // we don't care about xmlns attributes for this test
                 .filter(|kv| kv.key.as_namespace_binding().is_none())
                 .map(|Attribute { key: name, value }| {
-                    let (opt_ns, local_name) = r.resolve_attribute(name);
+                    let (opt_ns, local_name) = r.resolver().resolve_attribute(name);
                     (opt_ns, local_name.into_inner(), value)
                 });
             // the attribute should _not_ have a namespace name. The default namespace does not
@@ -291,7 +291,7 @@ mod default_namespace {
             );
             assert_eq!(attrs.next(), None);
 
-            let it = r.prefixes();
+            let it = r.resolver().bindings();
             assert_eq!(it.size_hint(), (0, Some(2)));
             assert_eq!(
                 it.collect::<Vec<_>>(),
@@ -307,7 +307,7 @@ mod default_namespace {
             }
             e => panic!("Expected End event (<outer>), got {:?}", e),
         }
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(1)));
         assert_eq!(
             it.collect::<Vec<_>>(),
@@ -349,7 +349,7 @@ mod default_namespace {
                 // we don't care about xmlns attributes for this test
                 .filter(|kv| kv.key.as_namespace_binding().is_none())
                 .map(|Attribute { key: name, value }| {
-                    let (opt_ns, local_name) = r.resolve_attribute(name);
+                    let (opt_ns, local_name) = r.resolver().resolve_attribute(name);
                     (opt_ns, local_name.into_inner(), value)
                 });
             // the attribute should _not_ have a namespace name. The default namespace does not
@@ -400,7 +400,7 @@ fn attributes_empty_ns() {
         // we don't care about xmlns attributes for this test
         .filter(|kv| kv.key.as_namespace_binding().is_none())
         .map(|Attribute { key: name, value }| {
-            let (opt_ns, local_name) = r.resolve_attribute(name);
+            let (opt_ns, local_name) = r.resolver().resolve_attribute(name);
             (opt_ns, local_name.into_inner(), value)
         });
     assert_eq!(
@@ -417,7 +417,7 @@ fn attributes_empty_ns() {
     );
     assert_eq!(attrs.next(), None);
 
-    let it = r.prefixes();
+    let it = r.resolver().bindings();
     assert_eq!(it.size_hint(), (0, Some(1)));
     assert_eq!(
         it.collect::<Vec<_>>(),
@@ -446,7 +446,7 @@ fn attributes_empty_ns_expanded() {
             // we don't care about xmlns attributes for this test
             .filter(|kv| kv.key.as_namespace_binding().is_none())
             .map(|Attribute { key: name, value }| {
-                let (opt_ns, local_name) = r.resolve_attribute(name);
+                let (opt_ns, local_name) = r.resolver().resolve_attribute(name);
                 (opt_ns, local_name.into_inner(), value)
             });
         assert_eq!(
@@ -463,7 +463,7 @@ fn attributes_empty_ns_expanded() {
         );
         assert_eq!(attrs.next(), None);
 
-        let it = r.prefixes();
+        let it = r.resolver().bindings();
         assert_eq!(it.size_hint(), (0, Some(1)));
         assert_eq!(
             it.collect::<Vec<_>>(),


### PR DESCRIPTION
This introduces small breaking change -- `Attributes::has_nil` now accepts `&NamespaceResolver` instead of `Reader<R>` and does not need to be generic anymore (which is good).

Other changes that may look as breaking in the diff not breaking changes, because they was made on initially private types.