### PR TITLE
docs: fix typo "crates" -> "creates"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ loop {
     match reader.read_event() {
         Ok(Event::Start(e)) if e.name().as_ref() == b"this_tag" => {
 
-            // crates a new element ... alternatively we could reuse `e` by calling
+            // creates a new element ... alternatively we could reuse `e` by calling
             // `e.into_owned()`
             let mut elem = BytesStart::new("my_elem");
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -31,7 +31,7 @@ use {crate::se::SeError, serde::Serialize};
 ///     match reader.read_event() {
 ///         Ok(Event::Start(e)) if e.name().as_ref() == b"this_tag" => {
 ///
-///             // crates a new element ... alternatively we could reuse `e` by calling
+///             // creates a new element ... alternatively we could reuse `e` by calling
 ///             // `e.into_owned()`
 ///             let mut elem = BytesStart::new("my_elem");
 ///


### PR DESCRIPTION
Fixes a potential typo from a comment in the README writer example: `crates` -> `creates`