### PR TITLE
Add compare sync async benchmark

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Build
       run: cargo build
     - name: Build benchmarks
-      run: cargo bench --no-run
+      run: cargo bench --features async-tokio --no-run
     - name: Build benchmarks (compare)
       working-directory: compare
       run: cargo bench --no-run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ regex = "1"
 # serde does not follow semver in numbering and their dependencies, so we specifying patch here
 serde_derive = { version = "1.0.206" }
 serde-value = "0.7"
-tokio = { version = "1.21", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.21", default-features = false, features = ["macros", "rt"] }
 tokio-test = "0.4"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ memchr = "2.1"
 # required, `dev-dependencies` are not used). `criterion` 0.6 has msrv = 1.80, so
 # we cannot check minimal versions with it. We allow to use `criterion` 0.4 for that
 # See https://github.com/rust-lang/cargo/issues/10958
-criterion = ">=0.4,<0.9"
+criterion = { version = ">=0.4,<0.9", features = ["async_tokio"] }
 pretty_assertions = "1.4"
 regex = "1"
 # https://github.com/serde-rs/serde/issues/1904 is fixed since 1.0.206
 # serde does not follow semver in numbering and their dependencies, so we specifying patch here
 serde_derive = { version = "1.0.206" }
 serde-value = "0.7"
-tokio = { version = "1.21", default-features = false, features = ["macros", "rt"] }
+tokio = { version = "1.21", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
 tokio-test = "0.4"
 
 [lib]
@@ -61,6 +61,12 @@ path = "benches/microbenches.rs"
 name = "macrobenches"
 harness = false
 path = "benches/macrobenches.rs"
+
+[[bench]]
+name = "compare_sync_async"
+harness = false
+path = "benches/compare_sync_async.rs"
+required-features = ["async-tokio"]
 
 [features]
 default = []

--- a/benches/compare_sync_async.rs
+++ b/benches/compare_sync_async.rs
@@ -1,0 +1,51 @@
+// std::hint::black_box stable since 1.66, but our MSRV = 1.56.
+// criterion::black_box is deprecated in since criterion 0.7.
+// Running benchmarks assumed on current Rust version, so this should be fine
+#![allow(clippy::incompatible_msrv)]
+use criterion::{self, criterion_group, criterion_main, Criterion, Throughput};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+use std::hint::black_box;
+
+static SAMPLE_RSS: &[u8] = include_bytes!("../tests/documents/sample_rss.xml");
+
+pub fn bench_sync(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compare_sync");
+
+    group.throughput(Throughput::Bytes(SAMPLE_RSS.len() as u64));
+    group.bench_function("sample_rss.xml", |b| {
+        b.iter(|| {
+            let mut r = Reader::from_reader(SAMPLE_RSS);
+            let mut buf = Vec::new();
+            while !matches!(black_box(r.read_event_into(&mut buf).unwrap()), Event::Eof) {
+                buf.clear();
+            }
+        })
+    });
+
+    group.finish();
+}
+
+pub fn bench_async(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compare_async");
+
+    group.throughput(Throughput::Bytes(SAMPLE_RSS.len() as u64));
+    group.bench_function("sample_rss.xml", |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter(|| async {
+                let mut r = Reader::from_reader(SAMPLE_RSS);
+                let mut buf = Vec::new();
+                while !matches!(
+                    black_box(r.read_event_into_async(&mut buf).await.unwrap()),
+                    Event::Eof
+                ) {
+                    buf.clear();
+                }
+            })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_sync, bench_async,);
+criterion_main!(benches);

--- a/benches/compare_sync_async.rs
+++ b/benches/compare_sync_async.rs
@@ -31,17 +31,21 @@ pub fn bench_async(c: &mut Criterion) {
 
     group.throughput(Throughput::Bytes(SAMPLE_RSS.len() as u64));
     group.bench_function("sample_rss.xml", |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async {
-                let mut r = Reader::from_reader(SAMPLE_RSS);
-                let mut buf = Vec::new();
-                while !matches!(
-                    black_box(r.read_event_into_async(&mut buf).await.unwrap()),
-                    Event::Eof
-                ) {
-                    buf.clear();
-                }
-            })
+        b.to_async(
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap(),
+        )
+        .iter(|| async {
+            let mut r = Reader::from_reader(SAMPLE_RSS);
+            let mut buf = Vec::new();
+            while !matches!(
+                black_box(r.read_event_into_async(&mut buf).await.unwrap()),
+                Event::Eof
+            ) {
+                buf.clear();
+            }
+        })
     });
 
     group.finish();


### PR DESCRIPTION
It seems like the async implementation is much slower that the synchronous implementation. As a first start, add an benchmark to more easily compare them and be able to track improvements / regressions.

My actual usage does not read from static data but I would expect that reading from static data should have very similar performance for sync and async.

```
cargo bench --features async-tokio --bench compare_sync_async
   Compiling quick-xml v0.39.0 (/home/moritz/Documents/quick-xml)
    Finished `bench` profile [optimized + debuginfo] target(s) in 30.10s
     Running benches/compare_sync_async.rs (target/release/deps/compare_sync_async-ded794078866a808)
Gnuplot not found, using plotters backend
compare_sync/sample_rss.xml
                        time:   [103.25 µs 103.51 µs 103.77 µs]
                        thrpt:  [1.7749 GiB/s 1.7794 GiB/s 1.7839 GiB/s]
                 change:
                        time:   [−0.5326% −0.2991% −0.0553%] (p = 0.02 < 0.05)
                        thrpt:  [+0.0553% +0.2999% +0.5355%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

compare_async/sample_rss.xml
                        time:   [176.42 µs 176.71 µs 177.05 µs]
                        thrpt:  [1.0403 GiB/s 1.0423 GiB/s 1.0440 GiB/s]
                 change:
                        time:   [−0.1489% +1.0627% +2.0229%] (p = 0.05 < 0.05)
                        thrpt:  [−1.9828% −1.0515% +0.1491%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
```