### PR TITLE
Fix slice-index panic in DtdParser on long single-chunk unknown markup (#960)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,10 @@
   is split across `BufReader` chunks. As with [#950], the returned
   `Event::DocType` may contain the malformed DTD; this fix only ensures that
   the parser does not panic.
+- [#960]: Fix sibling slice-index panic when a single chunk delivers `<` followed
+  by 9+ bytes of unknown markup inside a DTD internal subset. Same disposition
+  as [#957] / [#950]: parser must not panic; DTD validity reporting is a future
+  improvement.
 
 ### Misc Changes
 
@@ -56,6 +60,7 @@
 [#938]: https://github.com/tafia/quick-xml/pull/938
 [#944]: https://github.com/tafia/quick-xml/pull/944
 [#957]: https://github.com/tafia/quick-xml/issues/957
+[#960]: https://github.com/tafia/quick-xml/issues/960
 
 
 ## 0.39.3 -- 2026-05-04

--- a/src/parser/dtd.rs
+++ b/src/parser/dtd.rs
@@ -135,8 +135,23 @@ impl DtdParser {
                             continue;
                         }
                         // Keep the number of already looked bytes (started from byte after `<`, so -1),
-                        // try to decide after feeding the new chunk
-                        *self = Self::UndecidedMarkup(cur.len() - i - 1);
+                        // try to decide after feeding the new chunk.
+                        let skipped = cur.len() - i - 1;
+                        // The 9-byte work buffer in `UndecidedMarkup` is sized
+                        // for `!NOTATION` (the longest keyword). If the chunk
+                        // already gave us 9+ bytes after `<` and `switch()`
+                        // returned `None`, the markup is definitively not one
+                        // of `<!--`, `<![CDATA[`, `<!ELEMENT`, `<!ATTLIST`,
+                        // `<!ENTITY`, `<!NOTATION`, so skip until `>` rather
+                        // than staging more bytes than the buffer can hold
+                        // (which would panic on the slice copy in
+                        // `UndecidedMarkup`).
+                        if skipped >= 9 {
+                            cur = &cur[i + 1..];
+                            *self = Self::InElementDecl;
+                            continue;
+                        }
+                        *self = Self::UndecidedMarkup(skipped);
                     }
                     break;
                 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -686,3 +686,25 @@ fn issue957() {
     // future improvement.
     let _ = reader.read_event_into(&mut buf);
 }
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/960
+#[test]
+fn issue960() {
+    // Sibling of `issue957`. The fix in #958 prevents `skipped` from growing
+    // across multiple `UndecidedMarkup` re-entries, but the same panic was
+    // still reachable via the *initial* `Self::UndecidedMarkup(cur.len() - i - 1)`
+    // assignment one arm earlier: when a single chunk delivered `<` followed
+    // by 9+ bytes of unknown markup, `skipped` was set to that long value in
+    // one shot, and the next call panicked on
+    // `bytes[..skipped].copy_from_slice(...)` against the 9-byte work buffer.
+    let reader = BufReader::with_capacity(
+        24,
+        "<!DOCTYPE r[<aaaaaaaaaaaaaaaaaaaaaaaaaaaaa>]>".as_bytes(),
+    );
+    let mut reader = Reader::from_reader(reader);
+    let mut buf = Vec::new();
+    // Same disposition as `issue950` / `issue957`: malformed DTD must not
+    // panic; we do not assert on the returned event since DTD validity
+    // reporting is a future improvement.
+    let _ = reader.read_event_into(&mut buf);
+}


### PR DESCRIPTION
Fixes #960. Sibling of #957.

## Bug

The fix in #958 prevents `skipped` from growing across multiple `UndecidedMarkup` re-entries inside `DtdParser::feed`, but the same panic was still reachable via the *initial* assignment one arm earlier (`InsideOfInternalSubset`):

https://github.com/tafia/quick-xml/blob/master/src/parser/dtd.rs#L139

```rust
*self = Self::UndecidedMarkup(cur.len() - i - 1);
```

When a chunk delivered `<` followed by 9+ bytes of unknown markup (so `switch()` returned `None` on a window long enough to definitively rule out all keywords), `skipped` was set to that long value in one shot. The next entry into the `UndecidedMarkup` arm panicked on the very first line:

```rust
bytes[..skipped].copy_from_slice(&buf[buf.len() - skipped..]);
// range end index 24 out of range for slice of length 9
```

CIFuzz on #959 (the new chunked-`BufRead` fuzz target) reproduced this 

## Fix

Mirror the bail-out already present in the `UndecidedMarkup` arm: when `cur.len() - i - 1 >= 9`, the markup is definitively not one of `<!--`, `<![CDATA[`, `<!ELEMENT`, `<!ATTLIST`, `<!ENTITY`, `<!NOTATION`, so transition to `InElementDecl` (skip until `>`) instead of staging more bytes than the 9-byte work buffer can hold.

```rust
let skipped = cur.len() - i - 1;
if skipped >= 9 {
    cur = &cur[i + 1..];
    *self = Self::InElementDecl;
    continue;
}
*self = Self::UndecidedMarkup(skipped);
```

## Test

Added `issue960` in `tests/issues.rs` in the same style as `issue957` and `issue950`:

```rust
let reader = BufReader::with_capacity(
    24,
    "<!DOCTYPE r[<aaaaaaaaaaaaaaaaaaaaaaaaaaaaa>]>".as_bytes(),
);
```

Same disposition as `issue950` / `issue957`: malformed DTD must not panic; we don't assert on the returned event since DTD validity reporting is a future improvement.

## Verification

- `cargo test --test issues` — all 27 issue tests pass, including the new `issue960`.
- `cargo test` (full suite) — green.
- Reverting this commit + running the seeded `fuzz_chunked_reader` from #959 reproduces the original panic; with this commit applied, the same seeded corpus stays clean.

Once #959 rebases on top of this, its CIFuzz job should turn green too.