### PR TITLE
Performance Improvement: Avoid Second Pass for `name_len` when parsing an element

### DIFF
--- a/src/parser/fast_element.rs
+++ b/src/parser/fast_element.rs
@@ -1,0 +1,243 @@
+//! Contains a parser for an XML element.
+
+use crate::errors::SyntaxError;
+
+/// A parser that search a `>` symbol in the slice outside of quoted regions.
+///
+/// The parser considers two quoted regions: a double-quoted (`"..."`) and
+/// a single-quoted (`'...'`) region. Matches found inside those regions are not
+/// considered as results. Each region starts and ends by its quote symbol,
+/// which cannot be escaped (but can be encoded as XML character entity or named
+/// entity. Anyway, that encoding does not contain literal quotes).
+///
+/// To use a parser create an instance of parser and [`feed`] data into it.
+/// After successful search the parser will return [`Some`] with position of
+/// found symbol. If search is unsuccessful, a [`None`] will be returned. You
+/// typically would expect positive result of search, so that you should feed
+/// new data until you get it.
+///
+/// NOTE: after successful match the parser does not returned to the initial
+/// state and should not be used anymore. Create a new parser if you want to perform
+/// new search.
+///
+/// # Example
+///
+/// ```
+/// # use pretty_assertions::assert_eq;
+/// use quick_xml::parser::{ElementParser, Parser};
+///
+/// let mut parser = ElementParser::default();
+///
+/// // Parse `<my-element  with = 'some > inside'>and the text follow...`
+/// // splitted into three chunks
+/// assert_eq!(parser.feed(b"<my-element"), None);
+/// // ...get new chunk of data
+/// assert_eq!(parser.feed(b" with = 'some >"), None);
+/// // ...get another chunk of data
+/// assert_eq!(parser.feed(b" inside'>and the text follow..."), Some(8));
+/// //                       ^       ^
+/// //                       0       8
+/// ```
+///
+/// [`feed`]: Self::feed()
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FastElementParser {
+    /// The initial state, inside the Tag name.
+    /// Contains the current length of the tag name.
+    Tag(usize),
+    /// The name fast completely parsed. Now look for the '>'.
+    Attributes(usize, AttributeParser),
+}
+
+/// The internal state of the attribute parser.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AttributeParser {
+    /// The initial state, not within ' or ".
+    Outside,
+    /// Inside a single-quoted region (`'...'`).
+    /// Contains the length of the tag name.
+    SingleQ,
+    /// Inside a double-quoted region (`"..."`).
+    /// Contains the length of the tag name.
+    DoubleQ,
+}
+
+impl FastElementParser {
+    /// Returns the length of the name and the number of consumed bytes of the current call or `None` if `>` was not found in `bytes`.
+    /// A return-value of None implies, that the full butes array was consumed.
+    /// Assumes, that the initial '<' or '</' are already consumed.
+    #[inline]
+    pub fn feed(&mut self, bytes: &[u8]) -> Option<(usize, usize)> {
+        // The number of bytes consumed in the current feed iteration.
+        let mut consumed: usize = 0;
+
+        let (name_len, mut attr_parser) = 'name_len: {
+            match *self {
+                Self::Tag(name_len) => {
+                    for i in 0..bytes.len() {
+                        let byte = bytes[i];
+
+                        if matches!(byte, b' ' | b'\r' | b'\n' | b'\t' | b'/') {
+                            // TODO(flxbe): Somehow make sure, that the only expect a '>' after the '/'.
+                            let name_len = name_len + i;
+                            let attr_parser = AttributeParser::Outside;
+                            *self = Self::Attributes(name_len, attr_parser);
+
+                            consumed += i;
+                            break 'name_len (name_len, attr_parser);
+                        } else if byte == b'>' {
+                            return Some((name_len + i, consumed + i));
+                        }
+                    }
+
+                    *self = Self::Tag(name_len + bytes.len());
+                    return None;
+                }
+                Self::Attributes(name_len, attr_parser) => (name_len, attr_parser),
+            }
+        };
+
+        let new_data = &bytes[consumed..];
+        for i in memchr::memchr3_iter(b'>', b'\'', b'"', new_data) {
+            attr_parser = match (attr_parser, new_data[i]) {
+                // only allowed to match `>` while we are in state `Outside`
+                (AttributeParser::Outside, b'>') => return Some((name_len, consumed + i)),
+                (AttributeParser::Outside, b'\'') => AttributeParser::SingleQ,
+                (AttributeParser::Outside, b'"') => AttributeParser::DoubleQ,
+
+                // the only end_byte that gets us out if the same character
+                (AttributeParser::SingleQ, b'\'') | (AttributeParser::DoubleQ, b'"') => {
+                    AttributeParser::Outside
+                }
+
+                // all other bytes: no state change
+                _ => continue,
+            };
+        }
+
+        *self = Self::Attributes(name_len, attr_parser);
+        None
+    }
+
+    /// Return the correct EOF SyntaxError based on the current internal state.
+    #[inline]
+    pub fn eof_error(self, _content: &[u8]) -> SyntaxError {
+        match self {
+            Self::Tag(_) => SyntaxError::UnclosedTag,
+            Self::Attributes(_, attr) => match attr {
+                AttributeParser::Outside => SyntaxError::UnclosedTag,
+                AttributeParser::SingleQ => SyntaxError::UnclosedSingleQuotedAttributeValue,
+                AttributeParser::DoubleQ => SyntaxError::UnclosedDoubleQuotedAttributeValue,
+            },
+        }
+    }
+}
+
+impl Default for FastElementParser {
+    #[inline]
+    fn default() -> Self {
+        Self::Tag(0)
+    }
+}
+
+#[test]
+fn parse_all() {
+    use pretty_assertions::assert_eq;
+
+    fn parse_input(input: &[u8], name_len: usize) {
+        let mut parser = FastElementParser::default();
+
+        assert_eq!(parser.feed(input), Some((name_len, input.len() - 1)));
+    }
+
+    parse_input(b"tag key='value' key=\"value\">", 3);
+    parse_input(b"tag>", 3);
+    parse_input(b"tag />", 3);
+    parse_input(b"tag/>", 3);
+}
+
+#[test]
+fn parse_internal_state() {
+    use pretty_assertions::assert_eq;
+
+    let mut parser = FastElementParser::default();
+    assert_eq!(parser.feed(b""), None);
+    assert_eq!(parser, FastElementParser::Tag(0));
+
+    // start feeding the tag
+    assert_eq!(parser.feed(b"tag"), None);
+    assert_eq!(parser, FastElementParser::Tag(3));
+
+    // Finish the tag parsing after seeing some whitespace
+    assert_eq!(parser.feed(b" "), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::Outside)
+    );
+
+    // Remain in state when no progress is made
+    assert_eq!(parser.feed(b""), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::Outside)
+    );
+    assert_eq!(parser.feed(b"some random content"), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::Outside)
+    );
+
+    // Handle single qoute
+    assert_eq!(parser.feed(b"\'"), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::SingleQ)
+    );
+
+    // Remain in state when no progress is made
+    assert_eq!(parser.feed(b""), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::SingleQ)
+    );
+    assert_eq!(parser.feed(b"some random content \">"), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::SingleQ)
+    );
+
+    // Close single quote
+    assert_eq!(parser.feed(b"'"), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::Outside)
+    );
+
+    // Handle double qoute
+    assert_eq!(parser.feed(b"\""), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::DoubleQ)
+    );
+
+    // Remain in state when no progress is made
+    assert_eq!(parser.feed(b""), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::DoubleQ)
+    );
+    assert_eq!(parser.feed(b"some random content '>"), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::DoubleQ)
+    );
+
+    // Close double quote
+    assert_eq!(parser.feed(b"\""), None);
+    assert_eq!(
+        parser,
+        FastElementParser::Attributes(3, AttributeParser::Outside)
+    );
+
+    assert_eq!(parser.feed(b">"), Some((3, 0)));
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,14 +5,14 @@ use crate::errors::SyntaxError;
 mod comment;
 mod dtd;
 mod element;
-mod start_element;
 mod pi;
+mod start_element;
 
 pub use comment::CommentParser;
 pub(crate) use dtd::DtdParser;
 pub use element::ElementParser;
-pub use start_element::StartElementParser;
 pub use pi::PiParser;
+pub use start_element::StartElementParser;
 
 /// Used to decouple reading of data from data source and parsing XML structure from it.
 /// This is a state preserved between getting chunks of bytes from the reader.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,13 +5,13 @@ use crate::errors::SyntaxError;
 mod comment;
 mod dtd;
 mod element;
-mod fast_element;
+mod start_element;
 mod pi;
 
 pub use comment::CommentParser;
 pub(crate) use dtd::DtdParser;
 pub use element::ElementParser;
-pub use fast_element::FastElementParser;
+pub use start_element::StartElementParser;
 pub use pi::PiParser;
 
 /// Used to decouple reading of data from data source and parsing XML structure from it.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,11 +5,13 @@ use crate::errors::SyntaxError;
 mod comment;
 mod dtd;
 mod element;
+mod fast_element;
 mod pi;
 
 pub use comment::CommentParser;
 pub(crate) use dtd::DtdParser;
 pub use element::ElementParser;
+pub use fast_element::FastElementParser;
 pub use pi::PiParser;
 
 /// Used to decouple reading of data from data source and parsing XML structure from it.

--- a/src/parser/start_element.rs
+++ b/src/parser/start_element.rs
@@ -11,7 +11,8 @@ use crate::errors::SyntaxError;
 /// entity. Anyway, that encoding does not contain literal quotes).
 ///
 /// To use a parser create an instance of parser and [`feed`] data into it.
-/// After successful search the parser will return [`Some`] with position of
+/// After successful search the parser will return [`Some`] with the length
+/// of the element name and the position of
 /// found symbol. If search is unsuccessful, a [`None`] will be returned. You
 /// typically would expect positive result of search, so that you should feed
 /// new data until you get it.
@@ -41,7 +42,7 @@ use crate::errors::SyntaxError;
 ///
 /// [`feed`]: Self::feed()
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum FastElementParser {
+pub enum StartElementParser {
     /// The initial state, inside the Tag name.
     /// Contains the current length of the tag name.
     Tag(usize),
@@ -55,17 +56,15 @@ pub enum AttributeParser {
     /// The initial state, not within ' or ".
     Outside,
     /// Inside a single-quoted region (`'...'`).
-    /// Contains the length of the tag name.
     SingleQ,
     /// Inside a double-quoted region (`"..."`).
-    /// Contains the length of the tag name.
     DoubleQ,
 }
 
-impl FastElementParser {
+impl StartElementParser {
     /// Returns the length of the name and the number of consumed bytes of the current call or `None` if `>` was not found in `bytes`.
-    /// A return-value of None implies, that the full butes array was consumed.
-    /// Assumes, that the initial '<' or are already consumed.
+    /// A return-value of None implies, that the full bytes array was consumed.
+    /// Assumes, that the initial '<' is already consumed.
     #[inline]
     pub fn feed(&mut self, bytes: &[u8]) -> Option<(usize, usize)> {
         // The number of bytes consumed in the current feed iteration.
@@ -133,7 +132,7 @@ impl FastElementParser {
     }
 }
 
-impl Default for FastElementParser {
+impl Default for StartElementParser {
     #[inline]
     fn default() -> Self {
         Self::Tag(0)
@@ -145,7 +144,7 @@ fn parse_all() {
     use pretty_assertions::assert_eq;
 
     fn parse_input(input: &[u8], name_len: usize) {
-        let mut parser = FastElementParser::default();
+        let mut parser = StartElementParser::default();
 
         assert_eq!(parser.feed(input), Some((name_len, input.len() - 1)));
     }
@@ -160,83 +159,83 @@ fn parse_all() {
 fn parse_internal_state() {
     use pretty_assertions::assert_eq;
 
-    let mut parser = FastElementParser::default();
+    let mut parser = StartElementParser::default();
     assert_eq!(parser.feed(b""), None);
-    assert_eq!(parser, FastElementParser::Tag(0));
+    assert_eq!(parser, StartElementParser::Tag(0));
 
     // start feeding the tag
     assert_eq!(parser.feed(b"tag"), None);
-    assert_eq!(parser, FastElementParser::Tag(3));
+    assert_eq!(parser, StartElementParser::Tag(3));
 
     // Finish the tag parsing after seeing some whitespace
     assert_eq!(parser.feed(b" "), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::Outside)
+        StartElementParser::Attributes(3, AttributeParser::Outside)
     );
 
     // Remain in state when no progress is made
     assert_eq!(parser.feed(b""), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::Outside)
+        StartElementParser::Attributes(3, AttributeParser::Outside)
     );
     assert_eq!(parser.feed(b"some random content"), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::Outside)
+        StartElementParser::Attributes(3, AttributeParser::Outside)
     );
 
     // Handle single qoute
     assert_eq!(parser.feed(b"\'"), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::SingleQ)
+        StartElementParser::Attributes(3, AttributeParser::SingleQ)
     );
 
     // Remain in state when no progress is made
     assert_eq!(parser.feed(b""), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::SingleQ)
+        StartElementParser::Attributes(3, AttributeParser::SingleQ)
     );
     assert_eq!(parser.feed(b"some random content \">"), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::SingleQ)
+        StartElementParser::Attributes(3, AttributeParser::SingleQ)
     );
 
     // Close single quote
     assert_eq!(parser.feed(b"'"), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::Outside)
+        StartElementParser::Attributes(3, AttributeParser::Outside)
     );
 
     // Handle double qoute
     assert_eq!(parser.feed(b"\""), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::DoubleQ)
+        StartElementParser::Attributes(3, AttributeParser::DoubleQ)
     );
 
     // Remain in state when no progress is made
     assert_eq!(parser.feed(b""), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::DoubleQ)
+        StartElementParser::Attributes(3, AttributeParser::DoubleQ)
     );
     assert_eq!(parser.feed(b"some random content '>"), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::DoubleQ)
+        StartElementParser::Attributes(3, AttributeParser::DoubleQ)
     );
 
     // Close double quote
     assert_eq!(parser.feed(b"\""), None);
     assert_eq!(
         parser,
-        FastElementParser::Attributes(3, AttributeParser::Outside)
+        StartElementParser::Attributes(3, AttributeParser::Outside)
     );
 
     assert_eq!(parser.feed(b">"), Some((3, 0)));

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::parser::Parser;
+use crate::parser::{FastElementParser, Parser};
 use crate::reader::{BangType, ReadRefResult, ReadTextResult, Reader, Span, XmlSource};
 use crate::utils::is_whitespace;
 
@@ -317,6 +317,45 @@ macro_rules! impl_buffered_source {
                     Err(e) => Err(e),
                 };
             }
+        }
+
+        #[inline]
+        $($async)? fn read_start_element<'i>(&mut self, buf: &'i mut Vec<u8>, position: &mut u64) -> Result<(usize, &'i [u8])> {
+            let mut parser = FastElementParser::default();
+            let mut read = 0;
+            let start = buf.len();
+            loop {
+                let available = match self $(.$reader)? .fill_buf() $(.$await)? {
+                    Ok(n) if n.is_empty() => break,
+                    Ok(n) => n,
+                    Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(e) => {
+                        *position += read;
+                        return Err(Error::Io(e.into()));
+                    }
+                };
+
+                if let Some((name_len, consumed)) = parser.feed(available) {
+                    buf.extend_from_slice(&available[..consumed]);
+
+                    // +1 for `>` which we do not include
+                    self $(.$reader)? .consume(consumed + 1);
+                    read += consumed as u64 + 1;
+
+                    *position += read;
+                    return Ok((name_len, &buf[start..]));
+                }
+
+                // The `>` symbol not yet found, continue reading
+                buf.extend_from_slice(available);
+
+                let used = available.len();
+                self $(.$reader)? .consume(used);
+                read += used as u64;
+            }
+
+            *position += read;
+            Err(Error::Syntax(parser.eof_error(&buf[start..])))
         }
     };
 }

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::parser::{FastElementParser, Parser};
+use crate::parser::{StartElementParser, Parser};
 use crate::reader::{BangType, ReadRefResult, ReadTextResult, Reader, Span, XmlSource};
 use crate::utils::is_whitespace;
 
@@ -329,7 +329,7 @@ macro_rules! impl_buffered_source {
 
         #[inline]
         $($async)? fn read_start_element<'i>(&mut self, buf: &'i mut Vec<u8>, position: &mut u64) -> Result<(usize, &'i [u8])> {
-            let mut parser = FastElementParser::default();
+            let mut parser = StartElementParser::default();
             let mut read = 1;
             // '<' was consumed in peek_one(), but not placed in buf
             buf.push(b'<');

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::parser::{StartElementParser, Parser};
+use crate::parser::{Parser, StartElementParser};
 use crate::reader::{BangType, ReadRefResult, ReadTextResult, Reader, Span, XmlSource};
 use crate::utils::is_whitespace;
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1153,7 +1153,11 @@ trait XmlSource<'r, B> {
     /// - `position`: Will be increased by amount of bytes consumed
     ///
     /// [events]: crate::events::Event
-    fn read_start_element(&mut self, buf: B, position: &mut u64) -> Result<(usize, &'r [u8]), Error>;
+    fn read_start_element(
+        &mut self,
+        buf: B,
+        position: &mut u64,
+    ) -> Result<(usize, &'r [u8]), Error>;
 }
 
 /// Possible elements started with `<!`

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -459,10 +459,10 @@ macro_rules! read_until_close {
             },
             // `<...` - opening or self-closed tag
             Ok(Some(_)) => match $reader
-                .read_with(ElementParser::Outside, $buf, &mut $self.state.offset)
+                .read_start_element($buf, &mut $self.state.offset)
                 $(.$await)?
             {
-                Ok(bytes) => Ok($self.state.emit_start(bytes)),
+                Ok((name_len, bytes)) => Ok($self.state.emit_start(name_len, bytes)),
                 Err(e) => {
                     // We want to report error at `<`, but offset was increased,
                     // so return it back (-1 for `<`)
@@ -1147,6 +1147,24 @@ trait XmlSource<'r, B> {
     /// Return one character without consuming it, so that future `read_*` calls
     /// will still include it. On EOF, return `None`.
     fn peek_one(&mut self) -> io::Result<Option<u8>>;
+
+    /// Read input until start element is finished.
+    ///
+    /// This method expect that start sequence of a parser already was read.
+    ///
+    /// Returns a tuple of the length of the tag name and a slice of data read up to the end of the thing being parsed.
+    /// The end of thing and the returned content is determined by the used parser.
+    ///
+    /// If input (`Self`) is exhausted and no bytes was read, or if the specified
+    /// parser could not find the ending sequence of the thing, returns `SyntaxError`.
+    ///
+    /// # Parameters
+    /// - `buf`: Buffer that could be filled from an input (`Self`) and
+    ///   from which [events] could borrow their data
+    /// - `position`: Will be increased by amount of bytes consumed
+    ///
+    /// [events]: crate::events::Event
+    fn read_start_element(&mut self, buf: B, position: &mut u64) -> Result<(usize, &'r [u8]), Error>;
 }
 
 /// Possible elements started with `<!`

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -13,7 +13,7 @@ use encoding_rs::{Encoding, UTF_8};
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::parser::Parser;
+use crate::parser::{FastElementParser, Parser};
 use crate::reader::{BangType, ReadRefResult, ReadTextResult, Reader, Span, XmlSource};
 use crate::utils::is_whitespace;
 
@@ -385,6 +385,22 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     #[inline]
     fn peek_one(&mut self) -> io::Result<Option<u8>> {
         Ok(self.first().copied())
+    }
+
+    #[inline]
+    fn read_start_element(&mut self, _buf: (), position: &mut u64) -> Result<(usize, &'a [u8])> {
+        let mut parser = FastElementParser::default();
+
+        if let Some((name_len, consumed)) = parser.feed(self) {
+            // +1 for `>` which we do not include
+            *position += consumed as u64 + 1;
+            let bytes = &self[..consumed];
+            *self = &self[consumed + 1..];
+            return Ok((name_len, bytes));
+        }
+
+        *position += self.len() as u64;
+        Err(Error::Syntax(parser.eof_error(self)))
     }
 }
 

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -13,7 +13,7 @@ use encoding_rs::{Encoding, UTF_8};
 use crate::errors::{Error, Result};
 use crate::events::Event;
 use crate::name::QName;
-use crate::parser::{FastElementParser, Parser};
+use crate::parser::{Parser, StartElementParser};
 use crate::reader::{BangType, ReadRefResult, ReadTextResult, Reader, Span, XmlSource};
 use crate::utils::is_whitespace;
 
@@ -398,7 +398,7 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
         *position += 1;
         *self = &self[1..];
 
-        let mut parser = FastElementParser::default();
+        let mut parser = StartElementParser::default();
 
         if let Some((name_len, consumed)) = parser.feed(self) {
             // +1 for `>` which we do not include

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -283,10 +283,10 @@ impl ReaderState {
     ///
     /// # Parameters
     /// - `content`: Content of a tag between `<` and `>`
-    pub fn emit_start<'b>(&mut self, content: &'b [u8]) -> Event<'b> {
+    pub fn emit_start<'b>(&mut self, name_len: usize, content: &'b [u8]) -> Event<'b> {
         if let Some(content) = content.strip_suffix(b"/") {
             // This is self-closed tag `<something/>`
-            let event = BytesStart::wrap(content, name_len(content), self.decoder());
+            let event = BytesStart::wrap(content, name_len, self.decoder());
 
             if self.config.expand_empty_elements {
                 self.state = ParseState::InsideEmpty;
@@ -297,7 +297,7 @@ impl ReaderState {
                 Event::Empty(event)
             }
         } else {
-            let event = BytesStart::wrap(content, name_len(content), self.decoder());
+            let event = BytesStart::wrap(content, name_len, self.decoder());
 
             // #514: Always store names event when .check_end_names == false,
             // because checks can be temporary disabled and when they would be


### PR DESCRIPTION
Hi,

Currently, after reading a start element, there’s a second pass over the data to determine the `name_len`. I’ve implemented a new `StartElementParser` that calculates the length during the initial parsing, eliminating the need for the second pass.

The new parser could also be used to parse the end element, but this slightly changes the current behaviour, as the new parser always trims trailing whitespace. This would therefore effectively remove the option `trim_markup_names_in_closing_tags`.

I’d love to hear your thoughts on these changes. I am of course happy to change the code in any way necessary to make it more suitable for your code base.

### Benchmark Results

The changes are mostly neutral or positive, with improvements up to 5% in some cases. There’s a notable negative outlier (~3%) in parse_document_nocopy/test_writer_ident.xml, which I’m happy to investigate further if needed.

```
parse_document_nocopy/rpm_primary.xml
                        time:   [37.652 µs 37.663 µs 37.677 µs]
                        thrpt:  [537.93 MiB/s 538.12 MiB/s 538.28 MiB/s]
                 change:
                        time:   [−0.7040% −0.6536% −0.6042%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6079% +0.6579% +0.7090%]
                        Change within noise threshold.
parse_document_nocopy/rpm_primary2.xml
                        time:   [12.127 µs 12.133 µs 12.142 µs]
                        thrpt:  [590.66 MiB/s 591.07 MiB/s 591.40 MiB/s]
                 change:
                        time:   [−0.4083% −0.3461% −0.2758%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2765% +0.3473% +0.4100%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
parse_document_nocopy/rpm_filelists.xml
                        time:   [15.632 µs 15.638 µs 15.643 µs]
                        thrpt:  [702.08 MiB/s 702.31 MiB/s 702.55 MiB/s]
                 change:
                        time:   [−4.2438% −3.9935% −3.7498%] (p = 0.00 < 0.05)
                        thrpt:  [+3.8959% +4.1596% +4.4319%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
parse_document_nocopy/rpm_other.xml
                        time:   [31.120 µs 31.134 µs 31.150 µs]
                        thrpt:  [710.69 MiB/s 711.05 MiB/s 711.35 MiB/s]
                 change:
                        time:   [−2.1446% −2.0347% −1.9292%] (p = 0.00 < 0.05)
                        thrpt:  [+1.9672% +2.0769% +2.1917%]
                        Performance has improved.
parse_document_nocopy/libreoffice_document.fodt
                        time:   [100.70 µs 100.72 µs 100.74 µs]
                        thrpt:  [541.98 MiB/s 542.10 MiB/s 542.20 MiB/s]
                 change:
                        time:   [+0.7645% +0.8703% +0.9730%] (p = 0.00 < 0.05)
                        thrpt:  [−0.9636% −0.8628% −0.7587%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
parse_document_nocopy/document.xml
                        time:   [27.630 µs 27.637 µs 27.644 µs]
                        thrpt:  [397.56 MiB/s 397.66 MiB/s 397.76 MiB/s]
                 change:
                        time:   [+0.4047% +0.5292% +0.6335%] (p = 0.00 < 0.05)
                        thrpt:  [−0.6295% −0.5264% −0.4031%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
parse_document_nocopy/test_writer_ident.xml
                        time:   [5.7594 µs 5.7637 µs 5.7688 µs]
                        thrpt:  [735.48 MiB/s 736.14 MiB/s 736.69 MiB/s]
                 change:
                        time:   [+3.5505% +3.6799% +3.8170%] (p = 0.00 < 0.05)
                        thrpt:  [−3.6767% −3.5493% −3.4288%]
                        Performance has regressed.
parse_document_nocopy/sample_1.xml
                        time:   [2.0167 µs 2.0179 µs 2.0192 µs]
                        thrpt:  [544.57 MiB/s 544.92 MiB/s 545.25 MiB/s]
                 change:
                        time:   [−1.6777% −1.4294% −1.1941%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2085% +1.4501% +1.7064%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
parse_document_nocopy/linescore.xml
                        time:   [6.8884 µs 6.8916 µs 6.8955 µs]
                        thrpt:  [512.14 MiB/s 512.43 MiB/s 512.66 MiB/s]
                 change:
                        time:   [−0.3856% −0.2808% −0.1799%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1802% +0.2816% +0.3870%]
                        Change within noise threshold.
Found 19 outliers among 100 measurements (19.00%)
  18 (18.00%) high mild
  1 (1.00%) high severe
parse_document_nocopy/sample_ns.xml
                        time:   [1.4501 µs 1.4507 µs 1.4514 µs]
                        thrpt:  [498.05 MiB/s 498.29 MiB/s 498.51 MiB/s]
                 change:
                        time:   [−2.6905% −2.5497% −2.4144%] (p = 0.00 < 0.05)
                        thrpt:  [+2.4742% +2.6164% +2.7648%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
parse_document_nocopy/sample_rss.xml
                        time:   [149.89 µs 149.92 µs 149.95 µs]
                        thrpt:  [1.2282 GiB/s 1.2285 GiB/s 1.2287 GiB/s]
                 change:
                        time:   [−1.8269% −1.7924% −1.7593%] (p = 0.00 < 0.05)
                        thrpt:  [+1.7908% +1.8251% +1.8609%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
parse_document_nocopy/players.xml
                        time:   [46.645 µs 46.662 µs 46.679 µs]
                        thrpt:  [310.55 MiB/s 310.66 MiB/s 310.77 MiB/s]
                 change:
                        time:   [+0.4728% +0.5357% +0.5978%] (p = 0.00 < 0.05)
                        thrpt:  [−0.5942% −0.5329% −0.4705%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

decode_and_parse_document/rpm_primary.xml
                        time:   [43.416 µs 43.424 µs 43.433 µs]
                        thrpt:  [466.63 MiB/s 466.74 MiB/s 466.82 MiB/s]
                 change:
                        time:   [−3.4105% −3.3089% −3.2093%] (p = 0.00 < 0.05)
                        thrpt:  [+3.3157% +3.4221% +3.5309%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
decode_and_parse_document/rpm_primary2.xml
                        time:   [14.302 µs 14.308 µs 14.313 µs]
                        thrpt:  [501.05 MiB/s 501.25 MiB/s 501.44 MiB/s]
                 change:
                        time:   [−1.7644% −1.7139% −1.6629%] (p = 0.00 < 0.05)
                        thrpt:  [+1.6910% +1.7438% +1.7961%]
                        Performance has improved.
decode_and_parse_document/rpm_filelists.xml
                        time:   [19.131 µs 19.136 µs 19.142 µs]
                        thrpt:  [573.73 MiB/s 573.91 MiB/s 574.07 MiB/s]
                 change:
                        time:   [−6.7699% −5.9946% −5.2544%] (p = 0.00 < 0.05)
                        thrpt:  [+5.5458% +6.3768% +7.2615%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
decode_and_parse_document/rpm_other.xml
                        time:   [31.728 µs 31.739 µs 31.751 µs]
                        thrpt:  [697.23 MiB/s 697.49 MiB/s 697.72 MiB/s]
                 change:
                        time:   [−3.2067% −3.0087% −2.8193%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9011% +3.1020% +3.3129%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
decode_and_parse_document/libreoffice_document.fodt
                        time:   [109.85 µs 109.87 µs 109.89 µs]
                        thrpt:  [496.85 MiB/s 496.96 MiB/s 497.05 MiB/s]
                 change:
                        time:   [−1.9105% −1.7392% −1.5575%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5822% +1.7700% +1.9477%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe
decode_and_parse_document/document.xml
                        time:   [28.384 µs 28.483 µs 28.634 µs]
                        thrpt:  [383.82 MiB/s 385.85 MiB/s 387.20 MiB/s]
                 change:
                        time:   [−2.3086% −2.1583% −1.9709%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0105% +2.2059% +2.3632%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
decode_and_parse_document/test_writer_ident.xml
                        time:   [6.3261 µs 6.3396 µs 6.3556 µs]
                        thrpt:  [667.58 MiB/s 669.27 MiB/s 670.69 MiB/s]
                 change:
                        time:   [−0.0598% +0.3835% +0.9399%] (p = 0.13 > 0.05)
                        thrpt:  [−0.9312% −0.3820% +0.0598%]
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
decode_and_parse_document/sample_1.xml
                        time:   [2.5346 µs 2.5384 µs 2.5436 µs]
                        thrpt:  [432.30 MiB/s 433.17 MiB/s 433.83 MiB/s]
                 change:
                        time:   [+0.6966% +0.9699% +1.2794%] (p = 0.00 < 0.05)
                        thrpt:  [−1.2632% −0.9606% −0.6918%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
decode_and_parse_document/linescore.xml
                        time:   [7.1312 µs 7.1345 µs 7.1388 µs]
                        thrpt:  [494.69 MiB/s 494.99 MiB/s 495.21 MiB/s]
                 change:
                        time:   [−0.5200% −0.4774% −0.4286%] (p = 0.00 < 0.05)
                        thrpt:  [+0.4304% +0.4797% +0.5227%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
decode_and_parse_document/sample_ns.xml
                        time:   [1.7295 µs 1.7303 µs 1.7311 µs]
                        thrpt:  [417.59 MiB/s 417.78 MiB/s 417.98 MiB/s]
                 change:
                        time:   [−3.1944% −3.1342% −3.0776%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1753% +3.2356% +3.2998%]
                        Performance has improved.
decode_and_parse_document/sample_rss.xml
                        time:   [172.83 µs 172.87 µs 172.91 µs]
                        thrpt:  [1.0652 GiB/s 1.0654 GiB/s 1.0656 GiB/s]
                 change:
                        time:   [−2.6050% −2.5637% −2.5243%] (p = 0.00 < 0.05)
                        thrpt:  [+2.5896% +2.6312% +2.6747%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
decode_and_parse_document/players.xml
                        time:   [47.049 µs 47.059 µs 47.070 µs]
                        thrpt:  [307.96 MiB/s 308.04 MiB/s 308.10 MiB/s]
                 change:
                        time:   [−0.0501% −0.0066% +0.0365%] (p = 0.76 > 0.05)
                        thrpt:  [−0.0365% +0.0066% +0.0501%]
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

parse_document_nocopy_with_namespaces/rpm_primary.xml
                        time:   [55.821 µs 55.840 µs 55.862 µs]
                        thrpt:  [362.81 MiB/s 362.95 MiB/s 363.08 MiB/s]
                 change:
                        time:   [−0.3979% −0.3248% −0.2538%] (p = 0.00 < 0.05)
                        thrpt:  [+0.2545% +0.3259% +0.3995%]
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
parse_document_nocopy_with_namespaces/rpm_primary2.xml
                        time:   [18.249 µs 18.255 µs 18.261 µs]
                        thrpt:  [392.73 MiB/s 392.86 MiB/s 392.99 MiB/s]
                 change:
                        time:   [−0.6810% −0.6084% −0.5370%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5399% +0.6122% +0.6856%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
parse_document_nocopy_with_namespaces/rpm_filelists.xml
                        time:   [23.762 µs 23.890 µs 24.039 µs]
                        thrpt:  [456.86 MiB/s 459.71 MiB/s 462.18 MiB/s]
                 change:
                        time:   [−4.2331% −4.0294% −3.7331%] (p = 0.00 < 0.05)
                        thrpt:  [+3.8778% +4.1986% +4.4202%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  9 (9.00%) high severe
parse_document_nocopy_with_namespaces/rpm_other.xml
                        time:   [42.502 µs 42.593 µs 42.686 µs]
                        thrpt:  [518.62 MiB/s 519.75 MiB/s 520.86 MiB/s]
                 change:
                        time:   [+0.7454% +0.9073% +1.0655%] (p = 0.00 < 0.05)
                        thrpt:  [−1.0543% −0.8991% −0.7398%]
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  8 (8.00%) high severe
parse_document_nocopy_with_namespaces/libreoffice_document.fodt
                        time:   [161.96 µs 162.02 µs 162.09 µs]
                        thrpt:  [336.84 MiB/s 336.98 MiB/s 337.11 MiB/s]
                 change:
                        time:   [+0.2711% +0.4096% +0.5517%] (p = 0.00 < 0.05)
                        thrpt:  [−0.5487% −0.4079% −0.2704%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
parse_document_nocopy_with_namespaces/document.xml
                        time:   [41.761 µs 41.798 µs 41.841 µs]
                        thrpt:  [262.66 MiB/s 262.93 MiB/s 263.16 MiB/s]
                 change:
                        time:   [+1.2191% +1.3331% +1.4413%] (p = 0.00 < 0.05)
                        thrpt:  [−1.4208% −1.3156% −1.2044%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
parse_document_nocopy_with_namespaces/test_writer_ident.xml
                        time:   [9.1443 µs 9.1519 µs 9.1603 µs]
                        thrpt:  [463.18 MiB/s 463.61 MiB/s 463.99 MiB/s]
                 change:
                        time:   [+1.2867% +1.3810% +1.4826%] (p = 0.00 < 0.05)
                        thrpt:  [−1.4610% −1.3621% −1.2703%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
parse_document_nocopy_with_namespaces/sample_1.xml
                        time:   [2.9547 µs 2.9573 µs 2.9599 µs]
                        thrpt:  [371.49 MiB/s 371.83 MiB/s 372.15 MiB/s]
                 change:
                        time:   [+0.5262% +0.6296% +0.7372%] (p = 0.00 < 0.05)
                        thrpt:  [−0.7318% −0.6257% −0.5234%]
                        Change within noise threshold.
parse_document_nocopy_with_namespaces/linescore.xml
                        time:   [9.0871 µs 9.0910 µs 9.0950 µs]
                        thrpt:  [388.28 MiB/s 388.46 MiB/s 388.62 MiB/s]
                 change:
                        time:   [+1.2101% +1.2942% +1.3692%] (p = 0.00 < 0.05)
                        thrpt:  [−1.3507% −1.2777% −1.1956%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
parse_document_nocopy_with_namespaces/sample_ns.xml
                        time:   [2.4334 µs 2.4349 µs 2.4364 µs]
                        thrpt:  [296.70 MiB/s 296.89 MiB/s 297.07 MiB/s]
                 change:
                        time:   [−1.8184% −1.7329% −1.6527%] (p = 0.00 < 0.05)
                        thrpt:  [+1.6805% +1.7635% +1.8520%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
parse_document_nocopy_with_namespaces/sample_rss.xml
                        time:   [237.72 µs 237.79 µs 237.86 µs]
                        thrpt:  [792.90 MiB/s 793.14 MiB/s 793.37 MiB/s]
                 change:
                        time:   [−1.1989% −1.1520% −1.1070%] (p = 0.00 < 0.05)
                        thrpt:  [+1.1194% +1.1655% +1.2134%]
                        Performance has improved.
parse_document_nocopy_with_namespaces/players.xml
                        time:   [58.641 µs 58.659 µs 58.682 µs]
                        thrpt:  [247.02 MiB/s 247.12 MiB/s 247.20 MiB/s]
                 change:
                        time:   [+0.0902% +0.1627% +0.2450%] (p = 0.00 < 0.05)
                        thrpt:  [−0.2444% −0.1624% −0.0902%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

decode_and_parse_document_with_namespaces/rpm_primary.xml
                        time:   [58.841 µs 58.877 µs 58.911 µs]
                        thrpt:  [344.04 MiB/s 344.23 MiB/s 344.45 MiB/s]
                 change:
                        time:   [−3.9701% −3.8648% −3.7566%] (p = 0.00 < 0.05)
                        thrpt:  [+3.9033% +4.0202% +4.1342%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
decode_and_parse_document_with_namespaces/rpm_primary2.xml
                        time:   [19.667 µs 19.695 µs 19.724 µs]
                        thrpt:  [363.60 MiB/s 364.14 MiB/s 364.66 MiB/s]
                 change:
                        time:   [−2.3489% −2.1892% −2.0303%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0724% +2.2381% +2.4054%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe
decode_and_parse_document_with_namespaces/rpm_filelists.xml
                        time:   [25.445 µs 25.458 µs 25.470 µs]
                        thrpt:  [431.19 MiB/s 431.40 MiB/s 431.62 MiB/s]
                 change:
                        time:   [−3.5623% −3.4606% −3.3628%] (p = 0.00 < 0.05)
                        thrpt:  [+3.4799% +3.5847% +3.6939%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
decode_and_parse_document_with_namespaces/rpm_other.xml
                        time:   [41.620 µs 41.637 µs 41.653 µs]
                        thrpt:  [531.48 MiB/s 531.68 MiB/s 531.89 MiB/s]
                 change:
                        time:   [−2.7263% −2.6604% −2.5939%] (p = 0.00 < 0.05)
                        thrpt:  [+2.6630% +2.7331% +2.8027%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
decode_and_parse_document_with_namespaces/libreoffice_document.fodt
                        time:   [164.74 µs 164.87 µs 165.00 µs]
                        thrpt:  [330.90 MiB/s 331.18 MiB/s 331.42 MiB/s]
                 change:
                        time:   [−1.7514% −1.6479% −1.5432%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5674% +1.6755% +1.7826%]
                        Performance has improved.
decode_and_parse_document_with_namespaces/document.xml
                        time:   [42.192 µs 42.225 µs 42.260 µs]
                        thrpt:  [260.06 MiB/s 260.27 MiB/s 260.48 MiB/s]
                 change:
                        time:   [−2.9642% −2.8800% −2.7875%] (p = 0.00 < 0.05)
                        thrpt:  [+2.8675% +2.9654% +3.0547%]
                        Performance has improved.
decode_and_parse_document_with_namespaces/test_writer_ident.xml
                        time:   [9.4393 µs 9.4475 µs 9.4565 µs]
                        thrpt:  [448.67 MiB/s 449.10 MiB/s 449.49 MiB/s]
                 change:
                        time:   [−2.3612% −2.2433% −2.1215%] (p = 0.00 < 0.05)
                        thrpt:  [+2.1675% +2.2948% +2.4183%]
                        Performance has improved.
decode_and_parse_document_with_namespaces/sample_1.xml
                        time:   [3.3402 µs 3.3443 µs 3.3479 µs]
                        thrpt:  [328.44 MiB/s 328.80 MiB/s 329.20 MiB/s]
                 change:
                        time:   [−0.6112% −0.4832% −0.3600%] (p = 0.00 < 0.05)
                        thrpt:  [+0.3613% +0.4855% +0.6150%]
                        Change within noise threshold.
decode_and_parse_document_with_namespaces/linescore.xml
                        time:   [9.2078 µs 9.2151 µs 9.2269 µs]
                        thrpt:  [382.73 MiB/s 383.23 MiB/s 383.53 MiB/s]
                 change:
                        time:   [+0.3936% +0.4528% +0.5220%] (p = 0.00 < 0.05)
                        thrpt:  [−0.5193% −0.4507% −0.3921%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high severe
decode_and_parse_document_with_namespaces/sample_ns.xml
                        time:   [2.6705 µs 2.6723 µs 2.6741 µs]
                        thrpt:  [270.33 MiB/s 270.51 MiB/s 270.69 MiB/s]
                 change:
                        time:   [−2.0051% −1.9104% −1.8178%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8515% +1.9476% +2.0461%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
decode_and_parse_document_with_namespaces/sample_rss.xml
                        time:   [241.57 µs 241.69 µs 241.80 µs]
                        thrpt:  [779.98 MiB/s 780.34 MiB/s 780.71 MiB/s]
                 change:
                        time:   [−3.2531% −3.1301% −3.0123%] (p = 0.00 < 0.05)
                        thrpt:  [+3.1059% +3.2313% +3.3625%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
decode_and_parse_document_with_namespaces/players.xml
                        time:   [59.328 µs 59.349 µs 59.368 µs]
                        thrpt:  [244.17 MiB/s 244.25 MiB/s 244.33 MiB/s]
                 change:
                        time:   [+0.4435% +0.4928% +0.5470%] (p = 0.00 < 0.05)
                        thrpt:  [−0.5440% −0.4904% −0.4415%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

     Running benches/microbenches.rs (target/release/deps/microbenches-0214319a012ada6d)
Gnuplot not found, using plotters backend
read_event/trim_text = false
                        time:   [66.373 µs 66.392 µs 66.412 µs]
                        change: [−5.0336% −4.9710% −4.9079%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
read_event/trim_text = true
                        time:   [67.483 µs 67.503 µs 67.523 µs]
                        change: [−2.1760% −2.0694% −1.9749%] (p = 0.00 < 0.05)
                        Performance has improved.

NsReader::read_resolved_event_into/trim_text = false
                        time:   [121.10 µs 121.15 µs 121.22 µs]
                        change: [−3.4586% −3.4085% −3.3622%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
NsReader::read_resolved_event_into/trim_text = true
                        time:   [122.42 µs 122.46 µs 122.51 µs]
                        change: [−2.5293% −2.4897% −2.4463%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

One event/Start         time:   [56.590 ns 56.612 ns 56.638 ns]
                        change: [−1.4987% −1.4341% −1.3650%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
One event/Comment       time:   [45.840 ns 45.843 ns 45.846 ns]
                        change: [−0.0416% −0.0098% +0.0164%] (p = 0.53 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe
One event/CData         time:   [14.840 ns 14.841 ns 14.842 ns]
                        change: [−0.0117% +0.0056% +0.0226%] (p = 0.54 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

attributes/with_checks = true
                        time:   [36.685 µs 36.691 µs 36.696 µs]
                        change: [−0.8596% −0.8130% −0.7734%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
attributes/with_checks = false
                        time:   [25.730 µs 25.741 µs 25.753 µs]
                        change: [−0.2101% −0.1488% −0.0784%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
attributes/try_get_attribute
                        time:   [38.292 µs 38.300 µs 38.309 µs]
                        change: [−0.1398% −0.0871% −0.0174%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

escape_text/no_chars_to_escape_long
                        time:   [545.54 ns 545.60 ns 545.65 ns]
                        change: [−0.0212% +0.0055% +0.0307%] (p = 0.69 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
escape_text/no_chars_to_escape_short
                        time:   [7.6503 ns 7.6526 ns 7.6551 ns]
                        change: [−0.0843% −0.0275% +0.0219%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  11 (11.00%) high mild
escape_text/escaped_chars_short
                        time:   [175.54 ns 176.12 ns 176.68 ns]
                        change: [+1.5749% +1.8662% +2.1607%] (p = 0.00 < 0.05)
                        Performance has regressed.
escape_text/escaped_chars_long
                        time:   [704.86 ns 705.31 ns 705.76 ns]
                        change: [+2.1048% +2.1755% +2.2421%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild

unescape_text/no_chars_to_unescape_long
                        time:   [27.921 ns 27.922 ns 27.925 ns]
                        change: [−0.3303% −0.3075% −0.2827%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe
unescape_text/no_chars_to_unescape_short
                        time:   [2.9152 ns 2.9155 ns 2.9158 ns]
                        change: [−0.0261% −0.0051% +0.0169%] (p = 0.65 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  7 (7.00%) high mild
  3 (3.00%) high severe
unescape_text/char_reference
                        time:   [85.901 ns 85.911 ns 85.922 ns]
                        change: [−2.9592% −2.8452% −2.7329%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
unescape_text/entity_reference
                        time:   [91.728 ns 91.740 ns 91.752 ns]
                        change: [−0.6244% −0.5695% −0.5163%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe
unescape_text/mixed     time:   [108.42 ns 108.44 ns 108.46 ns]
                        change: [−0.6089% −0.5808% −0.5457%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```