### PR TITLE
Split SyntaxError::UnclosedPIOrXmlDecl into separate enum variants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,10 +33,14 @@ struct and can be applied at once. When `serde-types` feature is enabled, config
 - [#913]: Deprecate `.prefixes()`, `.resolve()`, `.resolve_attribute()`, and `.resolve_element()`
   of `NsReader`. Use `.resolver().bindings()` and `.resolver().resolve()` methods instead.
 - [#913]: `Attributes::has_nil` now accepts `NamespaceResolver` instead of `Reader<R>`.
+- [#924]: (breaking change) Split `SyntaxError::UnclosedPIOrXmlDecl` into `UnclosedPI` and
+  `UnclosedXmlDecl` for more precise error reporting.
+- [#924]: (breaking change) `Parser::eof_error` now takes `&self` and content `&[u8]` parameters.
 
 [#846]: https://github.com/tafia/quick-xml/issues/846
 [#908]: https://github.com/tafia/quick-xml/pull/908
 [#913]: https://github.com/tafia/quick-xml/pull/913
+[#924]: https://github.com/tafia/quick-xml/pull/924
 
 
 ## 0.38.4 -- 2025-11-11

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,9 +17,12 @@ pub enum SyntaxError {
     /// The parser started to parse `<!`, but the input ended before it can recognize
     /// anything.
     InvalidBangMarkup,
-    /// The parser started to parse processing instruction or XML declaration (`<?`),
+    /// The parser started to parse processing instruction (`<?`),
     /// but the input ended before the `?>` sequence was found.
-    UnclosedPIOrXmlDecl,
+    UnclosedPI,
+    /// The parser started to parse XML declaration (`<?xml` followed by `\t`, `\r`, `\n`, ` ` or `?`),
+    /// but the input ended before the `?>` sequence was found.
+    UnclosedXmlDecl,
     /// The parser started to parse comment (`<!--`) content, but the input ended
     /// before the `-->` sequence was found.
     UnclosedComment,
@@ -38,8 +41,11 @@ impl fmt::Display for SyntaxError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::InvalidBangMarkup => f.write_str("unknown or missed symbol in markup"),
-            Self::UnclosedPIOrXmlDecl => {
-                f.write_str("processing instruction or xml declaration not closed: `?>` not found before end of input")
+            Self::UnclosedPI => {
+                f.write_str("processing instruction not closed: `?>` not found before end of input")
+            }
+            Self::UnclosedXmlDecl => {
+                f.write_str("XML declaration not closed: `?>` not found before end of input")
             }
             Self::UnclosedComment => {
                 f.write_str("comment not closed: `-->` not found before end of input")

--- a/src/parser/element.rs
+++ b/src/parser/element.rs
@@ -73,7 +73,7 @@ impl Parser for ElementParser {
     }
 
     #[inline]
-    fn eof_error() -> SyntaxError {
+    fn eof_error(self, _content: &[u8]) -> SyntaxError {
         SyntaxError::UnclosedTag
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,5 +25,9 @@ pub trait Parser {
 
     /// Returns parse error produced by this parser in case of reaching end of
     /// input without finding the end of a parsed thing.
-    fn eof_error() -> SyntaxError;
+    ///
+    /// # Parameters
+    /// - `content`: the content that was read before EOF. Some parsers may use
+    ///   this to provide more specific error messages.
+    fn eof_error(self, content: &[u8]) -> SyntaxError;
 }

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -234,7 +234,7 @@ macro_rules! impl_buffered_source {
             }
 
             *position += read;
-            Err(Error::Syntax(P::eof_error()))
+            Err(Error::Syntax(parser.eof_error(&buf[start..])))
         }
 
         #[inline]

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -350,7 +350,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         }
 
         *position += self.len() as u64;
-        Err(Error::Syntax(P::eof_error()))
+        Err(Error::Syntax(parser.eof_error(self)))
     }
 
     #[inline]

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -2,8 +2,9 @@
 use encoding_rs::UTF_8;
 
 use crate::encoding::Decoder;
-use crate::errors::{Error, IllFormedError, Result, SyntaxError};
+use crate::errors::{Error, IllFormedError, Result};
 use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event};
+use crate::parser::{Parser, PiParser};
 #[cfg(feature = "encoding")]
 use crate::reader::EncodingRef;
 use crate::reader::{BangType, Config, ParseState};
@@ -270,11 +271,11 @@ impl ReaderState {
                 )))
             }
         } else {
-            // <?....EOF
-            //  ^^^^^ - `buf` does not contains `<`, but we want to report error at `<`,
+            // <?....>
+            //  ^^^^^ - `buf` does not contain `<`, but we want to report error at `<`,
             //          so we move offset to it (-2 for `<` and `>`)
             self.last_error_offset = self.offset - len as u64 - 2;
-            Err(Error::Syntax(SyntaxError::UnclosedPIOrXmlDecl))
+            Err(Error::Syntax(PiParser(false).eof_error(buf)))
         }
     }
 


### PR DESCRIPTION
Implements #916

The SyntaxError enum is public, so this is a breaking change. 
The Parser trait is also public, so the method signature change is also a breaking change.