### PR TITLE
Consider XML version when parse XML using Deserializer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,7 +21,13 @@
 
 ### Bug Fixes
 
+- [#938]: Use correct rules for EOL normalization in `Deserializer` when parse XML 1.0 documents.
+  Previously XML 1.1. rules was applied.
+
 ### Misc Changes
+
+- [#938]: Now `BytesText::xml_content`, `BytesCData::xml_content` and `BytesRef::xml_content`
+  accepts `XmlVersion` parameter to apply correct EOL normalization rules.
 
 [#938]: https://github.com/tafia/quick-xml/pull/938
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,9 +16,14 @@
 
 ### New Features
 
+- [#938]: Add new enumeration `XmlVersion` and typified getter `BytesDecl::xml_version()`.
+- [#938]: Add new error variant `IllFormedError::UnknownVersion`.
+
 ### Bug Fixes
 
 ### Misc Changes
+
+[#938]: https://github.com/tafia/quick-xml/pull/938
 
 
 ## 0.39.2 -- 2026-02-20
@@ -41,7 +46,7 @@
 
 ### New Features
 
-- [#598]: Add method `NamespaceResolver::set_level` which may be helpful in som circumstances.
+- [#598]: Add method `NamespaceResolver::set_level` which may be helpful in some circumstances.
 
 ### Bug Fixes
 

--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -59,7 +59,7 @@ fn parse_document_from_str(doc: &str) -> XmlResult<()> {
                 }
             }
             Event::Text(e) => {
-                black_box(e.xml_content()?);
+                black_box(e.xml10_content()?);
             }
             Event::CData(e) => {
                 black_box(e.into_inner());
@@ -84,7 +84,7 @@ fn parse_document_from_bytes(doc: &[u8]) -> XmlResult<()> {
                 }
             }
             Event::Text(e) => {
-                black_box(e.xml_content()?);
+                black_box(e.xml10_content()?);
             }
             Event::CData(e) => {
                 black_box(e.into_inner());
@@ -110,7 +110,7 @@ fn parse_document_from_str_with_namespaces(doc: &str) -> XmlResult<()> {
                 }
             }
             (resolved_ns, Event::Text(e)) => {
-                black_box(e.xml_content()?);
+                black_box(e.xml10_content()?);
                 black_box(resolved_ns);
             }
             (resolved_ns, Event::CData(e)) => {
@@ -138,7 +138,7 @@ fn parse_document_from_bytes_with_namespaces(doc: &[u8]) -> XmlResult<()> {
                 }
             }
             (resolved_ns, Event::Text(e)) => {
-                black_box(e.xml_content()?);
+                black_box(e.xml10_content()?);
                 black_box(resolved_ns);
             }
             (resolved_ns, Event::CData(e)) => {

--- a/benches/microbenches.rs
+++ b/benches/microbenches.rs
@@ -150,7 +150,7 @@ fn one_event(c: &mut Criterion) {
             config.trim_text(true);
             config.check_end_names = false;
             match r.read_event() {
-                Ok(Event::Comment(e)) => nbtxt += e.xml_content().unwrap().len(),
+                Ok(Event::Comment(e)) => nbtxt += e.xml10_content().unwrap().len(),
                 something_else => panic!("Did not expect {:?}", something_else),
             };
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -103,6 +103,8 @@ pub enum IllFormedError {
     ///
     /// [specification]: https://www.w3.org/TR/xml11/#sec-prolog-dtd
     MissingDeclVersion(Option<String>),
+    /// XML version specified in the declaration neither 1.0 or 1.1.
+    UnknownVersion,
     /// A document type definition (DTD) does not contain a name of a root element.
     ///
     /// According to the [specification], document type definition (`<!DOCTYPE foo>`)
@@ -151,6 +153,9 @@ impl fmt::Display for IllFormedError {
             }
             Self::MissingDeclVersion(Some(attr)) => {
                 write!(f, "an XML declaration must start with `version` attribute, but in starts with `{}`", attr)
+            }
+            Self::UnknownVersion => {
+                f.write_str("unknown XML version: either 1.0 or 1.1 is expected")
             }
             Self::MissingDoctypeName => {
                 f.write_str("`<!DOCTYPE>` declaration does not contain a name of a document type")

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -660,8 +660,11 @@ impl<'a> BytesText<'a> {
 
     /// Alias for [`xml11_content()`](Self::xml11_content).
     #[inline]
-    pub fn xml_content(&self) -> Result<Cow<'a, str>, EncodingError> {
-        self.xml11_content()
+    pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
+        match version {
+            XmlVersion::V1_0 => self.xml10_content(),
+            XmlVersion::V1_1 => self.xml11_content(),
+        }
     }
 
     /// Alias for [`xml10_content()`](Self::xml10_content).
@@ -968,8 +971,11 @@ impl<'a> BytesCData<'a> {
 
     /// Alias for [`xml11_content()`](Self::xml11_content).
     #[inline]
-    pub fn xml_content(&self) -> Result<Cow<'a, str>, EncodingError> {
-        self.xml11_content()
+    pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
+        match version {
+            XmlVersion::V1_0 => self.xml10_content(),
+            XmlVersion::V1_1 => self.xml11_content(),
+        }
     }
 
     /// Alias for [`xml10_content()`](Self::xml10_content).
@@ -1680,8 +1686,11 @@ impl<'a> BytesRef<'a> {
 
     /// Alias for [`xml11_content()`](Self::xml11_content).
     #[inline]
-    pub fn xml_content(&self) -> Result<Cow<'a, str>, EncodingError> {
-        self.xml11_content()
+    pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
+        match version {
+            XmlVersion::V1_0 => self.xml10_content(),
+            XmlVersion::V1_1 => self.xml11_content(),
+        }
     }
 
     /// Alias for [`xml10_content()`](Self::xml10_content).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,3 +78,22 @@ pub use crate::errors::serialize::{DeError, SeError};
 pub use crate::errors::{Error, Result};
 pub use crate::reader::{NsReader, Reader};
 pub use crate::writer::{ElementWriter, Writer};
+
+/// Version of XML standard
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum XmlVersion {
+    /// [Version 1.0], which is the default version of XML document if XML declaration
+    /// is missed. Most documents in the world are still XML 1.0 documents.
+    ///
+    /// [Version 1.0]: https://www.w3.org/TR/xml/
+    V1_0,
+    /// [Version 1.1](https://www.w3.org/TR/xml11/)
+    V1_1,
+}
+
+impl Default for XmlVersion {
+    #[inline]
+    fn default() -> Self {
+        Self::V1_0
+    }
+}

--- a/tests/encodings.rs
+++ b/tests/encodings.rs
@@ -37,7 +37,7 @@ fn test_koi8_r_encoding() {
     loop {
         match r.read_event_into(&mut buf) {
             Ok(Text(e)) => {
-                e.xml_content().unwrap();
+                e.xml10_content().unwrap();
             }
             Ok(Eof) => break,
             _ => (),

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -38,7 +38,7 @@ fn fuzz_101() {
                 }
             }
             Ok(Event::Text(e)) => {
-                if e.xml_content().is_err() {
+                if e.xml10_content().is_err() {
                     break;
                 }
             }

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -172,7 +172,7 @@ fn test_escaped_content() {
                 "content unexpected: expecting 'test', got '{:?}'",
                 from_utf8(&e)
             );
-            match e.xml_content() {
+            match e.xml10_content() {
                 Ok(c) => assert_eq!(c, "test"),
                 Err(e) => panic!(
                     "cannot escape content at position {}: {:?}",

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -236,7 +236,7 @@ fn reescape_text() {
         match reader.read_event().unwrap() {
             Eof => break,
             Text(e) => {
-                let t = e.xml_content().unwrap();
+                let t = e.xml10_content().unwrap();
                 assert!(writer.write_event(Text(BytesText::new(&t))).is_ok());
             }
             e => assert!(writer.write_event(e).is_ok()),


### PR DESCRIPTION
XML 1.0 and XML 1.1 has different rules for end-of-line normalization. Previously quick-xml used XML 1.1 rules, while it should rely on XML declaration.

After this PR XML declaration will be dictate the mode.

This PR introduces `XmlVersion` enumeration and makes breaking changes for `xml_version()` methods: now they accept the version.

Because in practice there very highly unlikely will be versions other that 1.0 and 1.1, all other version strings produces new `IllFormedError::UnknownVersion` error.