### PR TITLE
Improve XmlVersion enumeration: explicit and implicit 1.0 variants

### DIFF
--- a/benches/macrobenches.rs
+++ b/benches/macrobenches.rs
@@ -50,7 +50,7 @@ static INPUTS: &[(&str, &str)] = &[
 
 fn parse_document_from_str(doc: &str) -> XmlResult<()> {
     let mut r = Reader::from_str(doc);
-    let mut version = XmlVersion::V1_0;
+    let mut version = XmlVersion::Implicit1_0;
     loop {
         match black_box(r.read_event()?) {
             Event::Decl(e) => {
@@ -77,7 +77,7 @@ fn parse_document_from_str(doc: &str) -> XmlResult<()> {
 
 fn parse_document_from_bytes(doc: &[u8]) -> XmlResult<()> {
     let mut r = Reader::from_reader(doc);
-    let mut version = XmlVersion::V1_0;
+    let mut version = XmlVersion::Implicit1_0;
     let mut buf = Vec::new();
     loop {
         match black_box(r.read_event_into(&mut buf)?) {
@@ -106,7 +106,7 @@ fn parse_document_from_bytes(doc: &[u8]) -> XmlResult<()> {
 
 fn parse_document_from_str_with_namespaces(doc: &str) -> XmlResult<()> {
     let mut r = NsReader::from_str(doc);
-    let mut version = XmlVersion::V1_0;
+    let mut version = XmlVersion::Implicit1_0;
     loop {
         match black_box(r.read_resolved_event()?) {
             (_, Event::Decl(e)) => {
@@ -136,7 +136,7 @@ fn parse_document_from_str_with_namespaces(doc: &str) -> XmlResult<()> {
 
 fn parse_document_from_bytes_with_namespaces(doc: &[u8]) -> XmlResult<()> {
     let mut r = NsReader::from_reader(doc);
-    let mut version = XmlVersion::V1_0;
+    let mut version = XmlVersion::Implicit1_0;
     let mut buf = Vec::new();
     loop {
         match black_box(r.read_resolved_event_into(&mut buf)?) {

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -192,9 +192,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let attr = attrs.next().unwrap()?;
         assert_eq!(attr.key, QName(b"attr"));
         assert_eq!(
-            attr.decoded_and_normalized_value_with(XmlVersion::Implicit1_0, reader.decoder(), 9, |e| {
-                reader.get_entity(e)
-            })?,
+            attr.decoded_and_normalized_value_with(
+                XmlVersion::Implicit1_0,
+                reader.decoder(),
+                9,
+                |e| { reader.get_entity(e) }
+            )?,
             "Message: hello world"
         );
 

--- a/examples/custom_entities.rs
+++ b/examples/custom_entities.rs
@@ -157,7 +157,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(label.key, QName(b"label"));
         assert_eq!(
             label.decoded_and_normalized_value_with(
-                XmlVersion::V1_0,
+                XmlVersion::Implicit1_0,
                 reader.decoder(),
                 9,
                 |e| reader.get_entity(e)
@@ -192,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let attr = attrs.next().unwrap()?;
         assert_eq!(attr.key, QName(b"attr"));
         assert_eq!(
-            attr.decoded_and_normalized_value_with(XmlVersion::V1_0, reader.decoder(), 9, |e| {
+            attr.decoded_and_normalized_value_with(XmlVersion::Implicit1_0, reader.decoder(), 9, |e| {
                 reader.get_entity(e)
             })?,
             "Message: hello world"

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -79,10 +79,10 @@ impl Translation {
             let a = attr_result?;
             match a.key.as_ref() {
                 b"Language" => {
-                    lang = a.decoded_and_normalized_value(XmlVersion::V1_0, reader.decoder())?
+                    lang = a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())?
                 }
                 b"Tag" => {
-                    tag = a.decoded_and_normalized_value(XmlVersion::V1_0, reader.decoder())?
+                    tag = a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())?
                 }
                 _ => (),
             }
@@ -153,7 +153,7 @@ fn main() -> Result<(), AppError> {
                                             Ok::<Cow<'_, str>, Infallible>(std::borrow::Cow::from(""))
                                         })
                                         .unwrap().to_string();
-                                    let value = a.decoded_and_normalized_value(XmlVersion::V1_0, reader.decoder()).or_else(|err| {
+                                    let value = a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder()).or_else(|err| {
                                             dbg!("unable to read key in DefaultSettings attribute {:?}, utf8 error {:?}", &a, err);
                                             Ok::<Cow<'_, str>, Infallible>(std::borrow::Cow::from(""))
                                     }).unwrap().to_string();

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -79,10 +79,10 @@ impl Translation {
             let a = attr_result?;
             match a.key.as_ref() {
                 b"Language" => {
-                    lang = a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())?
+                    lang = a.decoded_and_normalized_value(XmlVersion::Explicit1_0, reader.decoder())?
                 }
                 b"Tag" => {
-                    tag = a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())?
+                    tag = a.decoded_and_normalized_value(XmlVersion::Explicit1_0, reader.decoder())?
                 }
                 _ => (),
             }
@@ -153,7 +153,7 @@ fn main() -> Result<(), AppError> {
                                             Ok::<Cow<'_, str>, Infallible>(std::borrow::Cow::from(""))
                                         })
                                         .unwrap().to_string();
-                                    let value = a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder()).or_else(|err| {
+                                    let value = a.decoded_and_normalized_value(XmlVersion::Explicit1_0, reader.decoder()).or_else(|err| {
                                             dbg!("unable to read key in DefaultSettings attribute {:?}, utf8 error {:?}", &a, err);
                                             Ok::<Cow<'_, str>, Infallible>(std::borrow::Cow::from(""))
                                     }).unwrap().to_string();

--- a/examples/read_nodes.rs
+++ b/examples/read_nodes.rs
@@ -79,10 +79,12 @@ impl Translation {
             let a = attr_result?;
             match a.key.as_ref() {
                 b"Language" => {
-                    lang = a.decoded_and_normalized_value(XmlVersion::Explicit1_0, reader.decoder())?
+                    lang =
+                        a.decoded_and_normalized_value(XmlVersion::Explicit1_0, reader.decoder())?
                 }
                 b"Tag" => {
-                    tag = a.decoded_and_normalized_value(XmlVersion::Explicit1_0, reader.decoder())?
+                    tag =
+                        a.decoded_and_normalized_value(XmlVersion::Explicit1_0, reader.decoder())?
                 }
                 _ => (),
             }

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -15,7 +15,7 @@ fn round_trip<R>(reader: &mut Reader<R>) -> ()
 where
     R: std::io::BufRead,
 {
-    let mut version = XmlVersion::V1_0;
+    let mut version = XmlVersion::Implicit1_0;
     let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut buf = vec![];
     let config = reader.config_mut();

--- a/src/de/attributes.rs
+++ b/src/de/attributes.rs
@@ -18,8 +18,7 @@ impl<'i> Attributes<'i> {
     /// # Parameters
     /// - `prefix`: a prefix of the field names in structs that should be stripped
     ///   to get the local attribute name. The [`crate::de::Deserializer`] uses `"@"`
-    ///   as a prefix, but [`Self::into_deserializer()`] uses empty string, which mean
-    ///   that we do not strip anything.
+    ///   as a prefix.
     ///
     /// # Example
     /// ```
@@ -85,8 +84,7 @@ impl<'i> Attributes<'i> {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// A deserializer used to make possible to pack all attributes into a struct.
-/// It is created by [`Attributes::into_map_access`] or [`Attributes::into_deserializer`]
-/// methods.
+/// It is created by [`Attributes::into_map_access`] method.
 ///
 /// This deserializer always call [`Visitor::visit_map`] with self as [`MapAccess`].
 ///

--- a/src/de/attributes.rs
+++ b/src/de/attributes.rs
@@ -47,7 +47,7 @@ impl<'i> Attributes<'i> {
     ///     3
     /// );
     /// // Strip nothing from the field names
-    /// let de = tag.attributes().clone().into_map_access(XmlVersion::V1_0, "");
+    /// let de = tag.attributes().clone().into_map_access(XmlVersion::Implicit1_0, "");
     /// assert_eq!(
     ///     MyData::deserialize(de).unwrap(),
     ///     MyData {
@@ -57,7 +57,7 @@ impl<'i> Attributes<'i> {
     /// );
     ///
     /// // Strip "@" from the field name
-    /// let de = tag.attributes().into_map_access(XmlVersion::V1_0, "@");
+    /// let de = tag.attributes().into_map_access(XmlVersion::Implicit1_0, "@");
     /// assert_eq!(
     ///     MyDataPrefixed::deserialize(de).unwrap(),
     ///     MyDataPrefixed {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3078,7 +3078,7 @@ where
         Self::new(
             SliceReader {
                 reader,
-                version: XmlVersion::V1_0,
+                version: XmlVersion::Implicit1_0,
             },
             entity_resolver,
         )
@@ -3161,7 +3161,7 @@ where
             IoReader {
                 reader,
                 buf: Vec::new(),
-                version: XmlVersion::V1_0,
+                version: XmlVersion::Implicit1_0,
             },
             entity_resolver,
         )
@@ -3181,7 +3181,7 @@ where
             IoReader {
                 reader,
                 buf: Vec::new(),
-                version: XmlVersion::V1_0,
+                version: XmlVersion::Implicit1_0,
             },
             entity_resolver,
         )
@@ -4161,11 +4161,11 @@ mod tests {
         let mut reader1 = IoReader {
             reader: NsReader::from_reader(s.as_bytes()),
             buf: Vec::new(),
-            version: XmlVersion::V1_0,
+            version: XmlVersion::Implicit1_0,
         };
         let mut reader2 = SliceReader {
             reader: NsReader::from_str(s),
-            version: XmlVersion::V1_0,
+            version: XmlVersion::Implicit1_0,
         };
 
         loop {
@@ -4191,7 +4191,7 @@ mod tests {
 
         let mut reader = SliceReader {
             reader: NsReader::from_str(s),
-            version: XmlVersion::V1_0,
+            version: XmlVersion::Implicit1_0,
         };
 
         let config = reader.reader.config_mut();

--- a/src/de/simple_type.rs
+++ b/src/de/simple_type.rs
@@ -516,7 +516,7 @@ impl<'de, 'a> SimpleTypeDeserializer<'de, 'a> {
             Cow::Borrowed(slice) => CowRef::Input(slice.as_bytes()),
             Cow::Owned(content) => CowRef::Owned(content.into_bytes()),
         };
-        Self::new(content, false, XmlVersion::V1_0, Decoder::utf8())
+        Self::new(content, false, XmlVersion::Implicit1_0, Decoder::utf8())
     }
     /// Creates a deserializer from an XML text node, that possible borrowed from input.
     ///
@@ -782,7 +782,7 @@ mod tests {
                 let de = SimpleTypeDeserializer::new(
                     CowRef::Input(xml.as_ref()),
                     true,
-                    XmlVersion::V1_0,
+                    XmlVersion::Implicit1_0,
                     decoder,
                 );
                 let data: $type = Deserialize::deserialize(de).unwrap();
@@ -801,7 +801,7 @@ mod tests {
                 let de = SimpleTypeDeserializer::new(
                     CowRef::Input(xml.as_ref()),
                     true,
-                    XmlVersion::V1_0,
+                    XmlVersion::Implicit1_0,
                     decoder,
                 );
                 let data: $type = Deserialize::deserialize(de).unwrap();
@@ -831,7 +831,7 @@ mod tests {
                 let de = SimpleTypeDeserializer::new(
                     CowRef::Input(xml.as_ref()),
                     true,
-                    XmlVersion::V1_0,
+                    XmlVersion::Implicit1_0,
                     decoder,
                 );
                 let err = <$type as Deserialize>::deserialize(de).unwrap_err();

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -300,7 +300,7 @@ impl<'a> Attribute<'a> {
     #[deprecated = "use `Self::normalized_value()`"]
     pub fn unescape_value(&self) -> XmlResult<Cow<'a, str>> {
         // resolve_predefined_entity returns only non-recursive replacements, so depth=1 is enough
-        self.normalized_value_with(XmlVersion::V1_0, 1, resolve_predefined_entity)
+        self.normalized_value_with(XmlVersion::Implicit1_0, 1, resolve_predefined_entity)
     }
 
     /// Decodes using UTF-8 then unescapes the value, using custom entities.
@@ -333,7 +333,7 @@ impl<'a> Attribute<'a> {
         &self,
         resolve_entity: impl FnMut(&str) -> Option<&'entity str>,
     ) -> XmlResult<Cow<'a, str>> {
-        self.normalized_value_with(XmlVersion::V1_0, 128, resolve_entity)
+        self.normalized_value_with(XmlVersion::Implicit1_0, 128, resolve_entity)
     }
 
     /// Decodes then unescapes the value.
@@ -344,7 +344,7 @@ impl<'a> Attribute<'a> {
     pub fn decode_and_unescape_value(&self, decoder: Decoder) -> XmlResult<Cow<'a, str>> {
         // resolve_predefined_entity returns only non-recursive replacements, so depth=1 is enough
         self.decoded_and_normalized_value_with(
-            XmlVersion::V1_0,
+            XmlVersion::Implicit1_0,
             decoder,
             1,
             resolve_predefined_entity,
@@ -361,7 +361,7 @@ impl<'a> Attribute<'a> {
         decoder: Decoder,
         resolve_entity: impl FnMut(&str) -> Option<&'entity str>,
     ) -> XmlResult<Cow<'a, str>> {
-        self.decoded_and_normalized_value_with(XmlVersion::V1_0, decoder, 128, resolve_entity)
+        self.decoded_and_normalized_value_with(XmlVersion::Implicit1_0, decoder, 128, resolve_entity)
     }
 
     /// If attribute value [represents] valid boolean values, returns `Some`, otherwise returns `None`.
@@ -1273,14 +1273,14 @@ mod xml {
             let attr = Attribute::from(("foo".as_bytes(), raw_value));
 
             let value = attr
-                .decoded_and_normalized_value(V1_0, Decoder::utf8())
+                .decoded_and_normalized_value(Implicit1_0, Decoder::utf8())
                 .unwrap();
             assert_eq!(value, "");
             // assert_eq! does not check if value is borrowed, but this is important
             assert!(matches!(value, Cow::Borrowed(_)));
 
             let value = attr
-                .decoded_and_normalized_value(V1_1, Decoder::utf8())
+                .decoded_and_normalized_value(Explicit1_1, Decoder::utf8())
                 .unwrap();
             assert_eq!(value, "");
             // assert_eq! does not check if value is borrowed, but this is important
@@ -1294,14 +1294,14 @@ mod xml {
             let attr = Attribute::from(("foo".as_bytes(), raw_value));
 
             let value = attr
-                .decoded_and_normalized_value(V1_0, Decoder::utf8())
+                .decoded_and_normalized_value(Implicit1_0, Decoder::utf8())
                 .unwrap();
             assert_eq!(value, "foobar123");
             // assert_eq! does not check if value is borrowed, but this is important
             assert!(matches!(value, Cow::Borrowed(_)));
 
             let value = attr
-                .decoded_and_normalized_value(V1_1, Decoder::utf8())
+                .decoded_and_normalized_value(Explicit1_1, Decoder::utf8())
                 .unwrap();
             assert_eq!(value, "foobar123");
             // assert_eq! does not check if value is borrowed, but this is important
@@ -1316,12 +1316,12 @@ mod xml {
             let attr = Attribute::from(("foo".as_bytes(), raw_value));
 
             assert_eq!(
-                attr.decoded_and_normalized_value(V1_0, Decoder::utf8())
+                attr.decoded_and_normalized_value(Implicit1_0, Decoder::utf8())
                     .unwrap(),
                 " foo\u{85}\u{2028} bar baz  delta  \u{85}"
             );
             assert_eq!(
-                attr.decoded_and_normalized_value(V1_1, Decoder::utf8())
+                attr.decoded_and_normalized_value(Explicit1_1, Decoder::utf8())
                     .unwrap(),
                 " foo   bar baz  delta  "
             );
@@ -1333,12 +1333,12 @@ mod xml {
             let raw_value = "abc&quotdef".as_bytes();
             let attr = Attribute::from(("foo".as_bytes(), raw_value));
 
-            match attr.decoded_and_normalized_value(V1_0, Decoder::utf8()) {
+            match attr.decoded_and_normalized_value(Implicit1_0, Decoder::utf8()) {
                 Err(Error::Escape(err)) => assert_eq!(err, UnterminatedEntity(3..11)),
                 x => panic!("Expected Err(Escape(_)), got {:?}", x),
             }
 
-            match attr.decoded_and_normalized_value(V1_1, Decoder::utf8()) {
+            match attr.decoded_and_normalized_value(Explicit1_1, Decoder::utf8()) {
                 Err(Error::Escape(err)) => assert_eq!(err, UnterminatedEntity(3..11)),
                 x => panic!("Expected Err(Escape(_)), got {:?}", x),
             }
@@ -1350,7 +1350,7 @@ mod xml {
             let raw_value = "abc&unkn;def".as_bytes();
             let attr = Attribute::from(("foo".as_bytes(), raw_value));
 
-            match attr.decoded_and_normalized_value(V1_0, Decoder::utf8()) {
+            match attr.decoded_and_normalized_value(Implicit1_0, Decoder::utf8()) {
                 // TODO: is this divergence between range behavior of UnterminatedEntity
                 // and UnrecognizedEntity appropriate? existing unescape code behaves the same.  (see: start index)
                 Err(Error::Escape(err)) => {
@@ -1358,7 +1358,7 @@ mod xml {
                 }
                 x => panic!("Expected Err(Escape(err)), got {:?}", x),
             }
-            match attr.decoded_and_normalized_value(V1_1, Decoder::utf8()) {
+            match attr.decoded_and_normalized_value(Explicit1_1, Decoder::utf8()) {
                 // TODO: is this divergence between range behavior of UnterminatedEntity
                 // and UnrecognizedEntity appropriate? existing unescape code behaves the same.  (see: start index)
                 Err(Error::Escape(err)) => {
@@ -1383,12 +1383,12 @@ mod xml {
             }
 
             assert_eq!(
-                attr.decoded_and_normalized_value_with(V1_0, Decoder::utf8(), 5, &custom_resolver)
+                attr.decoded_and_normalized_value_with(Implicit1_0, Decoder::utf8(), 5, &custom_resolver)
                     .unwrap(),
                 "\r\rA\n \nB\r\n"
             );
             assert_eq!(
-                attr.decoded_and_normalized_value_with(V1_1, Decoder::utf8(), 5, &custom_resolver)
+                attr.decoded_and_normalized_value_with(Explicit1_1, Decoder::utf8(), 5, &custom_resolver)
                     .unwrap(),
                 "\r\rA\n \nB\r\n"
             );
@@ -1401,12 +1401,12 @@ mod xml {
             let attr = Attribute::from(("foo".as_bytes(), raw_value));
 
             assert_eq!(
-                attr.decoded_and_normalized_value(V1_0, Decoder::utf8())
+                attr.decoded_and_normalized_value(Implicit1_0, Decoder::utf8())
                     .unwrap(),
                 "\r\rA\n\nB\r\n"
             );
             assert_eq!(
-                attr.decoded_and_normalized_value(V1_1, Decoder::utf8())
+                attr.decoded_and_normalized_value(Explicit1_1, Decoder::utf8())
                     .unwrap(),
                 "\r\rA\n\nB\r\n"
             );

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -361,7 +361,12 @@ impl<'a> Attribute<'a> {
         decoder: Decoder,
         resolve_entity: impl FnMut(&str) -> Option<&'entity str>,
     ) -> XmlResult<Cow<'a, str>> {
-        self.decoded_and_normalized_value_with(XmlVersion::Implicit1_0, decoder, 128, resolve_entity)
+        self.decoded_and_normalized_value_with(
+            XmlVersion::Implicit1_0,
+            decoder,
+            128,
+            resolve_entity,
+        )
     }
 
     /// If attribute value [represents] valid boolean values, returns `Some`, otherwise returns `None`.
@@ -1415,18 +1420,33 @@ mod xml {
             }
 
             assert_eq!(
-                attr.decoded_and_normalized_value_with(Implicit1_0, Decoder::utf8(), 5, &custom_resolver)
-                    .unwrap(),
+                attr.decoded_and_normalized_value_with(
+                    Implicit1_0,
+                    Decoder::utf8(),
+                    5,
+                    &custom_resolver
+                )
+                .unwrap(),
                 "\r\rA\n \nB\r\n"
             );
             assert_eq!(
-                attr.decoded_and_normalized_value_with(Explicit1_0, Decoder::utf8(), 5, &custom_resolver)
-                    .unwrap(),
+                attr.decoded_and_normalized_value_with(
+                    Explicit1_0,
+                    Decoder::utf8(),
+                    5,
+                    &custom_resolver
+                )
+                .unwrap(),
                 "\r\rA\n \nB\r\n"
             );
             assert_eq!(
-                attr.decoded_and_normalized_value_with(Explicit1_1, Decoder::utf8(), 5, &custom_resolver)
-                    .unwrap(),
+                attr.decoded_and_normalized_value_with(
+                    Explicit1_1,
+                    Decoder::utf8(),
+                    5,
+                    &custom_resolver
+                )
+                .unwrap(),
                 "\r\rA\n \nB\r\n"
             );
         }

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -1280,6 +1280,13 @@ mod xml {
             assert!(matches!(value, Cow::Borrowed(_)));
 
             let value = attr
+                .decoded_and_normalized_value(Explicit1_0, Decoder::utf8())
+                .unwrap();
+            assert_eq!(value, "");
+            // assert_eq! does not check if value is borrowed, but this is important
+            assert!(matches!(value, Cow::Borrowed(_)));
+
+            let value = attr
                 .decoded_and_normalized_value(Explicit1_1, Decoder::utf8())
                 .unwrap();
             assert_eq!(value, "");
@@ -1295,6 +1302,13 @@ mod xml {
 
             let value = attr
                 .decoded_and_normalized_value(Implicit1_0, Decoder::utf8())
+                .unwrap();
+            assert_eq!(value, "foobar123");
+            // assert_eq! does not check if value is borrowed, but this is important
+            assert!(matches!(value, Cow::Borrowed(_)));
+
+            let value = attr
+                .decoded_and_normalized_value(Explicit1_0, Decoder::utf8())
                 .unwrap();
             assert_eq!(value, "foobar123");
             // assert_eq! does not check if value is borrowed, but this is important
@@ -1321,6 +1335,11 @@ mod xml {
                 " foo\u{85}\u{2028} bar baz  delta  \u{85}"
             );
             assert_eq!(
+                attr.decoded_and_normalized_value(Explicit1_0, Decoder::utf8())
+                    .unwrap(),
+                " foo\u{85}\u{2028} bar baz  delta  \u{85}"
+            );
+            assert_eq!(
                 attr.decoded_and_normalized_value(Explicit1_1, Decoder::utf8())
                     .unwrap(),
                 " foo   bar baz  delta  "
@@ -1338,6 +1357,11 @@ mod xml {
                 x => panic!("Expected Err(Escape(_)), got {:?}", x),
             }
 
+            match attr.decoded_and_normalized_value(Explicit1_0, Decoder::utf8()) {
+                Err(Error::Escape(err)) => assert_eq!(err, UnterminatedEntity(3..11)),
+                x => panic!("Expected Err(Escape(_)), got {:?}", x),
+            }
+
             match attr.decoded_and_normalized_value(Explicit1_1, Decoder::utf8()) {
                 Err(Error::Escape(err)) => assert_eq!(err, UnterminatedEntity(3..11)),
                 x => panic!("Expected Err(Escape(_)), got {:?}", x),
@@ -1351,6 +1375,14 @@ mod xml {
             let attr = Attribute::from(("foo".as_bytes(), raw_value));
 
             match attr.decoded_and_normalized_value(Implicit1_0, Decoder::utf8()) {
+                // TODO: is this divergence between range behavior of UnterminatedEntity
+                // and UnrecognizedEntity appropriate? existing unescape code behaves the same.  (see: start index)
+                Err(Error::Escape(err)) => {
+                    assert_eq!(err, UnrecognizedEntity(4..8, "unkn".to_owned()))
+                }
+                x => panic!("Expected Err(Escape(err)), got {:?}", x),
+            }
+            match attr.decoded_and_normalized_value(Explicit1_0, Decoder::utf8()) {
                 // TODO: is this divergence between range behavior of UnterminatedEntity
                 // and UnrecognizedEntity appropriate? existing unescape code behaves the same.  (see: start index)
                 Err(Error::Escape(err)) => {
@@ -1388,6 +1420,11 @@ mod xml {
                 "\r\rA\n \nB\r\n"
             );
             assert_eq!(
+                attr.decoded_and_normalized_value_with(Explicit1_0, Decoder::utf8(), 5, &custom_resolver)
+                    .unwrap(),
+                "\r\rA\n \nB\r\n"
+            );
+            assert_eq!(
                 attr.decoded_and_normalized_value_with(Explicit1_1, Decoder::utf8(), 5, &custom_resolver)
                     .unwrap(),
                 "\r\rA\n \nB\r\n"
@@ -1402,6 +1439,11 @@ mod xml {
 
             assert_eq!(
                 attr.decoded_and_normalized_value(Implicit1_0, Decoder::utf8())
+                    .unwrap(),
+                "\r\rA\n\nB\r\n"
+            );
+            assert_eq!(
+                attr.decoded_and_normalized_value(Explicit1_0, Decoder::utf8())
                     .unwrap(),
                 "\r\rA\n\nB\r\n"
             );

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -662,8 +662,8 @@ impl<'a> BytesText<'a> {
     #[inline]
     pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
         match version {
-            XmlVersion::V1_0 => self.xml10_content(),
-            XmlVersion::V1_1 => self.xml11_content(),
+            XmlVersion::Implicit1_0 => self.xml10_content(),
+            XmlVersion::Explicit1_1 => self.xml11_content(),
         }
     }
 
@@ -973,8 +973,8 @@ impl<'a> BytesCData<'a> {
     #[inline]
     pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
         match version {
-            XmlVersion::V1_0 => self.xml10_content(),
-            XmlVersion::V1_1 => self.xml11_content(),
+            XmlVersion::Implicit1_0 => self.xml10_content(),
+            XmlVersion::Explicit1_1 => self.xml11_content(),
         }
     }
 
@@ -1459,11 +1459,11 @@ impl<'a> BytesDecl<'a> {
     ///
     /// // <?xml version='1.1'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" version='1.1'", 0));
-    /// assert_eq!(decl.xml_version().unwrap(), XmlVersion::V1_1);
+    /// assert_eq!(decl.xml_version().unwrap(), XmlVersion::Explicit1_1);
     ///
     /// // <?xml version='1.0' version='1.1'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" version='1.0' version='1.1'", 0));
-    /// assert_eq!(decl.xml_version().unwrap(), XmlVersion::V1_0);
+    /// assert_eq!(decl.xml_version().unwrap(), XmlVersion::Implicit1_0);
     ///
     /// // <?xml version='1.2'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" version='1.2'", 0));
@@ -1498,8 +1498,8 @@ impl<'a> BytesDecl<'a> {
     pub fn xml_version(&self) -> Result<XmlVersion, Error> {
         let v = self.version()?;
         match v.as_ref() {
-            b"1.0" => Ok(XmlVersion::V1_0),
-            b"1.1" => Ok(XmlVersion::V1_1),
+            b"1.0" => Ok(XmlVersion::Implicit1_0),
+            b"1.1" => Ok(XmlVersion::Explicit1_1),
             _ => Err(Error::IllFormed(IllFormedError::UnknownVersion)),
         }
     }
@@ -1688,8 +1688,8 @@ impl<'a> BytesRef<'a> {
     #[inline]
     pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
         match version {
-            XmlVersion::V1_0 => self.xml10_content(),
-            XmlVersion::V1_1 => self.xml11_content(),
+            XmlVersion::Implicit1_0 => self.xml10_content(),
+            XmlVersion::Explicit1_1 => self.xml11_content(),
         }
     }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -658,12 +658,19 @@ impl<'a> BytesText<'a> {
         self.decoder.content(&self.content, normalize_xml11_eols)
     }
 
-    /// Alias for [`xml11_content()`](Self::xml11_content).
+    /// Decodes the content of the XML event according to the specified version.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this text event.
+    ///
+    /// This will allocate if the value is encoded in non-UTF-8 encoding, or EOL normalization
+    /// is required.
     #[inline]
     pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
         match version {
-            XmlVersion::Implicit1_0 => self.xml10_content(),
             XmlVersion::Explicit1_1 => self.xml11_content(),
+            _ => self.xml10_content(),
         }
     }
 
@@ -969,12 +976,20 @@ impl<'a> BytesCData<'a> {
         self.decoder.content(&self.content, normalize_xml11_eols)
     }
 
-    /// Alias for [`xml11_content()`](Self::xml11_content).
+    /// Decodes the raw input byte content of the CDATA section of the XML event
+    /// into a string according to the specified version.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this CDATA event.
+    ///
+    /// This will allocate if the value in non-UTF-8 encoding, or EOL normalization
+    /// is required.
     #[inline]
     pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
         match version {
-            XmlVersion::Implicit1_0 => self.xml10_content(),
             XmlVersion::Explicit1_1 => self.xml11_content(),
+            _ => self.xml10_content(),
         }
     }
 
@@ -1463,7 +1478,7 @@ impl<'a> BytesDecl<'a> {
     ///
     /// // <?xml version='1.0' version='1.1'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" version='1.0' version='1.1'", 0));
-    /// assert_eq!(decl.xml_version().unwrap(), XmlVersion::Implicit1_0);
+    /// assert_eq!(decl.xml_version().unwrap(), XmlVersion::Explicit1_0);
     ///
     /// // <?xml version='1.2'?>
     /// let decl = BytesDecl::from_start(BytesStart::from_content(" version='1.2'", 0));
@@ -1498,7 +1513,7 @@ impl<'a> BytesDecl<'a> {
     pub fn xml_version(&self) -> Result<XmlVersion, Error> {
         let v = self.version()?;
         match v.as_ref() {
-            b"1.0" => Ok(XmlVersion::Implicit1_0),
+            b"1.0" => Ok(XmlVersion::Explicit1_0),
             b"1.1" => Ok(XmlVersion::Explicit1_1),
             _ => Err(Error::IllFormed(IllFormedError::UnknownVersion)),
         }
@@ -1685,11 +1700,20 @@ impl<'a> BytesRef<'a> {
     }
 
     /// Alias for [`xml11_content()`](Self::xml11_content).
+
+    /// Decodes the content of the XML event according to the specified version.
+    ///
+    /// When this event produced by the reader, it uses the encoding information
+    /// associated with that reader to interpret the raw bytes contained within
+    /// this general reference event.
+    ///
+    /// This will allocate if the value in non-UTF-8 encoding, or EOL normalization
+    /// is required.
     #[inline]
     pub fn xml_content(&self, version: XmlVersion) -> Result<Cow<'a, str>, EncodingError> {
         match version {
-            XmlVersion::Implicit1_0 => self.xml10_content(),
             XmlVersion::Explicit1_1 => self.xml11_content(),
+            _ => self.xml10_content(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,9 @@ pub enum XmlVersion {
     /// is missed. Most documents in the world are still XML 1.0 documents.
     ///
     /// [Version 1.0]: https://www.w3.org/TR/xml/
-    V1_0,
+    Implicit1_0,
     /// [Version 1.1](https://www.w3.org/TR/xml11/)
-    V1_1,
+    Explicit1_1,
 }
 
 impl XmlVersion {
@@ -105,8 +105,8 @@ impl XmlVersion {
         F: FnMut(&str) -> Option<&'entity str>,
     {
         match self {
-            Self::V1_0 => escape::normalize_xml10_attribute_value(value, depth, resolve_entity),
-            Self::V1_1 => escape::normalize_xml11_attribute_value(value, depth, resolve_entity),
+            Self::Implicit1_0 => escape::normalize_xml10_attribute_value(value, depth, resolve_entity),
+            Self::Explicit1_1 => escape::normalize_xml11_attribute_value(value, depth, resolve_entity),
         }
     }
 }
@@ -114,6 +114,6 @@ impl XmlVersion {
 impl Default for XmlVersion {
     #[inline]
     fn default() -> Self {
-        Self::V1_0
+        Self::Implicit1_0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,9 @@ impl XmlVersion {
         F: FnMut(&str) -> Option<&'entity str>,
     {
         match self {
-            Self::Explicit1_1 => escape::normalize_xml11_attribute_value(value, depth, resolve_entity),
+            Self::Explicit1_1 => {
+                escape::normalize_xml11_attribute_value(value, depth, resolve_entity)
+            }
             _ => escape::normalize_xml10_attribute_value(value, depth, resolve_entity),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,12 +84,21 @@ pub use crate::writer::{ElementWriter, Writer};
 /// Version of XML standard
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum XmlVersion {
-    /// [Version 1.0], which is the default version of XML document if XML declaration
-    /// is missed. Most documents in the world are still XML 1.0 documents.
+    /// XML declaration was missed in the entity (root document or referenced
+    /// external DTD), so according to the specification, [version 1.0] is assumed.
+    /// Most documents in the world are still XML 1.0 documents.
     ///
-    /// [Version 1.0]: https://www.w3.org/TR/xml/
+    /// [version 1.0]: https://www.w3.org/TR/xml/
     Implicit1_0,
-    /// [Version 1.1](https://www.w3.org/TR/xml11/)
+    /// XML version was specified as [`1.0`] in the entity (root document or referenced
+    /// external DTD).
+    ///
+    /// [`1.0`]: https://www.w3.org/TR/xml/
+    Explicit1_0,
+    /// XML version was specified as [`1.1`] in the entity (root document or referenced
+    /// external DTD).
+    ///
+    /// [`1.1`]: https://www.w3.org/TR/xml11/
     Explicit1_1,
 }
 
@@ -105,8 +114,8 @@ impl XmlVersion {
         F: FnMut(&str) -> Option<&'entity str>,
     {
         match self {
-            Self::Implicit1_0 => escape::normalize_xml10_attribute_value(value, depth, resolve_entity),
             Self::Explicit1_1 => escape::normalize_xml11_attribute_value(value, depth, resolve_entity),
+            _ => escape::normalize_xml10_attribute_value(value, depth, resolve_entity),
         }
     }
 }

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -32,7 +32,7 @@ fn fuzz_101() {
             Ok(Event::Start(e)) | Ok(Event::Empty(e)) => {
                 for a in e.attributes() {
                     if a.ok().map_or(true, |a| {
-                        a.decoded_and_normalized_value(XmlVersion::V1_0, reader.decoder())
+                        a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
                             .is_err()
                     }) {
                         break;


### PR DESCRIPTION
This PR changes XmlVersion from
```rust
pub enum XmlVersion {
  V1_0,
  V1_1,
}
```
to
```rust
pub enum XmlVersion {
  Implicit1_0,
  Explicit1_0,
  Explicit1_1,
}
```
The motivation behind this change is simplification with processing versions. XML specification explicitly allows at most one XML declaration (the `<?xml version=...?>` part). At the same time the `version` information in the declaration is mandatory. This leads us to a simple cycle that allows, using one variable, to track the uniqueness of the declaration and obtain values   according to the version
```rust
let mut reader = Reader::from_str(...);
let mut version = XmlVersion::Implicit1_0;
loop {
  match reader.read_event() {
    // Return error in case of duplicated declaration
    Event::XmlDecl(e) if version != XmlVersion::Implicit1_0 => return Err(...),
    // Return error in case of missing "version"
    Event::XmlDecl(e) => { version = e.xml_version()?; }

    Event::Text(e) => {
      let text = e.xml_content(version)?;
      // ...
    }
    ...
  }
}
```
Without thus changes you may use `Option<XmlVersion>`, but then you will forced to use `e.xml_content(version.unwrap_or(XmlVersion::V1_0))`, which will add check for `None` for every usage of `version` in the loop. Usually XML documents a well-formed, so this is just wasting of CPU cycles.

`XmlVersion` is not a part of any release yet, so it can be changed freely.