### PR TITLE
Add fuzz_chunked_reader target for chunk-boundary parser bugs

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,3 +31,9 @@ name = "structured_roundtrip"
 path = "fuzz_targets/structured_roundtrip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_chunked_reader"
+path = "fuzz_targets/fuzz_chunked_reader.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -5,3 +5,19 @@ cargo fuzz run -O -j4 fuzz_target_1
 ```
 
 See also: https://github.com/rust-fuzz/cargo-fuzz
+
+## Targets
+
+- `fuzz_target_1` — drives `Reader::from_reader` over `Cursor<&[u8]>` and
+  `Reader::from_str`. Broad coverage of event-decoding and writer
+  round-tripping. Fast per-execution.
+- `structured_roundtrip` — uses `arbitrary` to build a writer program,
+  emits XML, then re-reads it. Targets writer/reader symmetry.
+- `fuzz_chunked_reader` — drives `Reader::from_reader` over a `BufReader`
+  with a small fuzz-controlled capacity. Exercises parser states that
+  span chunk boundaries (where `BufRead::fill_buf` returns a partial
+  window) — a regime not reached by `Cursor`-backed harnesses. Issues
+  #950 and #957 are examples of bugs in this regime.
+
+The targets seed off the same input shape (`&[u8]`) so corpora can be
+shared between them.

--- a/fuzz/fuzz_targets/fuzz_chunked_reader.rs
+++ b/fuzz/fuzz_targets/fuzz_chunked_reader.rs
@@ -1,0 +1,66 @@
+//! Fuzz target that drives `Reader::from_reader` over a `BufRead` whose
+//! `fill_buf` returns small windows, forcing the parser to handle state
+//! that spans chunk boundaries.
+//!
+//! The default `fuzz_target_1` feeds the parser via `Cursor::new(data)`,
+//! and `<Cursor as BufRead>::fill_buf` always returns the entire remaining
+//! input in a single window. A class of parser bugs only manifests when
+//! the underlying reader hands back a partial window and the parser must
+//! resume on the next `fill_buf` call — see issues #950 and #957, both of
+//! which the regression tests in `tests/issues.rs` reproduce by wrapping
+//! the input in `BufReader::with_capacity(4, ..)`. This harness exposes
+//! that same shape to the fuzzer with a fuzz-controlled capacity.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::hint::black_box;
+use std::io::{BufReader, Cursor};
+
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+
+fuzz_target!(|data: &[u8]| {
+    // First byte selects the `BufReader` capacity in `1..=255`. Capacity 0
+    // is not legal, and any capacity `>= data.len()` degenerates to the
+    // Cursor case already covered by `fuzz_target_1`, so a small range is
+    // both sufficient and the most efficient use of fuzz budget.
+    let Some((&cap_byte, xml)) = data.split_first() else { return };
+    let capacity = (cap_byte as usize).max(1);
+
+    let mut reader =
+        Reader::from_reader(BufReader::with_capacity(capacity, Cursor::new(xml)));
+    let mut buf = Vec::new();
+    loop {
+        // Touch the event payload enough to exercise the borrowed-data
+        // invariants on chunked inputs. Mirrors the shape of `fuzz_target_1`
+        // without duplicating its full breadth — this target is about
+        // chunk-boundary state, not API surface coverage.
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                let _ = black_box(format!("{e:?}"));
+                break;
+            }
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let _ = black_box(e.name());
+                for a in e.attributes() {
+                    if a.is_err() {
+                        break;
+                    }
+                }
+            }
+            Ok(Event::Text(ref e)) | Ok(Event::Comment(ref e)) | Ok(Event::DocType(ref e)) => {
+                let _ = black_box(e.decode());
+            }
+            Ok(Event::CData(e)) => {
+                let _ = black_box(e.escape());
+            }
+            Ok(Event::End(ref e)) => {
+                let _ = black_box(e.name());
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+});


### PR DESCRIPTION
Follow-up to #958 / #957, and a response to your request in https://github.com/tafia/quick-xml/pull/958#issuecomment-3520760117 about improving the fuzzing setup.

## Why

`fuzz_target_1` drives `Reader::from_reader` via `Cursor::new(data)`. `<Cursor as BufRead>::fill_buf` always returns the entire remaining input in a single window, so the harness never exercises parser states that span `fill_buf` calls.

That gap is exactly what hid #950 and #957. Both regression tests in `tests/issues.rs` reproduce by wrapping the input in `BufReader::with_capacity(N, ..)` for a small N — the parser has to resume across chunk boundaries, and state that's only valid within a single `fill_buf` window can grow past its bounds. Neither bug is reachable from a `Cursor`-backed harness, regardless of fuzz budget.

## What

Adds `fuzz_chunked_reader`. The first input byte is the `BufReader` capacity (clamped to `1..=255`); the rest is fed as XML. Same input shape as `fuzz_target_1`, so corpora can be shared between the two.

The `1..=255` range is deliberate — capacities `>= data.len()` degenerate to the `Cursor` case already covered by `fuzz_target_1`, so this is the most efficient use of the fuzz budget for the chunk-boundary regime.

## Verification

I reverted 9fd1d58 (the #957 fix) on a local branch, seeded `fuzz/corpus/fuzz_chunked_reader/` with `tests/issues.rs::issue957`'s input prefixed with `0x04` (the capacity byte), and ran `cargo fuzz run fuzz_chunked_reader corpus/fuzz_chunked_reader`. libFuzzer reproduced the `slice_index_fail` in `DtdParser::feed` on the seed within one run — same panic site as the original bug.

With the fix back in place, 5000 runs over the seeded corpus are clean.

## Notes

- No corpus is committed — `fuzz/.gitignore` already excludes `corpus/`.
- No new dependencies; reuses existing `arbitrary` / `libfuzzer-sys`.
- `fuzz/README.md` updated to describe the three targets and how they differ.
- Doesn't touch `fuzz_target_1` or `structured_roundtrip` — keeping each target single-purpose.