### PR TITLE
Split `SyntaxError::UnclosedTag` into `UnclosedTag` and `UnclosedAttributeValue`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,12 +40,15 @@ struct and can be applied at once. When `serde-types` feature is enabled, config
 - [#924]: (breaking change) Split `SyntaxError::UnclosedPIOrXmlDecl` into `UnclosedPI` and
   `UnclosedXmlDecl` for more precise error reporting.
 - [#924]: (breaking change) `Parser::eof_error` now takes `&self` and content `&[u8]` parameters.
+- [#926]: (breaking change) Split `SyntaxError::UnclosedTag` into `UnclosedTag`,
+  `UnclosedSingleQuotedAttributeValue` and `UnclosedDoubleQuotedAttributeValue` for more precise error reporting.
 
 [#846]: https://github.com/tafia/quick-xml/issues/846
 [#908]: https://github.com/tafia/quick-xml/pull/908
 [#913]: https://github.com/tafia/quick-xml/pull/913
 [#923]: https://github.com/tafia/quick-xml/issues/923
 [#924]: https://github.com/tafia/quick-xml/pull/924
+[#926]: https://github.com/tafia/quick-xml/issues/926
 [#929]: https://github.com/tafia/quick-xml/pull/929
 
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,6 +35,18 @@ pub enum SyntaxError {
     /// The parser started to parse tag content, but the input ended
     /// before the closing `>` character was found.
     UnclosedTag,
+    /// The parser started to parse tag content and currently inside of a quoted string
+    /// (i.e. in an attribute value), but the input ended before the closing quote was found.
+    ///
+    /// Note, that currently error location will point to a start of a tag (the `<` character)
+    /// instead of a start of an attribute value.
+    UnclosedSingleQuotedAttributeValue,
+    /// The parser started to parse tag content and currently inside of a quoted string
+    /// (i.e. in an attribute value), but the input ended before the closing quote was found.
+    ///
+    /// Note, that currently error location will point to a start of a tag (the `<` character)
+    /// instead of a start of an attribute value.
+    UnclosedDoubleQuotedAttributeValue,
 }
 
 impl fmt::Display for SyntaxError {
@@ -57,6 +69,12 @@ impl fmt::Display for SyntaxError {
                 f.write_str("CDATA not closed: `]]>` not found before end of input")
             }
             Self::UnclosedTag => f.write_str("tag not closed: `>` not found before end of input"),
+            Self::UnclosedSingleQuotedAttributeValue => {
+                f.write_str("attribute value not closed: `'` not found before end of input")
+            }
+            Self::UnclosedDoubleQuotedAttributeValue => {
+                f.write_str("attribute value not closed: `\"` not found before end of input")
+            }
         }
     }
 }

--- a/src/parser/element.rs
+++ b/src/parser/element.rs
@@ -74,7 +74,11 @@ impl Parser for ElementParser {
 
     #[inline]
     fn eof_error(self, _content: &[u8]) -> SyntaxError {
-        SyntaxError::UnclosedTag
+        match self {
+            Self::Outside => SyntaxError::UnclosedTag,
+            Self::SingleQ => SyntaxError::UnclosedSingleQuotedAttributeValue,
+            Self::DoubleQ => SyntaxError::UnclosedDoubleQuotedAttributeValue,
+        }
     }
 }
 

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -67,6 +67,14 @@ mod syntax {
                 );
             }
         }
+
+        // TODO: errors reported at start of a tag, but is should be reported at start of attribute value
+        mod attribute {
+            use super::*;
+
+            syntax_err!(single_quoted(".<tag a='")  => SyntaxError::UnclosedSingleQuotedAttributeValue);
+            syntax_err!(double_quoted(".<tag a=\"") => SyntaxError::UnclosedDoubleQuotedAttributeValue);
+        }
     }
 
     // Incorrect after-bang symbol is detected early, so buffer_position() stay at `!`


### PR DESCRIPTION
For more precise error reporting.

Closes #926.

Currently error is reported at start of a tag instead of start of an attribute value.