### PR TITLE
Fix subtraction with overflow panic when parse malformed DTD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,7 +18,13 @@
 
 ### Bug Fixes
 
+- [#950]: Fix subtraction with overflow when parse malformed DTD in some cases.
+  Note, that currently we do not check the validity of DTD, so the returned `Event::DocType`
+  may contain the malformed DTD.
+
 ### Misc Changes
+
+[#950]: https://github.com/tafia/quick-xml/issues/950
 
 
 ## 0.39.2 -- 2026-02-20

--- a/src/parser/dtd.rs
+++ b/src/parser/dtd.rs
@@ -92,12 +92,12 @@ impl DtdParser {
                             b'\'' | b'"' => {
                                 // SystemLiteral or PubidLiteral
                                 *self = Self::BeforeInternalSubset(b);
-                                cur = &cur[i + 1..];
+                                cur = &cur[i + 1..]; // +1 to skip `'` or `"`
                                 continue;
                             }
                             b'[' => {
                                 *self = Self::InsideOfInternalSubset;
-                                cur = &cur[i + 1..];
+                                cur = &cur[i + 1..]; // +1 to skip `[`
                                 continue;
                             }
                             b'>' => {
@@ -122,7 +122,7 @@ impl DtdParser {
                     break;
                 }
                 Self::InsideOfInternalSubset => {
-                    // Find the end of internal subset ([) or the start of the markup inside (<)
+                    // Find the end of internal subset (]) or the start of the markup inside (<)
                     if let Some(i) = memchr::memchr2(b']', b'<', cur) {
                         if cur[i] == b']' {
                             *self = Self::AfterInternalSubset;
@@ -258,7 +258,7 @@ impl DtdParser {
                 // error reporting and go with ending the unknown markup with `>`.
                 if let Some(i) = memchr::memchr(b'>', markup) {
                     *self = Self::InsideOfInternalSubset;
-                    Some(i + 1)
+                    Some(i + 1) // +1 to skip `>`
                 } else {
                     None
                 }

--- a/src/parser/dtd.rs
+++ b/src/parser/dtd.rs
@@ -252,7 +252,6 @@ impl DtdParser {
             // or markup is not known.
             // Undecided markup bytes will be written to `buf` to be available on
             // next iteration.
-            _ if markup.len() < 9 => None,
             _ => {
                 // FIXME: to correctly report error position in DTD we need to provide
                 // DTD events. For now our task just to skip (correct) DTD, so we postpone
@@ -261,7 +260,7 @@ impl DtdParser {
                     *self = Self::InsideOfInternalSubset;
                     Some(i + 1)
                 } else {
-                    Some(markup.len())
+                    None
                 }
             }
         }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -641,3 +641,22 @@ fn issue939() {
 
     assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
 }
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/950
+#[test]
+fn issue950() {
+    // This DTD is malformed, because
+    // - it contains invalid markup `<>`
+    // - it contains unpaired `>` in internal subset
+    // To correctly report error position in DTD we need to provide DTD events.
+    // For now our task just to skip (correct) DTD, so we postpone error reporting
+    // and go with ending the unknown markup with `>` and skip any unpaired `>`.
+    let reader = BufReader::with_capacity(16, "<!DOCTYPE x[<>12>34567]>".as_bytes());
+    //                                 chunks: ________________--------
+    let mut reader = Reader::from_reader(reader);
+    let mut buf = Vec::new();
+    // Because DTD is malformed and we want to report parsing error in the future,
+    // but currently return Event::DocType, we do not check the read result,
+    // but just ensure that we do not panic
+    let _ = reader.read_event_into(&mut buf);
+}


### PR DESCRIPTION
Initially fix is implemented in v0.39 branch, that is started from v0.39.2 tag, and then merged in `issue950` branch (the branch that is PRed to master). I plan also include this fix into v0.39.3 patch (because master contains some breaking changes, that cannot be included in v0.39.3).

Closes #950