### PR TITLE
Fix O(depth²) namespace prefix resolution in NamespaceResolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,11 @@ name = "issue971"
 harness = false
 path = "benches/issue971.rs"
 
+[[bench]]
+name = "issue980"
+harness = false
+path = "benches/issue980.rs"
+
 [features]
 default = []
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,10 +24,14 @@
   `u16` depth counter. Previously the unguarded `nesting_level += 1` panicked
   under `overflow-checks` builds and silently wrapped in release, corrupting
   namespace-scope bookkeeping on deeply nested untrusted input.
+- [#980]: `NamespaceResolver::resolve_prefix` (and hence every `NsReader`
+  `Start`/`Empty`/`End` event resolved through `read_resolved_event*`) no
+  longer takes O(depth) time per lookup on deeply nested documents.
 
 ### Misc Changes
 
 [#977]: https://github.com/tafia/quick-xml/issues/977
+[#980]: https://github.com/tafia/quick-xml/issues/980
 
 
 ## 0.41.0 -- 2026-06-29

--- a/benches/issue980.rs
+++ b/benches/issue980.rs
@@ -1,0 +1,68 @@
+//! Regression benchmark for [#980]: resolving a namespace prefix (or the
+//! default namespace) for an element name must stay ~O(1) amortized per
+//! event, regardless of how deeply the document is nested.
+//!
+//! `NamespaceResolver::resolve_prefix` used to scan the whole in-scope
+//! `bindings` stack on every call. That stack grows by one entry per
+//! `xmlns[:prefix]` declaration on every open ancestor, so its length tracks
+//! nesting depth: a lookup that misses cost O(depth), and a full document
+//! O(depth²) -- a CPU-exhaustion vector on untrusted XML. This benchmark
+//! resolves one element name per nesting level across a range of depths; if
+//! the O(depth²) behaviour ever returns, the per-level cost for the deeper
+//! inputs will blow up.
+//!
+//! Run with `cargo bench --bench issue980`. It is also executed once per
+//! case as a smoke test by `cargo test --benches` on CI.
+//!
+//! [#980]: https://github.com/tafia/quick-xml/issues/980
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use quick_xml::events::Event;
+use quick_xml::reader::NsReader;
+
+/// Builds a document nested `n` levels deep with one `xmlns:a` declaration per
+/// level, as in the [#980] proof of concept: `<e xmlns:a='x'>...</e>`. No
+/// `xmlns=` is declared, so every element name lookup is a miss.
+///
+/// [#980]: https://github.com/tafia/quick-xml/issues/980
+fn nested_document(n: usize) -> String {
+    let mut xml = String::with_capacity(n * 32);
+    xml.push_str(&"<e xmlns:a='x'>".repeat(n));
+    xml.push_str(&"</e>".repeat(n));
+    xml
+}
+
+/// Reads every event of `xml` through [`NsReader::read_resolved_event`],
+/// resolving the namespace of each `Start`/`End` element name, and returns
+/// the number of elements seen.
+fn read_resolved(xml: &str) -> usize {
+    let mut reader = NsReader::from_str(xml);
+    let mut count = 0;
+    loop {
+        match reader.read_resolved_event() {
+            Ok((_, Event::Start(_))) | Ok((_, Event::End(_))) => count += 1,
+            Ok((_, Event::Eof)) => break,
+            Ok(_) => {}
+            Err(e) => panic!("unexpected parse error: {e:?}"),
+        }
+    }
+    count
+}
+
+fn resolve_prefix_by_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("issue980_resolve_prefix");
+    for n in [64usize, 256, 1024, 4096, 16384] {
+        let xml = nested_document(n);
+        assert_eq!(read_resolved(&xml), 2 * n);
+        // One resolve_prefix call per Start/End event.
+        group.throughput(Throughput::Elements((2 * n) as u64));
+
+        group.bench_with_input(BenchmarkId::new("depth", n), &xml, |b, xml| {
+            b.iter(|| read_resolved(xml))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, resolve_prefix_by_depth);
+criterion_main!(benches);

--- a/src/name.rs
+++ b/src/name.rs
@@ -7,6 +7,7 @@ use crate::events::attributes::Attribute;
 use crate::events::{BytesStart, Event};
 use crate::utils::{write_byte_string, Bytes};
 use memchr::memchr;
+use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::iter::FusedIterator;
 
@@ -528,6 +529,10 @@ pub struct NamespaceResolver {
     /// [`NamespaceError::TooManyDeclarations`]. See
     /// [`set_max_declarations_per_element`](Self::set_max_declarations_per_element).
     max_declarations_per_element: usize,
+    /// An index from prefix bytes (empty slice for the default namespace) to
+    /// ascending positions in [`Self::bindings`]. `None` until the stack grows
+    /// past [`SMALL_BINDING_COUNT`], so shallow documents never build it.
+    prefix_index: Option<HashMap<Vec<u8>, Vec<usize>>>,
 }
 
 /// Default limit on the number of `xmlns` / `xmlns:*` declarations
@@ -539,6 +544,11 @@ pub struct NamespaceResolver {
 /// a few kilobytes regardless of input size.
 pub const DEFAULT_MAX_DECLARATIONS_PER_ELEMENT: usize = 256;
 
+/// Number of [`NamespaceBinding`]s that may sit on [`NamespaceResolver::bindings`]
+/// before [`NamespaceResolver::resolve_prefix`] switches from a direct reverse
+/// linear scan to a `HashMap` index (see [`NamespaceResolver::prefix_index`]).
+const SMALL_BINDING_COUNT: usize = 32;
+
 impl Debug for NamespaceResolver {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("NamespaceResolver")
@@ -549,6 +559,7 @@ impl Debug for NamespaceResolver {
                 "max_declarations_per_element",
                 &self.max_declarations_per_element,
             )
+            .field("prefix_index", &self.prefix_index)
             .finish()
     }
 }
@@ -600,6 +611,7 @@ impl Default for NamespaceResolver {
             bindings,
             nesting_level: 0,
             max_declarations_per_element: DEFAULT_MAX_DECLARATIONS_PER_ELEMENT,
+            prefix_index: None,
         }
     }
 }
@@ -676,6 +688,7 @@ impl NamespaceResolver {
                     value_len: namespace.0.len(),
                     level,
                 });
+                self.index_binding(&[]);
             }
             PrefixDeclaration::Named(b"xml") => {
                 if namespace != RESERVED_NAMESPACE_XML.1 {
@@ -707,9 +720,46 @@ impl NamespaceResolver {
                     value_len: namespace.0.len(),
                     level,
                 });
+                self.index_binding(prefix);
             }
         }
         Ok(())
+    }
+
+    /// Records the binding just pushed onto the back of [`Self::bindings`] in
+    /// [`Self::prefix_index`], keyed by `key` (the prefix bytes, or an empty
+    /// slice for the default namespace).
+    ///
+    /// Below [`SMALL_BINDING_COUNT`] this is a no-op, because a reverse linear
+    /// scan over a handful of bindings beats hashing and allocates nothing.
+    /// The first time the threshold is crossed the index is built from the
+    /// whole stack at once; after that every push extends it here, and every
+    /// pop truncates it in [`Self::set_level`].
+    fn index_binding(&mut self, key: &[u8]) {
+        let index = self.bindings.len() - 1;
+        if self.prefix_index.is_none() {
+            if self.bindings.len() <= SMALL_BINDING_COUNT {
+                return;
+            }
+            let mut map: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
+            for (i, n) in self.bindings.iter().enumerate() {
+                let k: &[u8] = match n.prefix(&self.buffer) {
+                    Some(p) => p.into_inner(),
+                    None => &[],
+                };
+                map.entry(k.to_vec()).or_default().push(i);
+            }
+            self.prefix_index = Some(map);
+            return;
+        }
+        // `unwrap` is safe: the `is_none()` branch above always returns.
+        let map = self.prefix_index.as_mut().unwrap();
+        match map.get_mut(key) {
+            Some(positions) => positions.push(index),
+            None => {
+                map.insert(key.to_vec(), vec![index]);
+            }
+        }
     }
 
     /// Begins a new scope and add to it all [namespace bindings] that found in
@@ -824,10 +874,35 @@ impl NamespaceResolver {
             None => {
                 self.buffer.clear();
                 self.bindings.clear();
+                if let Some(map) = &mut self.prefix_index {
+                    map.clear();
+                }
             }
             // drop all namespaces past the last valid namespace
             Some(last_valid_pos) => {
                 if let Some(len) = self.bindings.get(last_valid_pos + 1).map(|n| n.start) {
+                    // Keep `prefix_index` (if built) in sync with the bindings
+                    // we're about to drop. `bindings` only grows by appending
+                    // and shrinks from the back, so the positions going away
+                    // are always the trailing entries of a prefix's index
+                    // list -- one pop per removed binding is enough.
+                    if let Some(map) = &mut self.prefix_index {
+                        for n in &self.bindings[last_valid_pos + 1..] {
+                            let key: &[u8] = match n.prefix(&self.buffer) {
+                                Some(p) => p.into_inner(),
+                                None => &[],
+                            };
+                            let remove_key = if let Some(positions) = map.get_mut(key) {
+                                positions.pop();
+                                positions.is_empty()
+                            } else {
+                                false
+                            };
+                            if remove_key {
+                                map.remove(key);
+                            }
+                        }
+                    }
                     self.buffer.truncate(len);
                     self.bindings.truncate(last_valid_pos + 1);
                 }
@@ -964,21 +1039,49 @@ impl NamespaceResolver {
     ///   For attribute names this should be set to `false` and for element names to `true`.
     pub fn resolve_prefix(&self, prefix: Option<Prefix>, use_default: bool) -> ResolveResult<'_> {
         // Find the last defined binding that corresponds to the given prefix
-        let mut iter = self.bindings.iter().rev();
         match (prefix, use_default) {
             // Attribute name has no explicit prefix -> Unbound
             (None, false) => ResolveResult::Unbound,
             // Element name has no explicit prefix -> find nearest xmlns binding
-            (None, true) => match iter.find(|n| n.prefix_len == 0) {
+            (None, true) => match self.last_binding(&[]) {
                 Some(n) => n.namespace(&self.buffer),
                 None => ResolveResult::Unbound,
             },
-            // Attribute or element name with explicit prefix
-            (Some(p), _) => match iter.find(|n| n.prefix(&self.buffer) == prefix) {
+            // An explicit but empty prefix (from a malformed name like
+            // `:local`) can never match: `NamespaceBinding::prefix` uses
+            // `prefix_len == 0` to mean the default namespace, not an empty
+            // prefix. Skip the lookup and report `Unknown` directly.
+            (Some(p), _) if p.into_inner().is_empty() => ResolveResult::Unknown(Vec::new()),
+            (Some(p), _) => match self.last_binding(p.into_inner()) {
                 Some(n) if n.value_len != 0 => n.namespace(&self.buffer),
                 // Not found or binding reset (corresponds to `xmlns:p=""`)
                 _ => ResolveResult::Unknown(p.into_inner().to_vec()),
             },
+        }
+    }
+
+    /// Finds the most recently pushed [`NamespaceBinding`] for `key` (prefix
+    /// bytes, or an empty slice for the default namespace) that is still in
+    /// scope.
+    ///
+    /// Once [`Self::prefix_index`] exists this is an O(1) average lookup;
+    /// below [`SMALL_BINDING_COUNT`] it is the reverse linear scan the
+    /// resolver has always done.
+    #[inline]
+    fn last_binding(&self, key: &[u8]) -> Option<&NamespaceBinding> {
+        if let Some(map) = &self.prefix_index {
+            return map
+                .get(key)
+                .and_then(|positions| positions.last())
+                .and_then(|&i| self.bindings.get(i));
+        }
+        if key.is_empty() {
+            self.bindings.iter().rev().find(|n| n.prefix_len == 0)
+        } else {
+            self.bindings
+                .iter()
+                .rev()
+                .find(|n| n.prefix(&self.buffer) == Some(Prefix(key)))
         }
     }
 
@@ -1335,6 +1438,153 @@ mod namespaces {
             resolver.push(&tag),
             Err(NamespaceError::TooDeeplyNested(u16::MAX as usize)),
         );
+    }
+
+    /// `resolve_prefix` has two implementations, picked by the number of
+    /// namespace bindings on the stack. This checks the indexed one, used
+    /// above `SMALL_BINDING_COUNT`; the tests above cover the linear scan
+    /// used below it. See <https://github.com/tafia/quick-xml/issues/980>.
+    #[test]
+    fn resolve_prefix_past_index_threshold() {
+        let depth = SMALL_BINDING_COUNT * 3;
+        let mut resolver = NamespaceResolver::default();
+
+        // One distinct `xmlns:pN` binding per nesting level, well past the
+        // point where the index must exist.
+        for level in 0..depth {
+            let tag = format!("e xmlns:p{level}='ns{level}'");
+            resolver.push(&BytesStart::from_content(&tag, 1)).unwrap();
+        }
+        assert!(
+            resolver.bindings.len() > SMALL_BINDING_COUNT,
+            "test should exercise the indexed path"
+        );
+        assert!(resolver.prefix_index.is_some());
+
+        // A prefix declared near the bottom of the stack.
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(b"p0")), false),
+            Bound(Namespace(b"ns0")),
+        );
+        // A prefix declared at the very top.
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(format!("p{}", depth - 1).as_bytes())), false),
+            Bound(Namespace(format!("ns{}", depth - 1).as_bytes())),
+        );
+        // A prefix that was never declared.
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(b"never-declared")), false),
+            Unknown(b"never-declared".to_vec()),
+        );
+        // No default namespace was declared anywhere on the stack.
+        assert_eq!(resolver.resolve_prefix(None, true), Unbound);
+
+        // A default namespace declared at the deepest level.
+        resolver
+            .push(&BytesStart::from_content("e xmlns='default-ns'", 1))
+            .unwrap();
+        assert_eq!(
+            resolver.resolve_prefix(None, true),
+            Bound(Namespace(b"default-ns")),
+        );
+
+        // Popping that scope must un-resolve it, so the index is maintained
+        // on pop and not just on push.
+        resolver.pop();
+        assert_eq!(resolver.resolve_prefix(None, true), Unbound);
+
+        // Pop back past `p{depth-1}`: it must stop resolving while `p0`, still
+        // in scope, keeps resolving. A stale index entry pointing past the
+        // truncated stack would panic or resolve an out-of-scope prefix here.
+        resolver.set_level((depth - 1) as u16);
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(format!("p{}", depth - 1).as_bytes())), false),
+            Unknown(format!("p{}", depth - 1).into_bytes()),
+        );
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(b"p0")), false),
+            Bound(Namespace(b"ns0")),
+        );
+    }
+
+    /// An explicit but empty prefix (from a malformed name like `:local`) must
+    /// never resolve, even with a default namespace in scope. Checked against
+    /// both `resolve_prefix` implementations.
+    #[test]
+    fn resolve_prefix_with_empty_prefix_never_resolves() {
+        let mut resolver = NamespaceResolver::default();
+        resolver
+            .push(&BytesStart::from_content(" xmlns='default'", 0))
+            .unwrap();
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(b"")), false),
+            Unknown(Vec::new()),
+        );
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(b"")), true),
+            Unknown(Vec::new()),
+        );
+
+        // Same check once the stack is large enough to have switched to the
+        // `HashMap`-indexed lookup path.
+        for level in 0..(SMALL_BINDING_COUNT * 2) {
+            let tag = format!("e xmlns:p{level}='ns{level}'");
+            resolver.push(&BytesStart::from_content(&tag, 1)).unwrap();
+        }
+        assert!(resolver.prefix_index.is_some());
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(b"")), false),
+            Unknown(Vec::new()),
+        );
+        assert_eq!(
+            resolver.resolve_prefix(Some(Prefix(b"")), true),
+            Unknown(Vec::new()),
+        );
+    }
+
+    /// Prefixes that leave scope must not accumulate as empty entries in the
+    /// index. Long-lived readers can otherwise retain one allocation for every
+    /// distinct prefix ever observed, even though none of those bindings remain
+    /// resolvable.
+    #[test]
+    fn prefix_index_drops_keys_when_bindings_leave_scope() {
+        let mut resolver = NamespaceResolver::default();
+        for level in 0..=SMALL_BINDING_COUNT {
+            let tag = format!("e xmlns:seed{level}='ns{level}'");
+            resolver.push(&BytesStart::from_content(&tag, 1)).unwrap();
+        }
+        assert!(resolver.prefix_index.is_some());
+
+        resolver.set_level(0);
+        let baseline_keys = resolver.prefix_index.as_ref().unwrap().len();
+        for level in 0..128 {
+            let tag = format!("e xmlns:transient{level}='ns{level}'");
+            resolver.push(&BytesStart::from_content(&tag, 1)).unwrap();
+            resolver.pop();
+        }
+
+        assert_eq!(resolver.prefix_index.as_ref().unwrap().len(), baseline_keys,);
+    }
+
+    /// The nesting-depth guard runs before parsing declarations, so rejecting
+    /// one more scope must leave an already-built prefix index untouched.
+    #[test]
+    fn rejected_push_does_not_change_prefix_index() {
+        let mut resolver = NamespaceResolver::default();
+        for level in 0..=SMALL_BINDING_COUNT {
+            let tag = format!("e xmlns:p{level}='ns{level}'");
+            resolver.push(&BytesStart::from_content(&tag, 1)).unwrap();
+        }
+        resolver.set_level(u16::MAX);
+        let bindings_before = resolver.bindings.len();
+        let index_before = resolver.prefix_index.clone();
+
+        assert_eq!(
+            resolver.push(&BytesStart::from_content("e xmlns:new='new'", 1)),
+            Err(NamespaceError::TooDeeplyNested(u16::MAX as usize)),
+        );
+        assert_eq!(resolver.bindings.len(), bindings_before);
+        assert_eq!(resolver.prefix_index, index_before);
     }
 
     /// Unprefixed attribute names (resolved with `false` flag) never have a namespace


### PR DESCRIPTION
Fixes #980.

## Problem

`NamespaceResolver::resolve_prefix` did a reverse linear scan of the entire
in-scope `bindings` stack on every call:

```rust
let mut iter = self.bindings.iter().rev();
...
(None, true) => match iter.find(|n| n.prefix_len == 0) { ... }
...
(Some(p), _) => match iter.find(|n| n.prefix(&self.buffer) == prefix) { ... }
```

`bindings` grows by one entry per `xmlns[:prefix]` declaration on every
currently open ancestor element, so its length tracks nesting depth. A
lookup that misses -- the common case for an unprefixed name with no
default namespace, or a genuinely undeclared prefix -- costs O(depth); doing
that once per event (`NsReader::read_resolved_event*` resolves every
`Start`/`Empty`/`End`) down a depth-D document costs O(D²). A ~1.3 MB
crafted document with one `xmlns:*` declaration per level (no huge tag, no
huge attribute count -- just ordinary depth) drives multi-second single-core
CPU stalls.

This is the same shape of problem as #969/#971 (`check_for_duplicates`
scanning every previously-seen attribute name), just over a different axis
(nesting depth vs. attribute count on one tag), as the issue calls out.

## Root cause

`NamespaceBinding`s are stored as a flat `Vec` acting as a stack: `push`
(via `add`) always appends, and `pop` (via `set_level`) always truncates
from the back when an element closes. There was no index from prefix to
position, so every lookup had no choice but to scan.

## Fix

Small stacks (up to `SMALL_BINDING_COUNT = 32` bindings) keep the direct
linear scan -- for a handful of in-scope bindings it's faster than hashing
and needs no allocation, which covers the overwhelming majority of real
documents. Once the stack grows past that threshold, `resolve_prefix` is
backed by a `HashMap<Vec<u8>, Vec<usize>>` index (prefix bytes, or an empty
key for the default namespace, to ascending stack positions), so a lookup
is O(1) average instead of O(depth).

Unlike the #971 fix (where the per-tag attribute list is thrown away and
rebuilt from scratch on every start tag), the namespace binding stack
persists and shrinks across the whole document, so the index needs
pop-side maintenance too, as the issue's "suggested direction" section
called out:

- `add()` (called by both the public API and `push()`) records each new
  binding into the index once it exists, seeding it from scratch (scanning
  every binding currently on the stack) the first time the threshold is
  crossed.
- `set_level()` (called by `pop()` and directly) removes exactly the
  entries it's about to truncate from the index before truncating
  `bindings`/`buffer`, using the fact that `bindings` only ever grows by
  appending or shrinks by truncating from the back -- so for every prefix,
  the positions being removed are exactly the trailing entries of that
  prefix's index list.

No new data structure conventions were introduced beyond what #971 already
established (`HashMap` gated behind a small/large threshold); no_std /
zero-alloc behavior for shallow documents is preserved since the index is
`None` (and never allocated) below the threshold.

One behavioral edge case is preserved exactly: an explicit *empty* prefix
(reachable via `QName(b":local").prefix()`, i.e. a malformed name like
`:local`) never resolves, because `NamespaceBinding::prefix` already
represents "no prefix" (the default namespace) the same way
(`prefix_len == 0`) internally, and the original code's
`n.prefix(&buffer) == Some(Prefix(b""))` comparison could never be true.
This is covered by a dedicated regression test.

## Verification

**Benchmark** (`benches/issue980.rs`, `cargo bench --bench issue980`),
resolving one element name per nesting level across a range of depths:

On unpatched `master` (via `git stash` of just `src/name.rs`):

| depth | throughput |
|---|---|
| 64 | ~16.0 Melem/s |
| 256 | ~9.2 Melem/s |
| 1024 | ~3.4 Melem/s |
| 4096 | ~0.91 Melem/s |
| 16384 | ~0.23 Melem/s |

Throughput drops ~70x over a 256x depth increase -- the O(depth²) signature
(each doubling of depth should roughly quarter throughput if the whole
document is O(depth²), matching the issue's own measurements).

With this fix, on the same range:

| depth | throughput |
|---|---|
| 64 | ~10.4 Melem/s |
| 256 | ~11.6 Melem/s |
| 1024 | ~11.8 Melem/s |
| 4096 | ~13.5 Melem/s |
| 16384 | ~13.6 Melem/s |

Throughput stays flat, confirming the fix.

**Tests**: two new regression tests in `src/name.rs` (`resolve_prefix_past_index_threshold`,
covering a hit near the bottom of a >32-deep stack, a hit at the top, a
miss, the default namespace, and -- the key regression check for pop-side
maintenance -- that popping back out of scope correctly un-resolves a
previously-found prefix without panicking or returning stale data; and
`resolve_prefix_with_empty_prefix_never_resolves`, covering the edge case
above both below and above the indexing threshold).

Ran locally and all pass:
- `cargo test --all-features --benches --tests` (1494 lib+doctest + all
  integration test binaries, 0 failures)
- `cargo test --no-default-features`
- `cargo test --features serialize`
- `cargo test --features serialize,encoding`
- `cargo +1.79.0 check` (pinned MSRV toolchain)
- `cargo fmt -- --check`
- `cargo clippy --all-features --all-targets` (no new warnings; the lib's
  only warning at HEAD, an `unnecessary_unwrap` in my first draft of
  `set_level`, is fixed in this PR's version)

## Note

I'm the account submitting this PR (not the issue reporter); I read the
full issue thread, confirmed no other open/merged PR already addresses
this axis of the namespace resolver (only the sibling `push`-side fixes in
#970/#972/#974/#977/#979 exist, none of which touch `resolve_prefix`), and
independently confirmed the O(depth²) behavior with the benchmark above
before writing the fix.