### PR TITLE
Fix typos in comments and doc strings

### DIFF
--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -217,7 +217,7 @@ where
         }
     }
 
-    /// Determines if subtree started with the specified event shoould be skipped.
+    /// Determines if subtree started with the specified event should be skipped.
     ///
     /// Used to map elements with `xsi:nil` attribute set to true to `None` in optional contexts.
     ///
@@ -896,7 +896,7 @@ impl<'de> TagFilter<'de> {
 /// <>
 ///   ...
 ///   <item>The is the one item</item>
-///   This is <![CDATA[one another]]> item<!-- even when--> it splitted by comments
+///   This is <![CDATA[one another]]> item<!-- even when--> it split by comments
 ///   <tag>...and that is the third!</tag>
 ///   ...
 /// </>

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -896,7 +896,7 @@ impl<'de> TagFilter<'de> {
 /// <>
 ///   ...
 ///   <item>The is the one item</item>
-///   This is <![CDATA[one another]]> item<!-- even when--> it split by comments
+///   This is <![CDATA[one another]]> item<!-- even when--> it is split by comments
 ///   <tag>...and that is the third!</tag>
 ///   ...
 /// </>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1350,7 +1350,7 @@
 //!   },
 //!   quick_xml::de::from_str("
 //!     <any-tag xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-//!       <element xsi:nil='true'>Content is skiped because of xsi:nil='true'</element>
+//!       <element xsi:nil='true'>Content is skipped because of xsi:nil='true'</element>
 //!     </any-tag>
 //!   ").unwrap(),
 //! );
@@ -1378,7 +1378,7 @@
 //!   },
 //!   quick_xml::de::from_str("
 //!     <any-tag attribute='42' xsi:nil='true' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-//!       <element>Content is skiped because of xsi:nil='true'</element>
+//!       <element>Content is skipped because of xsi:nil='true'</element>
 //!       <non_optional>Note, that non-optional fields will be deserialized as usual</non_optional>
 //!     </any-tag>
 //!   ").unwrap(),

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -736,7 +736,7 @@ pub enum AttrError {
     /// ```
     ///
     /// This error can be returned only for the last attribute in the list,
-    /// because otherwise any content after `=` will be threated as a value.
+    /// because otherwise any content after `=` will be treated as a value.
     /// The XML
     ///
     /// ```xml

--- a/src/parser/comment.rs
+++ b/src/parser/comment.rs
@@ -24,7 +24,7 @@ use crate::parser::Parser;
 /// let mut parser = CommentParser::default();
 ///
 /// // Parse `<!-- comment with some -> and --- inside-->and the text follow...`
-/// // splitted into three chunks
+/// // split into three chunks
 /// assert_eq!(parser.feed(b"<!-- comment"), None);
 /// // ...get new chunk of data
 /// assert_eq!(parser.feed(b" with some -> and -"), None);

--- a/src/parser/dtd.rs
+++ b/src/parser/dtd.rs
@@ -26,7 +26,7 @@ pub enum DtdParser {
     /// ```
     InElementDecl,
     /// This state handles ATTLIST, ENTITY and NOTATION elements, i.e. all elements that can have
-    /// quotes strings (`'...'` or `"..."`) inside their markup, in which `>` should not be threated
+    /// quotes strings (`'...'` or `"..."`) inside their markup, in which `>` should not be treated
     /// as the end of the markup.
     ///
     /// This state handles the following productions from XML grammar:

--- a/src/parser/element.rs
+++ b/src/parser/element.rs
@@ -30,7 +30,7 @@ use crate::parser::Parser;
 /// let mut parser = ElementParser::default();
 ///
 /// // Parse `<my-element  with = 'some > inside'>and the text follow...`
-/// // splitted into three chunks
+/// // split into three chunks
 /// assert_eq!(parser.feed(b"<my-element"), None);
 /// // ...get new chunk of data
 /// assert_eq!(parser.feed(b" with = 'some >"), None);

--- a/src/parser/pi.rs
+++ b/src/parser/pi.rs
@@ -25,7 +25,7 @@ use crate::utils::is_whitespace;
 /// let mut parser = PiParser::default();
 ///
 /// // Parse `<?instruction with = 'some > and ?' inside?>and the text follow...`
-/// // splitted into three chunks
+/// // split into three chunks
 /// assert_eq!(parser.feed(b"<?instruction"), None);
 /// // ...get new chunk of data
 /// assert_eq!(parser.feed(b" with = 'some > and ?"), None);

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -719,7 +719,7 @@ impl<'w, 'r, W: Write> Serializer<'w, 'r, W> {
 
     /// Enable or disable expansion of empty elements (without adding space before `/>`).
     ///
-    /// This is the historycally first way to configure empty element handling. You can use
+    /// This is the historically first way to configure empty element handling. You can use
     /// [`empty_element_handling`](Self::empty_element_handling) for more control.
     ///
     /// # Examples

--- a/tests/serde-de-xsi.rs
+++ b/tests/serde-de-xsi.rs
@@ -475,7 +475,7 @@ mod as_field {
                 let xml = r#"<bar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><foo attr="value"/></bar>"#;
 
                 // Without `xsi:nil="true"` <foo> is mapped to `foo` field,
-                // but failed to deserialzie because of missing required <elem> tag
+                // but failed to deserialize because of missing required <elem> tag
                 assert_error_matches!(from_str::<Bar>(xml), DeError::Custom(_));
                 assert_eq!(
                     from_str::<Root>(xml).unwrap(),
@@ -509,7 +509,7 @@ mod as_field {
                 let xml = r#"<bar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><foo xsi:nil="false" attr="value"/></bar>"#;
 
                 // With `xsi:nil="false"` <foo> is mapped to `foo` field,
-                // but failed to deserialzie because of missing required <elem> tag
+                // but failed to deserialize because of missing required <elem> tag
                 assert_error_matches!(from_str::<Bar>(xml), DeError::Custom(_));
                 assert_eq!(
                     from_str::<Root>(xml).unwrap(),
@@ -546,7 +546,7 @@ mod as_field {
                     fn true_() {
                         let value = AnyName {
                             attr: None,
-                            // Becase `nil=true``, element deserialized as `None`
+                            // Because `nil=true``, element deserialized as `None`
                             elem: None,
                         };
 

--- a/tests/serde-de-xsi.rs
+++ b/tests/serde-de-xsi.rs
@@ -546,7 +546,7 @@ mod as_field {
                     fn true_() {
                         let value = AnyName {
                             attr: None,
-                            // Because `nil=true``, element deserialized as `None`
+                            // Because `nil=true`, element deserialized as `None`
                             elem: None,
                         };
 


### PR DESCRIPTION
Fix several spelling mistakes found in doc comments and inline comments across the codebase.

Changes:
- `shoould` -> `should` in `src/de/map.rs`
- `splitted` -> `split` in `src/de/map.rs`, `src/parser/comment.rs`, `src/parser/element.rs`, `src/parser/pi.rs`
- `skiped` -> `skipped` in `src/de/mod.rs`
- `threated` -> `treated` in `src/parser/dtd.rs`, `src/events/attributes.rs`
- `historycally` -> `historically` in `src/se/mod.rs`
- `deserialzie` -> `deserialize` in `tests/serde-de-xsi.rs`
- `Becase` -> `Because` in `tests/serde-de-xsi.rs`