### PR TITLE
Bound NamespaceResolver nesting depth (fixes #977)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,13 @@
 
 ### Bug Fixes
 
+- [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
+  event) now returns the new `NamespaceError::TooDeeplyNested` when a document
+  nests elements deeper than `u16::MAX`, instead of overflowing the internal
+  `u16` depth counter. Previously the unguarded `nesting_level += 1` panicked
+  under `overflow-checks` builds and silently wrapped in release, corrupting
+  namespace-scope bookkeeping on deeply nested untrusted input.
+
 ### Misc Changes
 
 
@@ -47,6 +54,7 @@
 
 [#969]: https://github.com/tafia/quick-xml/issues/969
 [#970]: https://github.com/tafia/quick-xml/issues/970
+[#977]: https://github.com/tafia/quick-xml/issues/977
 
 
 ## 0.40.1 -- 2026-05-15

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,8 @@
 
 ### Misc Changes
 
+[#977]: https://github.com/tafia/quick-xml/issues/977
+
 
 ## 0.41.0 -- 2026-06-29
 
@@ -54,7 +56,6 @@
 
 [#969]: https://github.com/tafia/quick-xml/issues/969
 [#970]: https://github.com/tafia/quick-xml/issues/970
-[#977]: https://github.com/tafia/quick-xml/issues/977
 
 
 ## 0.40.1 -- 2026-05-15

--- a/src/name.rs
+++ b/src/name.rs
@@ -47,6 +47,10 @@ pub enum NamespaceError {
     /// This bounds the heap allocated by [`NamespaceResolver::push`] (and hence
     /// by [`NsReader`](crate::reader::NsReader)) on untrusted input.
     TooManyDeclarations(usize),
+    /// The document nested elements more deeply than the namespace resolver's
+    /// depth counter (a `u16`) can track. This bounds stack / scope-bookkeeping
+    /// work on untrusted input. Contains the depth limit that was exceeded.
+    TooDeeplyNested(usize),
 }
 
 impl fmt::Display for NamespaceError {
@@ -84,6 +88,9 @@ impl fmt::Display for NamespaceError {
                      raise the limit with NamespaceResolver::set_max_declarations_per_element",
                     limit,
                 )
+            }
+            Self::TooDeeplyNested(limit) => {
+                write!(f, "document nests elements deeper than the supported limit of {}", limit)
             }
         }
     }
@@ -706,7 +713,9 @@ impl NamespaceResolver {
     ///
     /// [namespace bindings]: https://www.w3.org/TR/xml-names11/#dt-NSDecl
     pub fn push(&mut self, start: &BytesStart) -> Result<(), NamespaceError> {
-        self.nesting_level += 1;
+        self.nesting_level = self.nesting_level
+            .checked_add(1)
+            .ok_or(NamespaceError::TooDeeplyNested(u16::MAX as usize))?;
         let mut count = 0usize;
         // adds new namespaces for attributes starting with 'xmlns:' and for the 'xmlns'
         // (default namespace) attribute.
@@ -1301,6 +1310,25 @@ mod namespaces {
                 1,
             )),
             Ok(()),
+        );
+    }
+
+    /// Regression test for <https://github.com/tafia/quick-xml/issues/977>:
+    /// `push()` previously incremented a `u16` depth counter with an unguarded
+    /// `+= 1`, so a document nested past `u16::MAX` panicked under
+    /// `overflow-checks` or silently wrapped the counter and corrupted namespace
+    /// scoping in release. It now returns `TooDeeplyNested` at the boundary.
+    #[test]
+    fn push_rejects_pathological_nesting_depth() {
+        let mut resolver = NamespaceResolver::default();
+        let tag = BytesStart::from_content("a", 1);
+        // `u16::MAX` successful pushes, then the next is rejected cleanly.
+        for _ in 0..u16::MAX {
+            assert_eq!(resolver.push(&tag), Ok(()));
+        }
+        assert_eq!(
+            resolver.push(&tag),
+            Err(NamespaceError::TooDeeplyNested(u16::MAX as usize)),
         );
     }
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -90,7 +90,11 @@ impl fmt::Display for NamespaceError {
                 )
             }
             Self::TooDeeplyNested(limit) => {
-                write!(f, "document nests elements deeper than the supported limit of {}", limit)
+                write!(
+                    f,
+                    "document nests elements deeper than the supported limit of {}",
+                    limit
+                )
             }
         }
     }
@@ -713,7 +717,8 @@ impl NamespaceResolver {
     ///
     /// [namespace bindings]: https://www.w3.org/TR/xml-names11/#dt-NSDecl
     pub fn push(&mut self, start: &BytesStart) -> Result<(), NamespaceError> {
-        self.nesting_level = self.nesting_level
+        self.nesting_level = self
+            .nesting_level
             .checked_add(1)
             .ok_or(NamespaceError::TooDeeplyNested(u16::MAX as usize))?;
         let mut count = 0usize;


### PR DESCRIPTION
Fixes #977.

`NamespaceResolver::push` incremented its `u16` `nesting_level` with an unguarded `+= 1`. A document nested past `u16::MAX` overflowed it — a panic under `overflow-checks` builds, or a silent wrap that corrupts namespace-scope truncation in a stock release build (bindings from closed scopes leak; in-scope bindings vanish). The sibling `pop` already saturates (`saturating_sub`); only the increment was unguarded. Reachable from the public `NsReader::read_resolved_event*` on ~490 KB of deeply nested XML. Still present on `master`; orthogonal to #970/#972 (which capped *declarations per element* — this is the *depth* counter).

### Fix

Return a new `NamespaceError::TooDeeplyNested` at the `u16` boundary, matching the existing per-element `TooManyDeclarations` guard:

```rust
self.nesting_level = self.nesting_level
    .checked_add(1)
    .ok_or(NamespaceError::TooDeeplyNested(u16::MAX as usize))?;
```

A `saturating_add` (mirroring `pop`) was considered but is **insufficient** — it removes the panic but not the scope corruption: at saturation all deep levels collapse to `u16::MAX` and `set_level`'s `rposition(|n| n.level <= level)` truncation still over-truncates, so the namespace misresolution persists (verified). The clean error rejects the pathological document instead.

### Validation

- `cargo test` and `cargo test --features serialize`: all green (incl. the existing `push_rejects_too_many_declarations`).
- Added `push_rejects_pathological_nesting_depth` next to the #970 test — `u16::MAX` successful pushes, then a clean `Err(TooDeeplyNested)`.
- The 490 KB PoC from #977 now returns `Err(TooDeeplyNested)` instead of panicking, and the namespace-misresolution demonstration no longer occurs.

*Alternative considered:* widen `nesting_level` to `u32`/`usize` (overflow becomes practically unreachable). I chose the explicit cap + error to mirror `max_declarations_per_element` and keep the depth bound intentional on untrusted input — happy to switch if you'd prefer no new variant.

Found by the [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace) security pipeline.
