### PR TITLE
Update nesting level data type from u16 to u32 to avoid attempt to add with overflow panic

### DIFF
--- a/src/name.rs
+++ b/src/name.rs
@@ -446,7 +446,7 @@ struct NamespaceBinding {
     /// Level of nesting at which this namespace was declared. The declaring element is included,
     /// i.e., a declaration on the document root has `level = 1`.
     /// This is used to pop the namespace when the element gets closed.
-    level: u16,
+    level: u32,
 }
 
 impl NamespaceBinding {
@@ -489,7 +489,7 @@ pub struct NamespaceResolver {
     bindings: Vec<NamespaceBinding>,
     /// The number of open tags at the moment. We need to keep track of this to know which namespace
     /// declarations to remove when we encounter an `End` event.
-    nesting_level: u16,
+    nesting_level: u32,
 }
 
 /// That constant define the one of [reserved namespaces] for the xml standard.
@@ -993,7 +993,7 @@ impl NamespaceResolver {
     /// ```
     ///
     /// [current]: Self::level
-    pub const fn bindings_of(&self, level: u16) -> NamespaceBindingsOfLevelIter<'_> {
+    pub const fn bindings_of(&self, level: u32) -> NamespaceBindingsOfLevelIter<'_> {
         NamespaceBindingsOfLevelIter {
             resolver: self,
             cursor: 0,
@@ -1030,7 +1030,7 @@ impl NamespaceResolver {
     ///
     /// [`push`]: Self::push
     /// [`pop`]: Self::pop
-    pub const fn level(&self) -> u16 {
+    pub const fn level(&self) -> u32 {
         self.nesting_level
     }
 }
@@ -1092,7 +1092,7 @@ pub type PrefixIter<'a> = NamespaceBindingsIter<'a>;
 pub struct NamespaceBindingsOfLevelIter<'a> {
     resolver: &'a NamespaceResolver,
     cursor: usize,
-    level: u16,
+    level: u32,
 }
 
 impl<'a> Iterator for NamespaceBindingsOfLevelIter<'a> {


### PR DESCRIPTION
I need to parse large XML files (50MB+) that represent traffic information following the [DATEX II](https://datex2.eu/) schema. The content of the XML looks like this:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<d2LogicalModel xmlns="http://datex2.eu/schema/1_0/1_0">
    <payloadPublication xsi:type="">
    <situation id="">
        <situationRecord xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="" id="">...</situationRecord>
        ...
    </situation>
    ...
    </payloadPublication>
</d2LogicalModel>
```

There can be several thousands of `<situation>`. I deserialize using `quick_xml` version 0.39 into custom struct:

```rust
#[derive(Deserialize)]
#[serde(rename_all = "camelCase")]
struct D2LogicalModel {
   payload_publication: SituationPublication,
}

#[derive(Deserialize)]
#[serde(rename_all = "camelCase")]
struct SituationPublication {
    #[serde(rename = "@xsi:type", alias = "@type")]
    xsi_type: String,
    situation: Vec<Situation>,
}

#[derive(Deserialize)]
#[serde(rename_all = "camelCase")]
struct Situation {
    #[serde(rename = "@id")]
    id: String,
    situation_record: Vec<SituationRecord>,
}

...

let data = include_bytes!("traffic.xml");
let model: D2LogicalModel = quick_xml::de::from_reader(data.as_slice()).unwrap();
```

But when I attempt to do so with the largest files I get a panic:

```
thread 'tests::test_deserialize_situation_publication' (384159) panicked at .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/quick-xml-0.39.0/src/name.rs:658:9:
attempt to add with overflow
```

This is the line that caused it 
```rust
pub fn push(&mut self, start: &BytesStart) -> Result<(), NamespaceError> {
        self.nesting_level += 1;
```

where `nesting_level` is a `u16` that ends up overflowing.

This patch fixes the issue by simply moving to `u32`. I am not familiar with this library so I am not sure if there are other implications, please feel free to suggest better alternatives. As a workaround I can use my fork with this commit or I could stream all the situations and deserialize one by one using this version of the library, but I'd rather avoid that.