### PR TITLE
de: Preserve whitespace for all nodes containg a text event

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -273,7 +273,14 @@ where
                 QNameDeserializer::from_attr(QName(&slice[key]), decoder, &mut self.de.key_buf)?;
             seed.deserialize(de).map(Some)
         } else {
-            self.skip_whitespaces()?;
+            // If we have dedicated "$text" field, whitespace-only text may be significant.
+            // That also means, that type with `$text` fields behaves as if its element has
+            // `xml:space="preserve"` attribute: you must not have pretty-print indents
+            // inside this element.
+            if !self.has_text_field {
+                self.skip_whitespaces()?;
+            }
+
             // try getting from events (<key>value</key>)
             match self.de.peek()? {
                 // If we have dedicated "$text" field, it will not be passed to "$value" field

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2789,16 +2789,8 @@ where
     fn skip_whitespaces(&mut self) -> Result<(), DeError> {
         loop {
             match self.peek()? {
-                // Skip only blank text nodes that contain a newline or carriage return
-                // (typical pretty-printed formatting). Preserve other blank text
-                // (e.g. single space) as they may be significant for some deserialization scenarios.
                 DeEvent::Text(e) if e.is_blank() => {
-                    let contains_newline = e.text.chars().any(|c| c == '\n' || c == '\r');
-                    if contains_newline {
-                        self.next()?;
-                        continue;
-                    }
-                    break;
+                    self.next()?;
                 }
                 _ => break,
             }
@@ -4656,6 +4648,7 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
+                    // Passes as expected
                 }
 
                 // start::text::text has no difference from start::text

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2789,8 +2789,16 @@ where
     fn skip_whitespaces(&mut self) -> Result<(), DeError> {
         loop {
             match self.peek()? {
+                // Skip only blank text nodes that contain a newline or carriage return
+                // (typical pretty-printed formatting). Preserve other blank text
+                // (e.g. single space) as they may be significant for some deserialization scenarios.
                 DeEvent::Text(e) if e.is_blank() => {
-                    self.next()?;
+                    let contains_newline = e.text.chars().any(|c| c == '\n' || c == '\r');
+                    if contains_newline {
+                        self.next()?;
+                        continue;
+                    }
+                    break;
                 }
                 _ => break,
             }
@@ -4648,7 +4656,6 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
-                    // Passes as expected
                 }
 
                 // start::text::text has no difference from start::text

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -4648,7 +4648,6 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Text(" ".into()));
                     assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
-                    // Passes as expected
                 }
 
                 // start::text::text has no difference from start::text

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -4641,6 +4641,16 @@ mod tests {
                     assert_eq!(de.next().unwrap(), DeEvent::Eof);
                 }
 
+                #[test]
+                fn space() {
+                    let mut de = make_de("<tag> </tag>");
+                    assert_eq!(de.next().unwrap(), DeEvent::Start(BytesStart::new("tag")));
+                    assert_eq!(de.next().unwrap(), DeEvent::Text(" ".into()));
+                    assert_eq!(de.next().unwrap(), DeEvent::End(BytesEnd::new("tag")));
+                    assert_eq!(de.next().unwrap(), DeEvent::Eof);
+                    // Passes as expected
+                }
+
                 // start::text::text has no difference from start::text
 
                 #[test]

--- a/tests/serde-de-seq.rs
+++ b/tests/serde-de-seq.rs
@@ -831,14 +831,7 @@ mod fixed_name {
             }
 
             from_str::<List>(
-                r#"
-                <root>
-                    <item/>
-                    <item/>
-                    text
-                    <![CDATA[cdata]]>
-                </root>
-                "#,
+                r#"<root><item/><item/>text<![CDATA[cdata]]></root>"#,
             )
             .unwrap();
         }
@@ -1688,14 +1681,7 @@ mod fixed_name {
             }
 
             let data: List = from_str(
-                r#"
-                <root>
-                    <item/>
-                    <item/>
-                    text
-                    <![CDATA[cdata]]>
-                </root>
-                "#,
+                r#"<root><item/><item/>text<![CDATA[cdata]]></root>"#,
             )
             .unwrap();
 
@@ -2946,14 +2932,7 @@ mod variable_name {
             }
 
             from_str::<List>(
-                r#"
-                <root>
-                    <item/>
-                    <item/>
-                    text
-                    <![CDATA[cdata]]>
-                </root>
-                "#,
+                r#"<root><item/><item/>text<![CDATA[cdata]]></root>"#,
             )
             .unwrap();
         }
@@ -4015,14 +3994,7 @@ mod variable_name {
             }
 
             let data: List = from_str(
-                r#"
-                <root>
-                    <item/>
-                    <item/>
-                    text
-                    <![CDATA[cdata]]>
-                </root>
-                "#,
+                r#"<root><item/><item/>text<![CDATA[cdata]]></root>"#,
             )
             .unwrap();
 

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -47,7 +47,6 @@ mod text {
 
         let item: Item = from_str(r#"<root>content </root>"#).unwrap();
 
-        // Passes as expected
         assert_eq!(
             item,
             Item {
@@ -66,7 +65,6 @@ mod text {
 
         let item: Item = from_str(r#"<root> </root>"#).unwrap();
 
-        // Fails: called `Result::unwrap()` on an `Err` value: Custom("missing field `$text`")
         assert_eq!(
             item,
             Item {

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -45,12 +45,32 @@ mod text {
             content: String,
         }
 
-        let item: Item = from_str(r#"<root>content</root>"#).unwrap();
+        let item: Item = from_str(r#"<root>content </root>"#).unwrap();
 
+        // Passes as expected
         assert_eq!(
             item,
             Item {
-                content: "content".into()
+                content: "content ".into()
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_space() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Item {
+            #[serde(rename = "$text")]
+            content: String,
+        }
+
+        let item: Item = from_str(r#"<root> </root>"#).unwrap();
+
+        // Fails: called `Result::unwrap()` on an `Err` value: Custom("missing field `$text`")
+        assert_eq!(
+            item,
+            Item {
+                content: " ".into()
             }
         );
     }

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -47,6 +47,7 @@ mod text {
 
         let item: Item = from_str(r#"<root>content </root>"#).unwrap();
 
+        // Passes as expected
         assert_eq!(
             item,
             Item {
@@ -65,6 +66,7 @@ mod text {
 
         let item: Item = from_str(r#"<root> </root>"#).unwrap();
 
+        // Fails: called `Result::unwrap()` on an `Err` value: Custom("missing field `$text`")
         assert_eq!(
             item,
             Item {


### PR DESCRIPTION
Potential solution (or intermediate solution) to #896.