### PR TITLE
Fix slice-index panic in DtdParser on chunked unknown markup (#957)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,10 @@
 
 - [#938]: Use correct rules for EOL normalization in `Deserializer` when parse XML 1.0 documents.
   Previously XML 1.1. rules was applied.
+- [#957]: Fix slice-index panic when reading malformed DTD whose unknown markup
+  is split across `BufReader` chunks. As with [#950], the returned
+  `Event::DocType` may contain the malformed DTD; this fix only ensures that
+  the parser does not panic.
 
 ### Misc Changes
 
@@ -51,6 +55,7 @@
 [#914]: https://github.com/tafia/quick-xml/pull/914
 [#938]: https://github.com/tafia/quick-xml/pull/938
 [#944]: https://github.com/tafia/quick-xml/pull/944
+[#957]: https://github.com/tafia/quick-xml/issues/957
 
 
 ## 0.39.3 -- 2026-05-04

--- a/src/parser/dtd.rs
+++ b/src/parser/dtd.rs
@@ -205,6 +205,17 @@ impl DtdParser {
                         cur = &cur[skip - skipped..];
                         continue;
                     }
+                    // No keyword matched. If we have a full 9-byte window the
+                    // markup is definitively not one of `<!--`, `<![CDATA[`,
+                    // `<!ELEMENT`, `<!ATTLIST`, `<!ENTITY`, `<!NOTATION`, so
+                    // fall back to skipping until the closing `>` instead of
+                    // accumulating `skipped` past `bytes.len()` (which would
+                    // panic on the slice-copy above on a later iteration).
+                    if end == bytes.len() {
+                        cur = &cur[end - skipped..];
+                        *self = Self::InElementDecl;
+                        continue;
+                    }
                     *self = Self::UndecidedMarkup(skipped + cur.len());
                     break;
                 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -666,3 +666,23 @@ fn issue950() {
     // but just ensure that we do not panic
     let _ = reader.read_event_into(&mut buf);
 }
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/957
+#[test]
+fn issue957() {
+    // Each `<aa`, `<bb`, ... is unknown markup that does not match any of
+    // `<!--`, `<![CDATA[`, `<!ELEMENT`, `<!ATTLIST`, `<!ENTITY`, `<!NOTATION`
+    // and is split across `BufReader` chunks, so the DTD parser re-enters
+    // the `UndecidedMarkup` arm multiple times in a row. Before the fix,
+    // each re-entry grew `skipped` by `cur.len()` until the slice copy
+    // `bytes[..skipped]` against the 9-byte work buffer panicked with
+    // `range end index N out of range for slice of length 9`.
+    let reader = BufReader::with_capacity(4, "<!DOCTYPE r[<aa<bb<cc<dd>".as_bytes());
+    //                                chunks: ____----____----____----_
+    let mut reader = Reader::from_reader(reader);
+    let mut buf = Vec::new();
+    // Same disposition as `issue950`: malformed DTD must not panic; we do
+    // not assert on the returned event since DTD validity reporting is a
+    // future improvement.
+    let _ = reader.read_event_into(&mut buf);
+}


### PR DESCRIPTION
Fixes #957.

**Bug**

In `src/parser/dtd.rs`, the `Self::UndecidedMarkup(skipped)` arm of `DtdParser::feed` stages the prefix of an unresolved markup token into a fixed `[u8; 9]` work buffer (long enough for the longest recognised keyword, `!NOTATION`). When the buffered window did not match any keyword *and* did not contain a `>`, the state was updated to `UndecidedMarkup(skipped + cur.len())` and `feed` returned to wait for more bytes.

With chunked input that keeps hitting `<!`-shaped tokens that never match one of `<!--`, `<![CDATA[`, `<!ELEMENT`, `<!ATTLIST`, `<!ENTITY`, `<!NOTATION`, `skipped` could grow past `bytes.len() == 9`. The next re-entry into the arm panicked on the very first line, `bytes[..skipped].copy_from_slice(&buf[buf.len() - skipped..])`, with

```
range end index N out of range for slice of length 9
```

This survived [#954]'s fix for #950 (different panic, same state machine).

**Fix**

Once the 9-byte window is full (`end == bytes.len()`) and `switch()` returned `None`, the markup is definitively not one of the recognised keywords. There is no benefit to waiting for more data; the parser can drop the examined window and skip until the closing `>`. The `InElementDecl` state already does exactly that (no quote awareness needed — we only reach this point if we *failed* to match the keywords that promote into `InQuoteSensitive`), so the new branch reuses it rather than introducing a new state.

```rust
if end == bytes.len() {
    cur = &cur[end - skipped..];
    *self = Self::InElementDecl;
    continue;
}
```

The shape of the existing comments — *\"Buffer is long enough to store the longest possible keyword `!NOTATION`\"* — already implies `skipped` was meant to be bounded by `bytes.len()`; this just enforces it.

**Test**

Added `issue957` in `tests/issues.rs` in the same style as `issue950`. A 25-byte malformed DTD plus `BufReader::with_capacity(4)` is enough to force the failure mode (each `<aa`, `<bb`, … straddles a chunk boundary, so `UndecidedMarkup` is re-entered repeatedly):

```rust
let reader = BufReader::with_capacity(4, "<!DOCTYPE r[<aa<bb<cc<dd>".as_bytes());
//                                chunks: ____----____----____----_
```

Same disposition as `issue950` — we don't assert on the returned event since proper DTD validity reporting is a future improvement; we just pin that the parser doesn't panic.

**Verification**

- New regression test passes on the fix; reverting the fix reproduces the panic.
- `cargo test` (full suite, all features default) stays green: doc tests + every `tests/*` binary, no failures.

**Why this matters**

Any consumer reading untrusted XML through `Reader::read_event_into` (with a `BufReader` or any chunked `BufRead`) can be panicked by ~25 bytes of crafted input. We hit it via a coverage-guided fuzzer feeding `BufReader<File>` over arbitrary bytes; the workaround downstream is to pre-reject `<!`-shaped tokens that aren't comments / CDATA before the reader sees them, but the state-machine invariant should be enforced in the library.

[#954]: https://github.com/tafia/quick-xml/pull/954