### PR TITLE
Deserialize custom entities inside attributes

### DIFF
--- a/src/de/attributes.rs
+++ b/src/de/attributes.rs
@@ -6,6 +6,7 @@ use serde::de::{DeserializeSeed, Deserializer, Error, MapAccess, Visitor};
 use serde::forward_to_deserialize_any;
 
 use crate::de::key::QNameDeserializer;
+use crate::de::{EntityResolver, PredefinedEntityResolver};
 use crate::de::SimpleTypeDeserializer;
 use crate::errors::serialize::DeError;
 use crate::events::attributes::Attributes;
@@ -25,6 +26,7 @@ impl<'i> Attributes<'i> {
     /// ```
     /// # use pretty_assertions::assert_eq;
     /// use quick_xml::events::BytesStart;
+    /// use quick_xml::de::PredefinedEntityResolver;
     /// use quick_xml::XmlVersion;
     /// use serde::Deserialize;
     ///
@@ -47,7 +49,7 @@ impl<'i> Attributes<'i> {
     ///     3
     /// );
     /// // Strip nothing from the field names
-    /// let de = tag.attributes().clone().into_map_access(XmlVersion::V1_0, "");
+    /// let de = tag.attributes().clone().into_map_access(XmlVersion::V1_0, "", &PredefinedEntityResolver);
     /// assert_eq!(
     ///     MyData::deserialize(de).unwrap(),
     ///     MyData {
@@ -57,7 +59,7 @@ impl<'i> Attributes<'i> {
     /// );
     ///
     /// // Strip "@" from the field name
-    /// let de = tag.attributes().into_map_access(XmlVersion::V1_0, "@");
+    /// let de = tag.attributes().into_map_access(XmlVersion::V1_0, "@", &PredefinedEntityResolver);
     /// assert_eq!(
     ///     MyDataPrefixed::deserialize(de).unwrap(),
     ///     MyDataPrefixed {
@@ -67,17 +69,19 @@ impl<'i> Attributes<'i> {
     /// );
     /// ```
     #[inline]
-    pub const fn into_map_access(
+    pub const fn into_map_access<E: EntityResolver>(
         self,
         version: XmlVersion,
         prefix: &'static str,
-    ) -> AttributesDeserializer<'i> {
+        entity_resolver: &'i E,
+    ) -> AttributesDeserializer<'i, E> {
         AttributesDeserializer {
             iter: self,
             value: None,
             prefix,
             key_buf: String::new(),
             version,
+            entity_resolver,
         }
     }
 }
@@ -96,7 +100,7 @@ impl<'i> Attributes<'i> {
 /// In particular, when reader was created from a string, this is lifetime of the
 /// string.
 #[derive(Debug, Clone)]
-pub struct AttributesDeserializer<'i> {
+pub struct AttributesDeserializer<'i, E: EntityResolver = PredefinedEntityResolver> {
     iter: Attributes<'i>,
     /// The value of the attribute, read in last call to `next_key_seed`.
     value: Option<Cow<'i, [u8]>>,
@@ -106,9 +110,10 @@ pub struct AttributesDeserializer<'i> {
     /// Kept in the deserializer to avoid many small allocations
     key_buf: String,
     version: XmlVersion,
+    entity_resolver: &'i E,
 }
 
-impl<'de> Deserializer<'de> for AttributesDeserializer<'de> {
+impl<'de, E: EntityResolver> Deserializer<'de> for AttributesDeserializer<'de, E> {
     type Error = DeError;
 
     #[inline]
@@ -126,7 +131,7 @@ impl<'de> Deserializer<'de> for AttributesDeserializer<'de> {
     }
 }
 
-impl<'de> MapAccess<'de> for AttributesDeserializer<'de> {
+impl<'de, E: EntityResolver> MapAccess<'de> for AttributesDeserializer<'de, E> {
     type Error = DeError;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -160,6 +165,7 @@ impl<'de> MapAccess<'de> for AttributesDeserializer<'de> {
                     0..value.len(),
                     self.version,
                     self.iter.decoder(),
+                    self.entity_resolver,
                 );
                 seed.deserialize(de)
             }

--- a/src/de/attributes.rs
+++ b/src/de/attributes.rs
@@ -49,7 +49,7 @@ impl<'i> Attributes<'i> {
     ///     3
     /// );
     /// // Strip nothing from the field names
-    /// let de = tag.attributes().clone().into_map_access(XmlVersion::V1_0, "", &PredefinedEntityResolver);
+    /// let de = tag.attributes().clone().into_map_access(XmlVersion::V1_0, "");
     /// assert_eq!(
     ///     MyData::deserialize(de).unwrap(),
     ///     MyData {
@@ -59,7 +59,7 @@ impl<'i> Attributes<'i> {
     /// );
     ///
     /// // Strip "@" from the field name
-    /// let de = tag.attributes().into_map_access(XmlVersion::V1_0, "@", &PredefinedEntityResolver);
+    /// let de = tag.attributes().into_map_access(XmlVersion::V1_0, "@");
     /// assert_eq!(
     ///     MyDataPrefixed::deserialize(de).unwrap(),
     ///     MyDataPrefixed {
@@ -69,19 +69,18 @@ impl<'i> Attributes<'i> {
     /// );
     /// ```
     #[inline]
-    pub const fn into_map_access<E: EntityResolver>(
+    pub const fn into_map_access(
         self,
         version: XmlVersion,
         prefix: &'static str,
-        entity_resolver: &'i E,
-    ) -> AttributesDeserializer<'i, E> {
+    ) -> AttributesDeserializer<'i, PredefinedEntityResolver> {
         AttributesDeserializer {
             iter: self,
             value: None,
             prefix,
             key_buf: String::new(),
             version,
-            entity_resolver,
+            resolver: &PredefinedEntityResolver,
         }
     }
 }
@@ -110,7 +109,33 @@ pub struct AttributesDeserializer<'i, E: EntityResolver = PredefinedEntityResolv
     /// Kept in the deserializer to avoid many small allocations
     key_buf: String,
     version: XmlVersion,
-    entity_resolver: &'i E,
+    resolver: &'i E,
+}
+
+impl<'i, OldE: EntityResolver> AttributesDeserializer<'i, OldE> {
+    /// Produce a copy of this deserializer with its
+    /// [`EntityResolver`] replaced by the one given.
+    pub fn with_resolver<NewE: EntityResolver>(
+        self,
+        resolver: &'i NewE,
+    ) -> AttributesDeserializer<'i, NewE> {
+        let AttributesDeserializer {
+            iter,
+            value,
+            prefix,
+            key_buf,
+            version,
+            resolver: _,
+        } = self;
+        AttributesDeserializer {
+            iter,
+            value,
+            prefix,
+            key_buf,
+            version,
+            resolver,
+        }
+    }
 }
 
 impl<'de, E: EntityResolver> Deserializer<'de> for AttributesDeserializer<'de, E> {
@@ -165,7 +190,7 @@ impl<'de, E: EntityResolver> MapAccess<'de> for AttributesDeserializer<'de, E> {
                     0..value.len(),
                     self.version,
                     self.iter.decoder(),
-                    self.entity_resolver,
+                    self.resolver.clone(),
                 );
                 seed.deserialize(de)
             }

--- a/src/de/attributes.rs
+++ b/src/de/attributes.rs
@@ -6,8 +6,8 @@ use serde::de::{DeserializeSeed, Deserializer, Error, MapAccess, Visitor};
 use serde::forward_to_deserialize_any;
 
 use crate::de::key::QNameDeserializer;
-use crate::de::{EntityResolver, PredefinedEntityResolver};
 use crate::de::SimpleTypeDeserializer;
+use crate::de::{EntityResolver, PredefinedEntityResolver};
 use crate::errors::serialize::DeError;
 use crate::events::attributes::Attributes;
 use crate::XmlVersion;

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -347,6 +347,7 @@ where
                 value,
                 self.de.reader.reader.xml_version(),
                 self.start.decoder(),
+                &self.de.reader.entity_resolver,
             )),
             // This arm processes the following XML shape:
             // <any-tag>
@@ -357,7 +358,10 @@ where
             // is a `Text` event (the value deserializer will see that event)
             // This case are checked by "xml_schema_lists::element" tests in tests/serde-de.rs
             ValueSource::Text => match self.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
+                    e,
+                    &self.de.reader.entity_resolver,
+                )),
                 // SAFETY: We set `Text` only when we seen `Text`
                 _ => unreachable!(),
             },
@@ -555,7 +559,7 @@ where
 {
     type Error = DeError;
 
-    deserialize_primitives!(mut);
+    deserialize_primitives!(self in &self.map.de.reader.entity_resolver, mut);
 
     #[inline]
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -659,9 +663,15 @@ where
                     let text = self.map.de.read_text(e.name())?;
                     if text.is_empty() {
                         // Map empty text (<field/>) to a special `$text` variant
-                        visitor.visit_enum(SimpleTypeDeserializer::from_text(TEXT_KEY.into()))
+                        visitor.visit_enum(SimpleTypeDeserializer::from_text(
+                            TEXT_KEY.into(),
+                            &self.map.de.reader.entity_resolver,
+                        ))
                     } else {
-                        visitor.visit_enum(SimpleTypeDeserializer::from_text(text))
+                        visitor.visit_enum(SimpleTypeDeserializer::from_text(
+                            text,
+                            &self.map.de.reader.entity_resolver,
+                        ))
                     }
                 }
                 // SAFETY: we use that deserializer with `fixed_name == true`
@@ -754,7 +764,10 @@ where
     {
         if self.is_text {
             match self.map.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
+                    e,
+                    &self.map.de.reader.entity_resolver,
+                )),
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
             }
@@ -775,7 +788,10 @@ where
         if self.is_text {
             match self.map.de.next()? {
                 DeEvent::Text(e) => {
-                    SimpleTypeDeserializer::from_text_content(e).deserialize_tuple(len, visitor)
+                    SimpleTypeDeserializer::from_text_content(
+                        e,
+                        &self.map.de.reader.entity_resolver,
+                    ).deserialize_tuple(len, visitor)
                 }
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
@@ -802,7 +818,10 @@ where
         match self.map.de.next()? {
             DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.map.de, e, fields)),
             DeEvent::Text(e) => {
-                SimpleTypeDeserializer::from_text_content(e).deserialize_struct("", fields, visitor)
+                SimpleTypeDeserializer::from_text_content(
+                    e,
+                    &self.map.de.reader.entity_resolver,
+                ).deserialize_struct("", fields, visitor)
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),
@@ -951,6 +970,7 @@ where
 {
     type Error = DeError;
 
+    #[cfg_attr(not(feature = "overlapped-lists"), allow(clippy::never_loop))]
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, DeError>
     where
         T: DeserializeSeed<'de>,
@@ -1083,7 +1103,7 @@ where
 {
     type Error = DeError;
 
-    deserialize_primitives!(mut);
+    deserialize_primitives!(self in &self.de.reader.entity_resolver, mut);
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -1131,7 +1151,10 @@ where
         V: Visitor<'de>,
     {
         let text = self.read_string()?;
-        SimpleTypeDeserializer::from_text(text).deserialize_seq(visitor)
+        SimpleTypeDeserializer::from_text(
+            text,
+            &self.de.reader.entity_resolver,
+        ).deserialize_seq(visitor)
     }
 
     fn deserialize_struct<V>(

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -787,12 +787,11 @@ where
     {
         if self.is_text {
             match self.map.de.next()? {
-                DeEvent::Text(e) => {
-                    SimpleTypeDeserializer::from_text_content(
-                        e,
-                        &self.map.de.reader.entity_resolver,
-                    ).deserialize_tuple(len, visitor)
-                }
+                DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(
+                    e,
+                    &self.map.de.reader.entity_resolver,
+                )
+                .deserialize_tuple(len, visitor),
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
             }
@@ -818,10 +817,8 @@ where
         match self.map.de.next()? {
             DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.map.de, e, fields)),
             DeEvent::Text(e) => {
-                SimpleTypeDeserializer::from_text_content(
-                    e,
-                    &self.map.de.reader.entity_resolver,
-                ).deserialize_struct("", fields, visitor)
+                SimpleTypeDeserializer::from_text_content(e, &self.map.de.reader.entity_resolver)
+                    .deserialize_struct("", fields, visitor)
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),
@@ -1151,10 +1148,8 @@ where
         V: Visitor<'de>,
     {
         let text = self.read_string()?;
-        SimpleTypeDeserializer::from_text(
-            text,
-            &self.de.reader.entity_resolver,
-        ).deserialize_seq(visitor)
+        SimpleTypeDeserializer::from_text(text, &self.de.reader.entity_resolver)
+            .deserialize_seq(visitor)
     }
 
     fn deserialize_struct<V>(

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -347,7 +347,7 @@ where
                 value,
                 self.de.reader.reader.xml_version(),
                 self.start.decoder(),
-                &self.de.reader.entity_resolver,
+                self.de.reader.entity_resolver.clone(),
             )),
             // This arm processes the following XML shape:
             // <any-tag>
@@ -358,10 +358,7 @@ where
             // is a `Text` event (the value deserializer will see that event)
             // This case are checked by "xml_schema_lists::element" tests in tests/serde-de.rs
             ValueSource::Text => match self.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
-                    e,
-                    &self.de.reader.entity_resolver,
-                )),
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
                 // SAFETY: We set `Text` only when we seen `Text`
                 _ => unreachable!(),
             },
@@ -559,7 +556,7 @@ where
 {
     type Error = DeError;
 
-    deserialize_primitives!(self in &self.map.de.reader.entity_resolver, mut);
+    deserialize_primitives!(mut);
 
     #[inline]
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -663,15 +660,9 @@ where
                     let text = self.map.de.read_text(e.name())?;
                     if text.is_empty() {
                         // Map empty text (<field/>) to a special `$text` variant
-                        visitor.visit_enum(SimpleTypeDeserializer::from_text(
-                            TEXT_KEY.into(),
-                            &self.map.de.reader.entity_resolver,
-                        ))
+                        visitor.visit_enum(SimpleTypeDeserializer::from_text(TEXT_KEY.into()))
                     } else {
-                        visitor.visit_enum(SimpleTypeDeserializer::from_text(
-                            text,
-                            &self.map.de.reader.entity_resolver,
-                        ))
+                        visitor.visit_enum(SimpleTypeDeserializer::from_text(text))
                     }
                 }
                 // SAFETY: we use that deserializer with `fixed_name == true`
@@ -764,10 +755,7 @@ where
     {
         if self.is_text {
             match self.map.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
-                    e,
-                    &self.map.de.reader.entity_resolver,
-                )),
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
             }
@@ -787,11 +775,9 @@ where
     {
         if self.is_text {
             match self.map.de.next()? {
-                DeEvent::Text(e) => SimpleTypeDeserializer::from_text_content(
-                    e,
-                    &self.map.de.reader.entity_resolver,
-                )
-                .deserialize_tuple(len, visitor),
+                DeEvent::Text(e) => {
+                    SimpleTypeDeserializer::from_text_content(e).deserialize_tuple(len, visitor)
+                }
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
             }
@@ -817,8 +803,7 @@ where
         match self.map.de.next()? {
             DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.map.de, e, fields)),
             DeEvent::Text(e) => {
-                SimpleTypeDeserializer::from_text_content(e, &self.map.de.reader.entity_resolver)
-                    .deserialize_struct("", fields, visitor)
+                SimpleTypeDeserializer::from_text_content(e).deserialize_struct("", fields, visitor)
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),
@@ -1100,7 +1085,7 @@ where
 {
     type Error = DeError;
 
-    deserialize_primitives!(self in &self.de.reader.entity_resolver, mut);
+    deserialize_primitives!(mut);
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -1148,8 +1133,7 @@ where
         V: Visitor<'de>,
     {
         let text = self.read_string()?;
-        SimpleTypeDeserializer::from_text(text, &self.de.reader.entity_resolver)
-            .deserialize_seq(visitor)
+        SimpleTypeDeserializer::from_text(text).deserialize_seq(visitor)
     }
 
     fn deserialize_struct<V>(

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1974,13 +1974,13 @@
 //! [`impl_deserialize_for_internally_tagged_enum!`]: crate::impl_deserialize_for_internally_tagged_enum
 
 macro_rules! forward_to_simple_type {
-    ($deserialize:ident, $($mut:tt)?) => {
+    ($deserialize:ident, $self:ident in $resolver:expr $(, $mut:tt)?) => {
         #[inline]
-        fn $deserialize<V>($($mut)? self, visitor: V) -> Result<V::Value, DeError>
+        fn $deserialize<V>($($mut)? $self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
         {
-            SimpleTypeDeserializer::from_text(self.read_string()?).$deserialize(visitor)
+            SimpleTypeDeserializer::from_text($self.read_string()?, $resolver).$deserialize(visitor)
         }
     };
 }
@@ -1988,28 +1988,28 @@ macro_rules! forward_to_simple_type {
 /// Implement deserialization methods for scalar types, such as numbers, strings,
 /// byte arrays, booleans and identifiers.
 macro_rules! deserialize_primitives {
-    ($($mut:tt)?) => {
-        forward_to_simple_type!(deserialize_i8, $($mut)?);
-        forward_to_simple_type!(deserialize_i16, $($mut)?);
-        forward_to_simple_type!(deserialize_i32, $($mut)?);
-        forward_to_simple_type!(deserialize_i64, $($mut)?);
+    ($self:ident in $resolver:expr $(, $mut:tt)?) => {
+        forward_to_simple_type!(deserialize_i8, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_i16, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_i32, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_i64, $self in $resolver $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_u8, $($mut)?);
-        forward_to_simple_type!(deserialize_u16, $($mut)?);
-        forward_to_simple_type!(deserialize_u32, $($mut)?);
-        forward_to_simple_type!(deserialize_u64, $($mut)?);
+        forward_to_simple_type!(deserialize_u8, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_u16, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_u32, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_u64, $self in $resolver $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_i128, $($mut)?);
-        forward_to_simple_type!(deserialize_u128, $($mut)?);
+        forward_to_simple_type!(deserialize_i128, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_u128, $self in $resolver $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_f32, $($mut)?);
-        forward_to_simple_type!(deserialize_f64, $($mut)?);
+        forward_to_simple_type!(deserialize_f32, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_f64, $self in $resolver $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_bool, $($mut)?);
-        forward_to_simple_type!(deserialize_char, $($mut)?);
+        forward_to_simple_type!(deserialize_bool, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_char, $self in $resolver $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_str, $($mut)?);
-        forward_to_simple_type!(deserialize_string, $($mut)?);
+        forward_to_simple_type!(deserialize_str, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_string, $self in $resolver $(, $mut)?);
 
         /// Forwards deserialization to the [`deserialize_any`](#method.deserialize_any).
         #[inline]
@@ -3195,7 +3195,7 @@ where
 {
     type Error = DeError;
 
-    deserialize_primitives!();
+    deserialize_primitives!(self in &self.reader.entity_resolver);
 
     fn deserialize_struct<V>(
         self,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1974,13 +1974,13 @@
 //! [`impl_deserialize_for_internally_tagged_enum!`]: crate::impl_deserialize_for_internally_tagged_enum
 
 macro_rules! forward_to_simple_type {
-    ($deserialize:ident, $self:ident in $resolver:expr $(, $mut:tt)?) => {
+    ($deserialize:ident $(, $mut:tt)?) => {
         #[inline]
-        fn $deserialize<V>($($mut)? $self, visitor: V) -> Result<V::Value, DeError>
+        fn $deserialize<V>($($mut)? self, visitor: V) -> Result<V::Value, DeError>
         where
             V: Visitor<'de>,
         {
-            SimpleTypeDeserializer::from_text($self.read_string()?, $resolver).$deserialize(visitor)
+            SimpleTypeDeserializer::from_text(self.read_string()?).$deserialize(visitor)
         }
     };
 }
@@ -1988,28 +1988,28 @@ macro_rules! forward_to_simple_type {
 /// Implement deserialization methods for scalar types, such as numbers, strings,
 /// byte arrays, booleans and identifiers.
 macro_rules! deserialize_primitives {
-    ($self:ident in $resolver:expr $(, $mut:tt)?) => {
-        forward_to_simple_type!(deserialize_i8, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_i16, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_i32, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_i64, $self in $resolver $(, $mut)?);
+    ($($mut:tt)?) => {
+        forward_to_simple_type!(deserialize_i8 $(, $mut)?);
+        forward_to_simple_type!(deserialize_i16 $(, $mut)?);
+        forward_to_simple_type!(deserialize_i32 $(, $mut)?);
+        forward_to_simple_type!(deserialize_i64 $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_u8, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_u16, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_u32, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_u64, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_u8 $(, $mut)?);
+        forward_to_simple_type!(deserialize_u16 $(, $mut)?);
+        forward_to_simple_type!(deserialize_u32 $(, $mut)?);
+        forward_to_simple_type!(deserialize_u64 $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_i128, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_u128, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_i128 $(, $mut)?);
+        forward_to_simple_type!(deserialize_u128 $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_f32, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_f64, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_f32 $(, $mut)?);
+        forward_to_simple_type!(deserialize_f64 $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_bool, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_char, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_bool $(, $mut)?);
+        forward_to_simple_type!(deserialize_char $(, $mut)?);
 
-        forward_to_simple_type!(deserialize_str, $self in $resolver $(, $mut)?);
-        forward_to_simple_type!(deserialize_string, $self in $resolver $(, $mut)?);
+        forward_to_simple_type!(deserialize_str $(, $mut)?);
+        forward_to_simple_type!(deserialize_string $(, $mut)?);
 
         /// Forwards deserialization to the [`deserialize_any`](#method.deserialize_any).
         #[inline]
@@ -3195,7 +3195,7 @@ where
 {
     type Error = DeError;
 
-    deserialize_primitives!(self in &self.reader.entity_resolver);
+    deserialize_primitives!();
 
     fn deserialize_struct<V>(
         self,

--- a/src/de/resolver.rs
+++ b/src/de/resolver.rs
@@ -68,7 +68,7 @@ use crate::events::BytesText;
 ///
 /// assert_eq!(data.get("entity_one"), Some(&"entity 1".to_string()));
 /// ```
-pub trait EntityResolver {
+pub trait EntityResolver: Clone {
     /// The error type that represents DTD parse error
     type Error: Error;
 

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -4,9 +4,9 @@
 //! [as defined]: https://www.w3.org/TR/xmlschema11-1/#Simple_Type_Definition
 
 use crate::de::Text;
+use crate::de::{EntityResolver, PredefinedEntityResolver};
 use crate::encoding::Decoder;
 use crate::errors::serialize::DeError;
-use crate::escape::resolve_predefined_entity;
 use crate::utils::{trim_xml_spaces, CowRef};
 use crate::XmlVersion;
 use memchr::memchr;
@@ -495,7 +495,7 @@ impl<'de, 'a> SeqAccess<'de> for ListIter<'de, 'a> {
 /// [simple types]: https://www.w3.org/TR/xmlschema11-1/#Simple_Type_Definition
 /// [`FromStr`]: std::str::FromStr
 /// [specification]: https://www.w3.org/TR/xmlschema11-2/#boolean
-pub struct SimpleTypeDeserializer<'de, 'a> {
+pub struct SimpleTypeDeserializer<'de, 'a, E: EntityResolver = PredefinedEntityResolver> {
     /// - In case of attribute contains escaped attribute value
     /// - In case of text contains unescaped text value
     content: CowRef<'de, 'a, [u8]>,
@@ -505,26 +505,32 @@ pub struct SimpleTypeDeserializer<'de, 'a> {
     /// Not used for deserializing raw byte buffers
     decoder: Decoder,
     version: XmlVersion,
+
+    /// Used to resolve unknown entities that would otherwise cause the parser
+    /// to return an [`EscapeError::UnrecognizedEntity`] error.
+    ///
+    /// [`EscapeError::UnrecognizedEntity`]: crate::escape::EscapeError::UnrecognizedEntity
+    entity_resolver: &'a E,
 }
 
-impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
+impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
     /// Creates a deserializer from a value, that possible borrowed from input.
     ///
     /// It is assumed that `text` does not have entities.
-    pub fn from_text(text: Cow<'de, str>) -> Self {
+    pub fn from_text(text: Cow<'de, str>, entity_resolver: &'a E) -> Self {
         let content = match text {
             Cow::Borrowed(slice) => CowRef::Input(slice.as_bytes()),
             Cow::Owned(content) => CowRef::Owned(content.into_bytes()),
         };
-        Self::new(content, false, XmlVersion::V1_0, Decoder::utf8())
+        Self::new(content, false, XmlVersion::V1_0, Decoder::utf8(), entity_resolver)
     }
     /// Creates a deserializer from an XML text node, that possible borrowed from input.
     ///
     /// It is assumed that `text` does not have entities.
     ///
     /// This constructor used internally to deserialize from text nodes.
-    pub fn from_text_content(value: Text<'de>) -> Self {
-        Self::from_text(value.text)
+    pub fn from_text_content(value: Text<'de>, entity_resolver: &'a E) -> Self {
+        Self::from_text(value.text, entity_resolver)
     }
 
     /// Creates a deserializer from a part of value at specified range.
@@ -536,12 +542,13 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
         range: Range<usize>,
         version: XmlVersion,
         decoder: Decoder,
+        entity_resolver: &'a E,
     ) -> Self {
         let content = match value {
             Cow::Borrowed(slice) => CowRef::Input(&slice[range]),
             Cow::Owned(slice) => CowRef::Slice(&slice[range]),
         };
-        Self::new(content, true, version, decoder)
+        Self::new(content, true, version, decoder, entity_resolver)
     }
 
     /// Constructor for tests
@@ -551,12 +558,14 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
         is_attr: bool,
         version: XmlVersion,
         decoder: Decoder,
+        entity_resolver: &'a E,
     ) -> Self {
         Self {
             content,
             is_attr,
             decoder,
             version,
+            entity_resolver,
         }
     }
 
@@ -585,7 +594,7 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
         if self.is_attr {
             let value =
                 self.version
-                    .normalize_attribute_value(&content, 128, resolve_predefined_entity)?;
+                    .normalize_attribute_value(&content, 128, |x| self.entity_resolver.resolve(x))?;
             return Ok(match value {
                 Cow::Borrowed(_) => content,
                 Cow::Owned(value) => CowRef::Owned(value),
@@ -595,7 +604,7 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
     }
 }
 
-impl<'de, 'a> Deserializer<'de> for SimpleTypeDeserializer<'de, 'a> {
+impl<'de, 'a, E: EntityResolver> Deserializer<'de> for SimpleTypeDeserializer<'de, 'a, E> {
     type Error = DeError;
 
     /// Forwards deserialization to the [`Self::deserialize_str`]
@@ -739,7 +748,7 @@ impl<'de, 'a> Deserializer<'de> for SimpleTypeDeserializer<'de, 'a> {
     }
 }
 
-impl<'de, 'a> EnumAccess<'de> for SimpleTypeDeserializer<'de, 'a> {
+impl<'de, 'a, E: EntityResolver> EnumAccess<'de> for SimpleTypeDeserializer<'de, 'a, E> {
     type Error = DeError;
     type Variant = UnitOnly;
 
@@ -752,7 +761,7 @@ impl<'de, 'a> EnumAccess<'de> for SimpleTypeDeserializer<'de, 'a> {
     }
 }
 
-impl<'de, 'a> IntoDeserializer<'de, DeError> for SimpleTypeDeserializer<'de, 'a> {
+impl<'de, 'a, E: EntityResolver> IntoDeserializer<'de, DeError> for SimpleTypeDeserializer<'de, 'a, E> {
     type Deserializer = Self;
 
     #[inline]
@@ -784,6 +793,7 @@ mod tests {
                     true,
                     XmlVersion::V1_0,
                     decoder,
+                    &PredefinedEntityResolver,
                 );
                 let data: $type = Deserialize::deserialize(de).unwrap();
 
@@ -803,6 +813,7 @@ mod tests {
                     true,
                     XmlVersion::V1_0,
                     decoder,
+                    &PredefinedEntityResolver,
                 );
                 let data: $type = Deserialize::deserialize(de).unwrap();
 
@@ -833,6 +844,7 @@ mod tests {
                     true,
                     XmlVersion::V1_0,
                     decoder,
+                    &PredefinedEntityResolver,
                 );
                 let err = <$type as Deserialize>::deserialize(de).unwrap_err();
 

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -510,14 +510,14 @@ pub struct SimpleTypeDeserializer<'de, 'a, E: EntityResolver = PredefinedEntityR
     /// to return an [`EscapeError::UnrecognizedEntity`] error.
     ///
     /// [`EscapeError::UnrecognizedEntity`]: crate::escape::EscapeError::UnrecognizedEntity
-    entity_resolver: &'a E,
+    entity_resolver: E,
 }
 
-impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
+impl<'de, 'a> SimpleTypeDeserializer<'de, 'a, PredefinedEntityResolver> {
     /// Creates a deserializer from a value, that possible borrowed from input.
     ///
     /// It is assumed that `text` does not have entities.
-    pub fn from_text(text: Cow<'de, str>, entity_resolver: &'a E) -> Self {
+    pub fn from_text(text: Cow<'de, str>) -> Self {
         let content = match text {
             Cow::Borrowed(slice) => CowRef::Input(slice.as_bytes()),
             Cow::Owned(content) => CowRef::Owned(content.into_bytes()),
@@ -527,7 +527,7 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
             false,
             XmlVersion::V1_0,
             Decoder::utf8(),
-            entity_resolver,
+            PredefinedEntityResolver,
         )
     }
     /// Creates a deserializer from an XML text node, that possible borrowed from input.
@@ -535,10 +535,12 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
     /// It is assumed that `text` does not have entities.
     ///
     /// This constructor used internally to deserialize from text nodes.
-    pub fn from_text_content(value: Text<'de>, entity_resolver: &'a E) -> Self {
-        Self::from_text(value.text, entity_resolver)
+    pub fn from_text_content(value: Text<'de>) -> Self {
+        Self::from_text(value.text)
     }
+}
 
+impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
     /// Creates a deserializer from a part of value at specified range.
     ///
     /// This constructor used internally to deserialize from attribute values.
@@ -548,7 +550,7 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
         range: Range<usize>,
         version: XmlVersion,
         decoder: Decoder,
-        entity_resolver: &'a E,
+        entity_resolver: E,
     ) -> Self {
         let content = match value {
             Cow::Borrowed(slice) => CowRef::Input(&slice[range]),
@@ -564,7 +566,7 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
         is_attr: bool,
         version: XmlVersion,
         decoder: Decoder,
-        entity_resolver: &'a E,
+        entity_resolver: E,
     ) -> Self {
         Self {
             content,
@@ -600,7 +602,9 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
         if self.is_attr {
             let value = self
                 .version
-                .normalize_attribute_value(&content, 128, |x| self.entity_resolver.resolve(x))?;
+                .normalize_attribute_value(&content, 128, |x| {
+                    self.entity_resolver.resolve(x)
+                })?;
             return Ok(match value {
                 Cow::Borrowed(_) => content,
                 Cow::Owned(value) => CowRef::Owned(value),
@@ -801,7 +805,7 @@ mod tests {
                     true,
                     XmlVersion::V1_0,
                     decoder,
-                    &PredefinedEntityResolver,
+                    PredefinedEntityResolver,
                 );
                 let data: $type = Deserialize::deserialize(de).unwrap();
 
@@ -821,7 +825,7 @@ mod tests {
                     true,
                     XmlVersion::V1_0,
                     decoder,
-                    &PredefinedEntityResolver,
+                    PredefinedEntityResolver,
                 );
                 let data: $type = Deserialize::deserialize(de).unwrap();
 
@@ -852,7 +856,7 @@ mod tests {
                     true,
                     XmlVersion::V1_0,
                     decoder,
-                    &PredefinedEntityResolver,
+                    PredefinedEntityResolver,
                 );
                 let err = <$type as Deserialize>::deserialize(de).unwrap_err();
 

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -602,9 +602,7 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
         if self.is_attr {
             let value = self
                 .version
-                .normalize_attribute_value(&content, 128, |x| {
-                    self.entity_resolver.resolve(x)
-                })?;
+                .normalize_attribute_value(&content, 128, |x| self.entity_resolver.resolve(x))?;
             return Ok(match value {
                 Cow::Borrowed(_) => content,
                 Cow::Owned(value) => CowRef::Owned(value),

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -522,7 +522,13 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
             Cow::Borrowed(slice) => CowRef::Input(slice.as_bytes()),
             Cow::Owned(content) => CowRef::Owned(content.into_bytes()),
         };
-        Self::new(content, false, XmlVersion::V1_0, Decoder::utf8(), entity_resolver)
+        Self::new(
+            content,
+            false,
+            XmlVersion::V1_0,
+            Decoder::utf8(),
+            entity_resolver,
+        )
     }
     /// Creates a deserializer from an XML text node, that possible borrowed from input.
     ///
@@ -592,9 +598,9 @@ impl<'de, 'a, E: EntityResolver> SimpleTypeDeserializer<'de, 'a, E> {
     fn content<'b>(&'b self) -> Result<CowRef<'de, 'b, str>, DeError> {
         let content = self.decode()?;
         if self.is_attr {
-            let value =
-                self.version
-                    .normalize_attribute_value(&content, 128, |x| self.entity_resolver.resolve(x))?;
+            let value = self
+                .version
+                .normalize_attribute_value(&content, 128, |x| self.entity_resolver.resolve(x))?;
             return Ok(match value {
                 Cow::Borrowed(_) => content,
                 Cow::Owned(value) => CowRef::Owned(value),
@@ -761,7 +767,9 @@ impl<'de, 'a, E: EntityResolver> EnumAccess<'de> for SimpleTypeDeserializer<'de,
     }
 }
 
-impl<'de, 'a, E: EntityResolver> IntoDeserializer<'de, DeError> for SimpleTypeDeserializer<'de, 'a, E> {
+impl<'de, 'a, E: EntityResolver> IntoDeserializer<'de, DeError>
+    for SimpleTypeDeserializer<'de, 'a, E>
+{
     type Deserializer = Self;
 
     #[inline]

--- a/src/de/text.rs
+++ b/src/de/text.rs
@@ -1,7 +1,7 @@
 use crate::{
     de::simple_type::SimpleTypeDeserializer,
-    de::{Text, TEXT_KEY},
     de::PredefinedEntityResolver,
+    de::{Text, TEXT_KEY},
     errors::serialize::DeError,
 };
 use serde::de::value::BorrowedStrDeserializer;
@@ -119,7 +119,8 @@ impl<'de> Deserializer<'de> for TextDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        SimpleTypeDeserializer::from_text_content(self.0, &PredefinedEntityResolver).deserialize_seq(visitor)
+        SimpleTypeDeserializer::from_text_content(self.0, &PredefinedEntityResolver)
+            .deserialize_seq(visitor)
     }
 
     #[inline]

--- a/src/de/text.rs
+++ b/src/de/text.rs
@@ -70,9 +70,7 @@ impl<'de> TextDeserializer<'de> {
 impl<'de> Deserializer<'de> for TextDeserializer<'de> {
     type Error = DeError;
 
-    // TODO consider adding entity_resolver member to this struct?
-    // is this feature desirable here?
-    deserialize_primitives!(self in &PredefinedEntityResolver);
+    deserialize_primitives!();
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -119,7 +117,7 @@ impl<'de> Deserializer<'de> for TextDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        SimpleTypeDeserializer::from_text_content(self.0, &PredefinedEntityResolver)
+        SimpleTypeDeserializer::from_text_content(self.0)
             .deserialize_seq(visitor)
     }
 

--- a/src/de/text.rs
+++ b/src/de/text.rs
@@ -1,6 +1,7 @@
 use crate::{
     de::simple_type::SimpleTypeDeserializer,
     de::{Text, TEXT_KEY},
+    de::PredefinedEntityResolver,
     errors::serialize::DeError,
 };
 use serde::de::value::BorrowedStrDeserializer;
@@ -69,7 +70,9 @@ impl<'de> TextDeserializer<'de> {
 impl<'de> Deserializer<'de> for TextDeserializer<'de> {
     type Error = DeError;
 
-    deserialize_primitives!();
+    // TODO consider adding entity_resolver member to this struct?
+    // is this feature desirable here?
+    deserialize_primitives!(self in &PredefinedEntityResolver);
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
@@ -116,7 +119,7 @@ impl<'de> Deserializer<'de> for TextDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        SimpleTypeDeserializer::from_text_content(self.0).deserialize_seq(visitor)
+        SimpleTypeDeserializer::from_text_content(self.0, &PredefinedEntityResolver).deserialize_seq(visitor)
     }
 
     #[inline]

--- a/src/de/text.rs
+++ b/src/de/text.rs
@@ -117,8 +117,7 @@ impl<'de> Deserializer<'de> for TextDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        SimpleTypeDeserializer::from_text_content(self.0)
-            .deserialize_seq(visitor)
+        SimpleTypeDeserializer::from_text_content(self.0).deserialize_seq(visitor)
     }
 
     #[inline]

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -97,7 +97,10 @@ where
     {
         if self.is_text {
             match self.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
+                    e,
+                    &self.de.reader.entity_resolver,
+                )),
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
             }
@@ -113,7 +116,10 @@ where
         if self.is_text {
             match self.de.next()? {
                 DeEvent::Text(e) => {
-                    SimpleTypeDeserializer::from_text_content(e).deserialize_tuple(len, visitor)
+                    SimpleTypeDeserializer::from_text_content(
+                        e,
+                        &self.de.reader.entity_resolver
+                    ).deserialize_tuple(len, visitor)
                 }
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
@@ -134,7 +140,10 @@ where
         match self.de.next()? {
             DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.de, e, fields)),
             DeEvent::Text(e) => {
-                SimpleTypeDeserializer::from_text_content(e).deserialize_struct("", fields, visitor)
+                SimpleTypeDeserializer::from_text_content(
+                    e,
+                    &self.de.reader.entity_resolver,
+                ).deserialize_struct("", fields, visitor)
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -97,10 +97,7 @@ where
     {
         if self.is_text {
             match self.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(
-                    e,
-                    &self.de.reader.entity_resolver,
-                )),
+                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
             }
@@ -116,8 +113,7 @@ where
         if self.is_text {
             match self.de.next()? {
                 DeEvent::Text(e) => {
-                    SimpleTypeDeserializer::from_text_content(e, &self.de.reader.entity_resolver)
-                        .deserialize_tuple(len, visitor)
+                    SimpleTypeDeserializer::from_text_content(e).deserialize_tuple(len, visitor)
                 }
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
@@ -138,8 +134,7 @@ where
         match self.de.next()? {
             DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.de, e, fields)),
             DeEvent::Text(e) => {
-                SimpleTypeDeserializer::from_text_content(e, &self.de.reader.entity_resolver)
-                    .deserialize_struct("", fields, visitor)
+                SimpleTypeDeserializer::from_text_content(e).deserialize_struct("", fields, visitor)
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -116,10 +116,8 @@ where
         if self.is_text {
             match self.de.next()? {
                 DeEvent::Text(e) => {
-                    SimpleTypeDeserializer::from_text_content(
-                        e,
-                        &self.de.reader.entity_resolver
-                    ).deserialize_tuple(len, visitor)
+                    SimpleTypeDeserializer::from_text_content(e, &self.de.reader.entity_resolver)
+                        .deserialize_tuple(len, visitor)
                 }
                 // SAFETY: the other events are filtered in `variant_seed()`
                 _ => unreachable!("Only `Text` events are possible here"),
@@ -140,10 +138,8 @@ where
         match self.de.next()? {
             DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.de, e, fields)),
             DeEvent::Text(e) => {
-                SimpleTypeDeserializer::from_text_content(
-                    e,
-                    &self.de.reader.entity_resolver,
-                ).deserialize_struct("", fields, visitor)
+                SimpleTypeDeserializer::from_text_content(e, &self.de.reader.entity_resolver)
+                    .deserialize_struct("", fields, visitor)
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -1837,6 +1837,7 @@ mod resolve {
     use std::convert::Infallible;
     use std::iter::FromIterator;
 
+    #[derive(Clone)]
     struct TestEntityResolver {
         capture_called: bool,
     }
@@ -1847,7 +1848,7 @@ mod resolve {
         fn capture(&mut self, doctype: BytesText) -> Result<(), Self::Error> {
             self.capture_called = true;
 
-            assert_eq!(doctype.as_ref(), br#"dict[ <!ENTITY unc "unclassified"> ]"#);
+            assert_eq!(doctype.as_ref(), br#"root[ <!ENTITY unc "unclassified"> ]"#);
 
             Ok(())
         }
@@ -1860,11 +1861,13 @@ mod resolve {
             match entity {
                 "t1" => Some("test_one"),
                 "t2" => Some("test_two"),
+                "myAmp" => Some("&"),
                 _ => None,
             }
         }
     }
 
+    #[derive(Clone)]
     struct TestHostileEntityResolver {
         capture_called: bool,
     }
@@ -1875,7 +1878,7 @@ mod resolve {
         fn capture(&mut self, doctype: BytesText) -> Result<(), Self::Error> {
             self.capture_called = true;
 
-            assert_eq!(doctype.as_ref(), br#"dict[ <!ENTITY unc "unclassified"> ]"#);
+            assert_eq!(doctype.as_ref(), br#"root[ <!ENTITY unc "unclassified"> ]"#);
 
             Ok(())
         }
@@ -1900,7 +1903,7 @@ mod resolve {
         };
         let mut de = Deserializer::with_resolver(
             br#"
-            <!DOCTYPE dict[ <!ENTITY unc "unclassified"> ]>
+            <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
 
             <root>
                 <entity_one>&t1;</entity_one>
@@ -1924,13 +1927,92 @@ mod resolve {
     }
 
     #[test]
+    fn resolve_predefined_entities_only_once() {
+        let value: String = from_str("<root>&amp;lt;</root>").unwrap();
+        assert_eq!(value, "&lt;");
+        let value: BTreeMap<String, String> = from_str(r#"<root attr="&amp;lt;" />"#).unwrap();
+        assert_eq!(
+            value,
+            BTreeMap::from_iter([(String::from("@attr"), String::from("&lt;"))])
+        );
+    }
+
+    #[test]
+    fn resolve_custom_entities_in_text_only_once() {
+        let resolver = TestEntityResolver {
+            capture_called: false,
+        };
+        let mut de = Deserializer::with_resolver(
+            br#"
+            <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
+
+            <root>
+                <entity_two>&myAmp;lt; 10</entity_two>
+                <entity_three>non-entity</entity_three>
+            </root>
+            "#
+            .as_ref(),
+            resolver,
+        );
+
+        let data: BTreeMap<String, String> = BTreeMap::deserialize(&mut de).unwrap();
+        assert_eq!(
+            data,
+            BTreeMap::from_iter([
+                (String::from("entity_two"), String::from("&lt; 10")),
+                (String::from("entity_three"), String::from("non-entity")),
+            ])
+        );
+    }
+
+    #[test]
+    fn resolve_custom_entities_in_attr_only_once() {
+        use quick_xml::Error;
+        use quick_xml::escape::EscapeError;
+
+        let resolver = TestEntityResolver {
+            capture_called: false,
+        };
+        let mut de = Deserializer::with_resolver(
+            br#"
+            <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
+
+            <root entity_one="&myAmp;lt; 3">
+                <entity_two>&myAmp;lt; 10</entity_two>
+                <entity_three>non-entity</entity_three>
+            </root>
+            "#
+            .as_ref(),
+            resolver,
+        );
+
+        let e = BTreeMap::<String, String>::deserialize(&mut de).unwrap_err();
+        // TODO https://github.com/rust-lang/rust/issues/82775
+        assert!(matches!(
+            e,
+            DeError::InvalidXml(Error::Escape(EscapeError::UnterminatedEntity(range))) if range == (0..1)
+        ));
+
+        // // naive expectation:
+        // let data: BTreeMap<String, String> = BTreeMap::deserialize(&mut de).unwrap();
+        // assert_eq!(
+        //     data,
+        //     BTreeMap::from_iter([
+        //         (String::from("@entity_one"), String::from("&lt; 3")),
+        //         (String::from("entity_two"), String::from("&lt; 10")),
+        //         (String::from("entity_three"), String::from("non-entity")),
+        //     ])
+        // );
+    }
+
+    #[test]
     fn resolve_custom_entity_in_attr() {
         let resolver = TestEntityResolver {
             capture_called: false,
         };
         let mut de = Deserializer::with_resolver(
             br#"
-            <!DOCTYPE dict[ <!ENTITY unc "unclassified"> ]>
+            <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
 
             <root
                 entity_one="&t1;"
@@ -1954,6 +2036,33 @@ mod resolve {
     }
 
     #[test]
+    fn resolve_custom_entity_in_text_but_reject_infinite_recursion() {
+        let resolver = TestHostileEntityResolver {
+            capture_called: false,
+        };
+        let mut de = Deserializer::with_resolver(
+            br#"
+            <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
+
+            <root>
+                <entity_one>&go_fork_yourself;</entity_one>
+            </root>
+            "#
+            .as_ref(),
+            resolver,
+        );
+
+        let data: BTreeMap<String, String> = BTreeMap::deserialize(&mut de).unwrap();
+        assert_eq!(
+            data,
+            BTreeMap::from_iter([(
+                String::from("entity_one"),
+                String::from("&go_fork_yourself;")
+            ),])
+        );
+    }
+
+    #[test]
     fn resolve_custom_entity_in_attr_but_reject_infinite_recursion() {
         use quick_xml::errors::Error;
         use quick_xml::escape::EscapeError;
@@ -1963,7 +2072,7 @@ mod resolve {
         };
         let mut de = Deserializer::with_resolver(
             br#"
-            <!DOCTYPE dict[ <!ENTITY unc "unclassified"> ]>
+            <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
 
             <root entity_one="&go_fork_yourself;" />
 

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -1832,14 +1832,18 @@ mod resolve {
     use super::*;
     use pretty_assertions::assert_eq;
     use quick_xml::de::EntityResolver;
+    use quick_xml::escape::resolve_xml_entity;
     use quick_xml::events::BytesText;
     use std::collections::BTreeMap;
     use std::convert::Infallible;
     use std::iter::FromIterator;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
 
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     struct TestEntityResolver {
         capture_called: bool,
+        rxe_called: Arc<AtomicUsize>,
     }
 
     impl EntityResolver for TestEntityResolver {
@@ -1862,12 +1866,16 @@ mod resolve {
                 "t1" => Some("test_one"),
                 "t2" => Some("test_two"),
                 "myAmp" => Some("&"),
-                _ => None,
+                _ => {
+                    self.rxe_called
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    resolve_xml_entity(entity)
+                }
             }
         }
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Default)]
     struct TestHostileEntityResolver {
         capture_called: bool,
     }
@@ -1898,9 +1906,7 @@ mod resolve {
 
     #[test]
     fn resolve_custom_entity() {
-        let resolver = TestEntityResolver {
-            capture_called: false,
-        };
+        let resolver = TestEntityResolver::default();
         let mut de = Deserializer::with_resolver(
             br#"
             <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
@@ -1939,9 +1945,7 @@ mod resolve {
 
     #[test]
     fn resolve_custom_entities_in_text_only_once() {
-        let resolver = TestEntityResolver {
-            capture_called: false,
-        };
+        let resolver = TestEntityResolver::default();
         let mut de = Deserializer::with_resolver(
             br#"
             <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
@@ -1967,12 +1971,10 @@ mod resolve {
 
     #[test]
     fn resolve_custom_entities_in_attr_only_once() {
-        use quick_xml::Error;
         use quick_xml::escape::EscapeError;
+        use quick_xml::Error;
 
-        let resolver = TestEntityResolver {
-            capture_called: false,
-        };
+        let resolver = TestEntityResolver::default();
         let mut de = Deserializer::with_resolver(
             br#"
             <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
@@ -2007,18 +2009,17 @@ mod resolve {
 
     #[test]
     fn resolve_custom_entity_in_attr() {
-        let resolver = TestEntityResolver {
-            capture_called: false,
-        };
+        let resolver = TestEntityResolver::default();
+        let rxe_called = resolver.rxe_called.clone();
         let mut de = Deserializer::with_resolver(
             br#"
             <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>
 
             <root
                 entity_one="&t1;"
-                entity_two="czech_&t2;"
+                entity_two="czech_&t2;&gt;"
                 entity_three="non-entity"
-            />
+            >&lt;</root>
             "#
             .as_ref(),
             resolver,
@@ -2029,17 +2030,22 @@ mod resolve {
             data,
             BTreeMap::from_iter([
                 (String::from("@entity_one"), String::from("test_one")),
-                (String::from("@entity_two"), String::from("czech_test_two")),
+                (String::from("@entity_two"), String::from("czech_test_two>")),
                 (String::from("@entity_three"), String::from("non-entity")),
+                (String::from("$text"), String::from("<")),
             ])
+        );
+
+        assert_eq!(
+            rxe_called.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "`EntityResolver::resolve` should be consulted first for both attributes and text contents"
         );
     }
 
     #[test]
     fn resolve_custom_entity_in_text_but_reject_infinite_recursion() {
-        let resolver = TestHostileEntityResolver {
-            capture_called: false,
-        };
+        let resolver = TestHostileEntityResolver::default();
         let mut de = Deserializer::with_resolver(
             br#"
             <!DOCTYPE root[ <!ENTITY unc "unclassified"> ]>

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -1865,6 +1865,34 @@ mod resolve {
         }
     }
 
+    struct TestHostileEntityResolver {
+        capture_called: bool,
+    }
+
+    impl EntityResolver for TestHostileEntityResolver {
+        type Error = Infallible;
+
+        fn capture(&mut self, doctype: BytesText) -> Result<(), Self::Error> {
+            self.capture_called = true;
+
+            assert_eq!(doctype.as_ref(), br#"dict[ <!ENTITY unc "unclassified"> ]"#);
+
+            Ok(())
+        }
+
+        fn resolve(&self, entity: &str) -> Option<&str> {
+            assert!(
+                self.capture_called,
+                "`EntityResolver::capture` should be called before `EntityResolver::resolve`"
+            );
+            match entity {
+                "go_fork_yourself" => Some("&go_fork_yourself;"),
+                "go_quote_yourself" => Some(r#"" aka Bobby Tables"#),
+                _ => None,
+            }
+        }
+    }
+
     #[test]
     fn resolve_custom_entity() {
         let resolver = TestEntityResolver {
@@ -1893,6 +1921,63 @@ mod resolve {
                 (String::from("entity_three"), String::from("non-entity")),
             ])
         );
+    }
+
+    #[test]
+    fn resolve_custom_entity_in_attr() {
+        let resolver = TestEntityResolver {
+            capture_called: false,
+        };
+        let mut de = Deserializer::with_resolver(
+            br#"
+            <!DOCTYPE dict[ <!ENTITY unc "unclassified"> ]>
+
+            <root
+                entity_one="&t1;"
+                entity_two="czech_&t2;"
+                entity_three="non-entity"
+            />
+            "#
+            .as_ref(),
+            resolver,
+        );
+
+        let data: BTreeMap<String, String> = BTreeMap::deserialize(&mut de).unwrap();
+        assert_eq!(
+            data,
+            BTreeMap::from_iter([
+                (String::from("@entity_one"), String::from("test_one")),
+                (String::from("@entity_two"), String::from("czech_test_two")),
+                (String::from("@entity_three"), String::from("non-entity")),
+            ])
+        );
+    }
+
+    #[test]
+    fn resolve_custom_entity_in_attr_but_reject_infinite_recursion() {
+        use quick_xml::errors::Error;
+        use quick_xml::escape::EscapeError;
+
+        let resolver = TestHostileEntityResolver {
+            capture_called: false,
+        };
+        let mut de = Deserializer::with_resolver(
+            br#"
+            <!DOCTYPE dict[ <!ENTITY unc "unclassified"> ]>
+
+            <root entity_one="&go_fork_yourself;" />
+
+            "#
+            .as_ref(),
+            resolver,
+        );
+
+        let e = BTreeMap::<String, String>::deserialize(&mut de).unwrap_err();
+        // TODO https://github.com/rust-lang/rust/issues/82775
+        assert!(matches!(
+            e,
+            DeError::InvalidXml(Error::Escape(EscapeError::TooManyNestedEntities))
+        ));
     }
 }
 


### PR DESCRIPTION
As shown by the new tests, the result is that deserialization will process custom entities in attributes as well as in text content.

This seems to require some breaking changes to the public API.