### PR TITLE
Change parser state only after .await points to prevent state corruption

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,7 +18,11 @@
 
 ### Bug Fixes
 
+- [#624]: Fix corruption of parser state after cancelling of async reading.
+
 ### Misc Changes
+
+[#624]: https://github.com/tafia/quick-xml/issues/624
 
 
 ## 0.39.0 -- 2026-01-11


### PR DESCRIPTION
See explanation in https://github.com/tafia/quick-xml/issues/624#issuecomment-3892689132

Unfortunately, I cannot create stable test for this, so this bugfix without tests.