### PR TITLE
Fix attribute iteration past buffer end

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -57,6 +57,8 @@ The MSRV has been raised to 1.86.
 
 ### Bug Fixes
 
+- [#989]: `Attributes::new` and `Attributes::html` now return empty iterators when
+  their starting position is past the end of the input instead of panicking.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
   event) now returns the new `NamespaceError::TooDeeplyNested` when a document
   nests elements deeper than `u16::MAX`, instead of overflowing the internal
@@ -77,6 +79,7 @@ The MSRV has been raised to 1.86.
 [#963]: https://github.com/tafia/quick-xml/pull/963
 [#977]: https://github.com/tafia/quick-xml/issues/977
 [#983]: https://github.com/tafia/quick-xml/issues/983
+[#989]: https://github.com/tafia/quick-xml/issues/989
 
 ## 0.41.0 -- 2026-06-29
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -946,7 +946,8 @@ impl IterState {
     fn recover(&self, slice: &[u8]) -> Option<usize> {
         match self.state {
             State::Done => None,
-            State::Next(offset) => Some(offset),
+            State::Next(offset) if offset <= slice.len() => Some(offset),
+            State::Next(_) => None,
             State::SkipValue(offset) => self.skip_value(slice, offset),
             State::SkipEqValue(offset) => self.skip_eq_value(slice, offset),
         }
@@ -1260,6 +1261,30 @@ impl IterState {
 mod xml {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn start_position_at_end_is_empty() {
+        let mut attributes = Attributes::new("a", 1);
+        assert_eq!(attributes.next(), None);
+
+        let mut attributes = Attributes::html("a", 1);
+        assert_eq!(attributes.next(), None);
+
+        let mut attributes = Attributes::new("a", 1);
+        assert!(!attributes.has_nil(&NamespaceResolver::default()));
+    }
+
+    #[test]
+    fn start_position_past_end_is_empty() {
+        let mut attributes = Attributes::new("a", 2);
+        assert_eq!(attributes.next(), None);
+
+        let mut attributes = Attributes::html("a", 2);
+        assert_eq!(attributes.next(), None);
+
+        let mut attributes = Attributes::new("a", 2);
+        assert!(!attributes.has_nil(&NamespaceResolver::default()));
+    }
 
     mod attribute_value_normalization {
         use super::*;


### PR DESCRIPTION
`Attributes::new` and `Attributes::html` document that a start position beyond the input returns an empty iterator, but the unchecked recovery offset currently panics while slicing.

This change bounds the initial recovery position and adds regression coverage for positions both at and beyond the input end through direct `next()` calls and indirect iteration via `has_nil()`. It also records the fix in the changelog.

Verification:
- `cargo test --all-features start_position_at_or_past_end_is_empty`
- `cargo fmt --all --check`
- `cargo test --all-features`
- `git diff --check`

Closes #989