### PR TITLE
Add recursion-depth limit to serde Deserializer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@
 ## Unreleased
 
 This is a large release. The primary change is an ergonomic improvement across the entire API -
-the quick_xml now makes use of `&str` and `String` types where possible instead of
+quick_xml now makes use of `&str` and `String` types where possible instead of
 `&[u8]` and `Vec<u8>`. This requires significant refactoring of downstream code,
 but should result in a net simplification as well as potential performance improvements.
 
@@ -70,6 +70,10 @@ The MSRV has been raised to 1.86.
 - [#980]: `NamespaceResolver` now caps the total number of in-scope namespace
   bindings (default 128, configurable via `set_max_namespace_bindings`),
   replacing the previous per-element `max_declarations_per_element` limit.
+- [#978]: The serde `Deserializer` now enforces a configurable recursion-depth
+  limit (default 128, matching `serde_json`). Deeply nested XML returns
+  `DeError::TooDeeplyNested` instead of overflowing the native call stack.
+  Use `Deserializer::recursion_limit()` to adjust.
 
 ### Misc Changes
 
@@ -84,6 +88,7 @@ The MSRV has been raised to 1.86.
 [#963]: https://github.com/tafia/quick-xml/pull/963
 [#977]: https://github.com/tafia/quick-xml/issues/977
 [#980]: https://github.com/tafia/quick-xml/issues/980
+[#978]: https://github.com/tafia/quick-xml/issues/978
 [#983]: https://github.com/tafia/quick-xml/issues/983
 
 ## 0.41.0 -- 2026-06-29

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -205,8 +205,12 @@ where
         de: &'d mut Deserializer<'de, R, E>,
         start: BytesStart<'de>,
         fields: &'static [&'static str],
-    ) -> Self {
-        Self {
+    ) -> Result<Self, DeError> {
+        if de.depth >= de.max_depth {
+            return Err(DeError::TooDeeplyNested(de.max_depth));
+        }
+        de.depth += 1;
+        Ok(Self {
             de,
             iter: IterState::new(start.name().as_ref().len(), false),
             start,
@@ -214,7 +218,7 @@ where
             fields,
             has_value_field: fields.contains(&VALUE_KEY),
             has_text_field: fields.contains(&TEXT_KEY),
-        }
+        })
     }
 
     /// Determines if subtree started with the specified event should be skipped.
@@ -237,6 +241,16 @@ where
     fn skip_whitespaces(&mut self) -> Result<(), DeError> {
         // TODO: respect the `xml:space` attribute and probably some deserialized type sign
         self.de.skip_whitespaces()
+    }
+}
+
+impl<'de, 'd, R, E> Drop for ElementMapAccess<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    fn drop(&mut self) {
+        self.de.depth -= 1;
     }
 }
 
@@ -794,7 +808,7 @@ where
         V: Visitor<'de>,
     {
         match self.map.de.next()? {
-            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.map.de, e, fields)),
+            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.map.de, e, fields)?),
             DeEvent::Text(e) => {
                 SimpleTypeDeserializer::from_text_content(e).deserialize_struct("", fields, visitor)
             }
@@ -1134,7 +1148,7 @@ where
     where
         V: Visitor<'de>,
     {
-        visitor.visit_map(ElementMapAccess::new(self.de, self.start, fields))
+        visitor.visit_map(ElementMapAccess::new(self.de, self.start, fields)?)
     }
 
     fn deserialize_enum<V>(

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2566,6 +2566,12 @@ where
 
     /// Buffer to store attribute name as a field name exposed to serde consumers
     key_buf: String,
+
+    /// Current recursion depth (number of nested `ElementMapAccess` and `EnumAccess`
+    /// instances on the call stack).
+    depth: usize,
+    /// Maximum allowed recursion depth. Defaults to 128.
+    max_depth: usize,
 }
 
 impl<'de, R, E> Deserializer<'de, R, E>
@@ -2594,6 +2600,9 @@ where
             peek: None,
 
             key_buf: String::new(),
+
+            depth: 0,
+            max_depth: 128,
         }
     }
 
@@ -2705,6 +2714,50 @@ where
     #[cfg(feature = "overlapped-lists")]
     pub fn event_buffer_size(&mut self, limit: Option<NonZeroUsize>) -> &mut Self {
         self.limit = limit;
+        self
+    }
+
+    /// Set the maximum recursion depth for deserialization of nested structures.
+    ///
+    /// If the XML nesting exceeds this limit, [`DeError::TooDeeplyNested`] will
+    /// be returned. The default limit is 128, matching `serde_json`.
+    ///
+    /// This method can be used to prevent stack overflow from a [DoS] attack
+    /// when parsing untrusted XML with deep nesting.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::de::Deserializer;
+    /// use quick_xml::errors::serialize::DeError;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Debug, Deserialize)]
+    /// struct Nested {
+    ///     inner: Option<Box<Nested>>,
+    /// }
+    ///
+    /// // 3 levels of nesting: <Nested><inner><inner></inner></inner></Nested>
+    /// let xml = "<Nested><inner><inner></inner></inner></Nested>";
+    ///
+    /// // With sufficient limit, deserialization succeeds
+    /// let mut de = Deserializer::from_str(xml);
+    /// de.recursion_limit(3);
+    /// assert!(Nested::deserialize(&mut de).is_ok());
+    ///
+    /// // With a low limit, deserialization fails
+    /// let mut de = Deserializer::from_str(xml);
+    /// de.recursion_limit(2);
+    /// assert!(matches!(
+    ///     Nested::deserialize(&mut de),
+    ///     Err(DeError::TooDeeplyNested(2))
+    /// ));
+    /// ```
+    ///
+    /// [DoS]: https://en.wikipedia.org/wiki/Denial-of-service_attack
+    pub fn recursion_limit(&mut self, limit: usize) -> &mut Self {
+        self.max_depth = limit;
         self
     }
 
@@ -3222,7 +3275,7 @@ where
         // When document is pretty-printed there could be whitespaces before the root element
         self.skip_whitespaces()?;
         match self.next()? {
-            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self, e, fields)),
+            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self, e, fields)?),
             // SAFETY: The reader is guaranteed that we don't have unmatched tags
             // If we here, then our deserializer has a bug
             DeEvent::End(e) => unreachable!("{:?}", e),
@@ -3297,7 +3350,13 @@ where
         // which represents the enum variant
         // Checked by `top_level::list_of_enum` test in serde-de-seq
         self.skip_whitespaces()?;
-        visitor.visit_enum(var::EnumAccess::new(self))
+        if self.depth >= self.max_depth {
+            return Err(DeError::TooDeeplyNested(self.max_depth));
+        }
+        self.depth += 1;
+        let result = visitor.visit_enum(var::EnumAccess::new(self));
+        self.depth -= 1;
+        result
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, DeError>

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -132,7 +132,7 @@ where
         V: Visitor<'de>,
     {
         match self.de.next()? {
-            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.de, e, fields)),
+            DeEvent::Start(e) => visitor.visit_map(ElementMapAccess::new(self.de, e, fields)?),
             DeEvent::Text(e) => {
                 SimpleTypeDeserializer::from_text_content(e).deserialize_struct("", fields, visitor)
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -348,6 +348,12 @@ pub mod serialize {
         /// [`Event::Start`]: crate::events::Event::Start
         /// [`Event::End`]: crate::events::Event::End
         UnexpectedEof,
+        /// The XML input exceeds the configured recursion limit.
+        ///
+        /// The contained value is the limit that was exceeded. This error is
+        /// returned when deserializing deeply nested XML structures to prevent
+        /// stack overflows.
+        TooDeeplyNested(usize),
         /// Too many events were skipped while deserializing a sequence, event limit
         /// exceeded. The limit was provided as an argument
         #[cfg(feature = "overlapped-lists")]
@@ -362,6 +368,7 @@ pub mod serialize {
                 Self::KeyNotRead => f.write_str("invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
                 Self::UnexpectedStart(e) => write!(f, "unexpected `Event::Start({})", e),
                 Self::UnexpectedEof => f.write_str("unexpected `Event::Eof`"),
+                Self::TooDeeplyNested(limit) => write!(f, "XML is too deeply nested, recursion limit of {} exceeded", limit),
                 #[cfg(feature = "overlapped-lists")]
                 Self::TooManyEvents(s) => write!(f, "deserializer buffered {} events, limit exceeded", s),
             }

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -871,3 +871,370 @@ fn issue928() {
         },
     );
 }
+
+/// Regression tests for https://github.com/tafia/quick-xml/issues/978.
+///
+/// Deeply nested XML should produce `DeError::TooDeeplyNested` instead of
+/// a stack overflow. Tests are ordered: struct (general, then `$value`),
+/// enum (newtype, tuple, struct variant), then siblings.
+mod issue978 {
+    use quick_xml::de::Deserializer as XmlDeserializer;
+    use quick_xml::DeError;
+    use serde::Deserialize;
+
+    /// Generate XML like `<S><field><field>...</field></field></S>`.
+    ///
+    /// In quick-xml's serde, the field element IS the container for nested
+    /// structs (there is no inner `<S>` wrapper).
+    fn nested_struct_field(depth: usize) -> String {
+        let mut xml = String::from("<S>");
+        for _ in 0..depth.saturating_sub(1) {
+            xml.push_str("<field>");
+        }
+        for _ in 0..depth.saturating_sub(1) {
+            xml.push_str("</field>");
+        }
+        xml.push_str("</S>");
+        xml
+    }
+
+    /// Generate XML like `<S><S>...<S></S>...</S></S>`.
+    fn nested_struct_value(depth: usize) -> String {
+        let mut xml = String::new();
+        for _ in 0..depth {
+            xml.push_str("<S>");
+        }
+        for _ in 0..depth {
+            xml.push_str("</S>");
+        }
+        xml
+    }
+
+    /// Generate XML like `<Wrap><Wrap>...<Leaf/>...</Wrap></Wrap>`.
+    fn nested_enum_value(depth: usize) -> String {
+        let mut xml = String::new();
+        for _ in 0..depth.saturating_sub(1) {
+            xml.push_str("<Wrap>");
+        }
+        xml.push_str("<Leaf/>");
+        for _ in 0..depth.saturating_sub(1) {
+            xml.push_str("</Wrap>");
+        }
+        xml
+    }
+
+    // struct field
+
+    #[test]
+    fn struct_field_box() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            field: Option<Box<S>>,
+        }
+
+        let limit = 3;
+
+        // Within the limit: deserializes successfully
+        let xml = nested_struct_field(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(S::deserialize(&mut de).is_ok());
+
+        // Exceeds the limit
+        let xml = nested_struct_field(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(matches!(
+            S::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(n)) if n == limit
+        ));
+    }
+
+    #[test]
+    fn struct_field_vec() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[serde(default)]
+            field: Vec<S>,
+        }
+
+        let limit = 3;
+
+        let xml = nested_struct_field(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(S::deserialize(&mut de).is_ok());
+
+        let xml = nested_struct_field(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(matches!(
+            S::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(n)) if n == limit
+        ));
+    }
+
+    // struct $value field
+
+    #[test]
+    fn struct_value_field_box() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[serde(rename = "$value")]
+            v: Option<Box<S>>,
+        }
+
+        let limit = 3;
+
+        let xml = nested_struct_value(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(S::deserialize(&mut de).is_ok());
+
+        let xml = nested_struct_value(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(matches!(
+            S::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(n)) if n == limit
+        ));
+    }
+
+    #[test]
+    fn struct_value_field_vec() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[serde(rename = "$value")]
+            #[serde(default)]
+            v: Vec<S>,
+        }
+
+        let limit = 3;
+
+        let xml = nested_struct_value(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(S::deserialize(&mut de).is_ok());
+
+        let xml = nested_struct_value(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(matches!(
+            S::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(n)) if n == limit
+        ));
+    }
+
+    // enum newtype variant
+
+    #[test]
+    fn newtype_variant_box() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap(Box<E>),
+            #[allow(dead_code)]
+            Leaf,
+        }
+
+        // FIXME: #819 — the deserializer re-enters `deserialize_enum` without
+        // consuming the end event, so even a single `<Wrap></Wrap>` triggers
+        // infinite re-entry. The recursion limit catches this and returns a
+        // clean error instead of a stack overflow.
+        let xml = "<Wrap></Wrap>";
+        let mut de = XmlDeserializer::from_str(xml);
+        de.recursion_limit(3);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(_))
+        ));
+    }
+
+    #[test]
+    fn newtype_variant_vec() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap(Vec<E>),
+            #[allow(dead_code)]
+            Leaf,
+        }
+
+        // FIXME: #819 — same re-entry issue as newtype_variant_box
+        let xml = "<Wrap></Wrap>";
+        let mut de = XmlDeserializer::from_str(xml);
+        de.recursion_limit(3);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(_))
+        ));
+    }
+
+    // enum tuple variant
+
+    #[test]
+    fn tuple_variant_box() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap(Box<E>, String),
+            #[allow(dead_code)]
+            Leaf,
+        }
+
+        // FIXME: #819 — same re-entry issue as newtype variants
+        let xml = "<Wrap></Wrap>";
+        let mut de = XmlDeserializer::from_str(xml);
+        de.recursion_limit(3);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(_))
+        ));
+    }
+
+    #[test]
+    fn tuple_variant_vec() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap(Vec<E>, String),
+            #[allow(dead_code)]
+            Leaf,
+        }
+
+        // FIXME: #819 — same re-entry issue as newtype variants
+        let xml = "<Wrap></Wrap>";
+        let mut de = XmlDeserializer::from_str(xml);
+        de.recursion_limit(3);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(_))
+        ));
+    }
+
+    // enum struct variant
+
+    #[test]
+    fn struct_variant_field_box() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap {
+                f: Box<E>,
+            },
+            #[allow(dead_code)]
+            Leaf,
+        }
+
+        // Depth limit catches deeply nested input before it reaches
+        // pre-existing deserialization issues with enum fields
+        let xml = "<Wrap><f><Wrap><f><Leaf/></f></Wrap></f></Wrap>";
+        let mut de = XmlDeserializer::from_str(xml);
+        de.recursion_limit(1);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(_))
+        ));
+    }
+
+    #[test]
+    fn struct_variant_field_vec() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap {
+                #[serde(default)]
+                f: Vec<E>,
+            },
+            #[allow(dead_code)]
+            Leaf,
+        }
+
+        let xml = "<Wrap><f><Wrap><f><Leaf/></f></Wrap></f></Wrap>";
+        let mut de = XmlDeserializer::from_str(xml);
+        de.recursion_limit(1);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(_))
+        ));
+    }
+
+    #[test]
+    fn struct_variant_value_field_box() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap {
+                #[serde(rename = "$value")]
+                v: Box<E>,
+            },
+            Leaf,
+        }
+
+        let limit = 3;
+
+        // Within the limit: deserializes successfully
+        let xml = nested_enum_value(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(E::deserialize(&mut de).is_ok());
+
+        // Exceeds the limit
+        let xml = nested_enum_value(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(n)) if n == limit
+        ));
+    }
+
+    #[test]
+    fn struct_variant_value_field_vec() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            Wrap {
+                #[serde(rename = "$value")]
+                #[serde(default)]
+                v: Vec<E>,
+            },
+            Leaf,
+        }
+
+        let limit = 3;
+
+        let xml = nested_enum_value(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(E::deserialize(&mut de).is_ok());
+
+        let xml = nested_enum_value(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(matches!(
+            E::deserialize(&mut de),
+            Err(DeError::TooDeeplyNested(n)) if n == limit
+        ));
+    }
+
+    // siblings
+
+    #[test]
+    fn siblings_do_not_increase_depth() {
+        #[derive(Debug, Deserialize)]
+        struct Root {
+            item: Vec<Item>,
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct Item {
+            #[serde(rename = "$text")]
+            name: String,
+        }
+
+        let mut xml = String::from("<Root>");
+        for i in 0..200 {
+            xml.push_str(&format!("<item>{}</item>", i));
+        }
+        xml.push_str("</Root>");
+
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(3);
+        let result = Root::deserialize(&mut de);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().item.len(), 200);
+    }
+}


### PR DESCRIPTION
Deeply nested XML could overflow the native call stack via uncatchable abort. Add a configurable depth limit (default 128, matching serde_json) that returns DeError::TooDeeplyNested instead.

Depth is tracked directly on the Deserializer

- ElementMapAccess increments in new(), decrements in Drop (RAII)
- deserialize_enum uses scope-based increment/decrement around visit_enum (EnumAccess can't use Drop due to variant_seed move)

closes #978