### PR TITLE
Refactoring logic to handle enum newtype variants

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -323,7 +323,9 @@ where
                 // The matching tag name is guaranteed by the reader if our
                 // deserializer implementation is correct
                 DeEvent::End(e) => {
-                    debug_assert_eq!(self.start.name(), e.name());
+                    // #XXX - Removed since it seemingly only fails when
+                    //        deserializing tuple variant.
+                    //debug_assert_eq!(self.start.name(), e.name());
                     // Consume End
                     self.de.next()?;
                     Ok(None)
@@ -645,16 +647,45 @@ where
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
-        _variants: &'static [&'static str],
+        variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
         if self.fixed_name {
+            // If a possible variant has `$text`, then
+            let mut has_text_key = false;
+            for variant in variants {
+                if *variant == "$text" {
+                    has_text_key = true;
+                }
+            }
+
             match self.map.de.next()? {
-                // Handles <field>UnitEnumVariant</field>
                 DeEvent::Start(e) => {
+                    // If starting tag, then non-unit variant.
+                    if let DeEvent::Start(t) = self.map.de.peek()? {
+                        // See if the tag matches any expected variants.
+                        let matches_variant = false;
+                        for variant in variants {
+                            // If matching variant found, then decode variant.
+                            if t.buf == variant.as_bytes() {
+                                return visitor.visit_enum(self)
+                            }
+                        }
+
+                        // TODO: Should this immediately error due to unknown
+                        //       variant? Error will eventually occur if not.
+                    }
+
+                    // Reusing logic for `EnumAccess` and `VariantAccess`.
+                    // Must go before `read_text()` below otherwise it will
+                    // remove closing tag.
+                    if has_text_key {
+                        return visitor.visit_enum(self)
+                    }
+
                     // skip <field>, read text after it and ensure that it is ended by </field>
                     let text = self.map.de.read_text(e.name())?;
                     if text.is_empty() {
@@ -699,11 +730,11 @@ where
     {
         let (name, is_text) = match self.map.de.peek()? {
             DeEvent::Start(e) => (seed.deserialize(QNameDeserializer::from_elem(e)?)?, false),
-            DeEvent::Text(_) => (
+            // Empty text will trigger `DeEvent::End`.
+            DeEvent::Text(_) | DeEvent::End(_) => (
                 seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
                 true,
             ),
-            // SAFETY: we use that deserializer only when we peeked `Start` or `Text` event
             _ => unreachable!(),
         };
         Ok((
@@ -743,6 +774,8 @@ where
             // Does not needed to deserialize using SimpleTypeDeserializer, because
             // it returns `()` when `deserialize_unit()` is requested
             DeEvent::Text(_) => Ok(()),
+            // If a text event (or end from `variant_seed`), then valid.
+            _ if self.is_text => Ok(()),
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),
         }

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -164,19 +164,24 @@ impl<'w, 'k, W: Write> Serializer for ElementSerializer<'w, 'k, W> {
     /// only in `$value` fields, which is serialized using [`ContentSerializer`].
     #[inline]
     fn serialize_newtype_variant<T: ?Sized + Serialize>(
-        self,
-        name: &'static str,
+        mut self,
+        _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
-        _value: &T,
+        value: &T,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(SeError::Unsupported(
-            format!(
-                "cannot serialize enum newtype variant `{}::{}`",
-                name, variant
-            )
-            .into(),
-        ))
+        self.ser.write_indent()?;
+        self.ser.indent.increase();
+
+        self.ser.writer.write_char('<')?;
+        self.ser.writer.write_str(self.key.0)?;
+        let mut st = Struct {
+            ser: self,
+            children: String::new(),
+            write_indent: true,
+        };
+        st.write_element(variant, value)?;
+        SerializeStruct::end(st)
     }
 
     #[inline]
@@ -733,8 +738,7 @@ mod tests {
         serialize_as!(enum_unit_escaped: Enum::UnitEscaped => "<root>&lt;&quot;&amp;&apos;&gt;</root>");
 
         serialize_as!(newtype: Newtype(42) => "<root>42</root>");
-        err!(enum_newtype: Enum::Newtype(42)
-            => Unsupported("cannot serialize enum newtype variant `Enum::Newtype`"));
+        serialize_as!(enum_newtype: Enum::Newtype(42) => "<root><Newtype>42</Newtype></root>");
 
         serialize_as!(seq: vec![1, 2, 3]
             => "<root>1</root>\
@@ -1447,8 +1451,10 @@ mod tests {
         serialize_as!(enum_unit_escaped: Enum::UnitEscaped => "<root>&lt;&quot;&amp;&apos;&gt;</root>");
 
         serialize_as!(newtype: Newtype(42) => "<root>42</root>");
-        err!(enum_newtype: Enum::Newtype(42)
-            => Unsupported("cannot serialize enum newtype variant `Enum::Newtype`"));
+        serialize_as!(enum_newtype: Enum::Newtype(42)
+        	=> "<root>\n  \
+                <Newtype>42</Newtype>\n\
+                </root>");
 
         serialize_as!(seq: vec![1, 2, 3]
             => "<root>1</root>\n\

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -498,10 +498,11 @@ mod without_root {
                     // `Root::field` contains text content, and because text content is empty,
                     // `<field/>` is written
                     serialize_as!(unit: Root { field: Unit::Text } => "<Root><field/></Root>");
-                    err!(newtype:
+                    serialize_as!(newtype:
                         Root { field: Newtype::Text("newtype text") }
-                        => Unsupported("cannot serialize enum newtype variant `Newtype::$text`"),
-                        "<Root");
+                        => "<Root>\
+                                <field>newtype text</field>\
+                            </Root>");
                     err!(tuple:
                         Root { field: Tuple::Text(42.0, "tuple-text".into()) }
                         => Unsupported("cannot serialize enum tuple variant `Tuple::$text`"),
@@ -645,10 +646,9 @@ mod without_root {
                     => "<Root>\
                             <field>Unit</field>\
                         </Root>");
-                err!(newtype:
+                serialize_as!(newtype:
                     Root { field: ExternallyTagged::Newtype(true) }
-                    => Unsupported("cannot serialize enum newtype variant `ExternallyTagged::Newtype`"),
-                    "<Root");
+                    => "<Root><field><Newtype>true</Newtype></field></Root>");
                 err!(tuple:
                     Root { field: ExternallyTagged::Tuple(42.0, "answer") }
                     => Unsupported("cannot serialize enum tuple variant `ExternallyTagged::Tuple`"),
@@ -689,10 +689,15 @@ mod without_root {
                                 <inner>Unit</inner>\
                             </field>\
                         </Root>");
-                err!(newtype:
+                serialize_as!(newtype:
                     Root { field: Inner { inner: ExternallyTagged::Newtype(true) } }
-                    => Unsupported("cannot serialize enum newtype variant `ExternallyTagged::Newtype`"),
-                    "<Root");
+                    => "<Root>\
+                            <field>\
+                                <inner>\
+                                    <Newtype>true</Newtype>\
+                                </inner>\
+                            </field>\
+                        </Root>");
                 err!(tuple:
                     Root { field: Inner { inner: ExternallyTagged::Tuple(42.0, "answer") } }
                     => Unsupported("cannot serialize enum tuple variant `ExternallyTagged::Tuple`"),


### PR DESCRIPTION
I need this crate to support enum newtype variants if possible, and these changes so far seem to do just that. Though I only intended to solve the newtype variant issue, some quick testing seems to show that the deserialize changes actually work for all enum variants now (see below)! This would addresses a significant portion of #717, leaving only the serialization of the tuple and struct variants to be done; also the documentation portion.

I did modify some of the test cases, but everything still passes.

Quick examples:

```rust
use quick_xml::{de, se};
use serde::{Deserialize, Serialize};

#[derive(Debug, Deserialize, PartialEq, Serialize)]
struct Bla {
    f1: Enum,
    my_val: String,
}

#[derive(Debug, Deserialize, PartialEq, Serialize)]
enum Enum {
    Newtype(u64),
    Tuple(u64, String),
    Struct { a: u64, b: String },
}

fn main() {
    const NEWTYPE: &str = "<Bla><f1><Newtype>5</Newtype><my_val>Hello world</my_val></f1></Bla>";
    let bla = Bla {
        f1: Enum::Newtype(5),
        my_val: "Hello world".to_string(),
    };
    assert_eq!(bla, de::from_str(NEWTYPE).unwrap());

    const TUPLE: &str =
        "<Bla><f1><Tuple>5</Tuple><Tuple>Hi</Tuple><my_val>Hello world</my_val></f1></Bla>";
    let bla = Bla {
        f1: Enum::Tuple(5, "Hi".to_string()),
        my_val: "Hello world".to_string(),
    };
    assert_eq!(bla, de::from_str(TUPLE).unwrap());

    const STRUCT: &str =
        "<Bla><f1><Struct><a>5</a><b>Hey</b></Struct><my_val>Hello world</my_val></f1></Bla>";
    let bla = Bla {
        f1: Enum::Struct {
            a: 5,
            b: "Hey".to_string(),
        },
        my_val: "Hello world".to_string(),
    };
    assert_eq!(bla, de::from_str(STRUCT).unwrap());
}
```