### PR TITLE
Fix empty text after trimming whitespace

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -57,6 +57,8 @@ The MSRV has been raised to 1.86.
 
 ### Bug Fixes
 
+- [#984]: `Reader` no longer emits an empty `Text` event when `trim_text_end`
+  removes whitespace-only text immediately before markup.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
   event) now returns the new `NamespaceError::TooDeeplyNested` when a document
   nests elements deeper than `u16::MAX`, instead of overflowing the internal
@@ -77,6 +79,7 @@ The MSRV has been raised to 1.86.
 [#963]: https://github.com/tafia/quick-xml/pull/963
 [#977]: https://github.com/tafia/quick-xml/issues/977
 [#983]: https://github.com/tafia/quick-xml/issues/983
+[#984]: https://github.com/tafia/quick-xml/issues/984
 
 ## 0.41.0 -- 2026-06-29
 

--- a/src/reader/buffered_reader.rs
+++ b/src/reader/buffered_reader.rs
@@ -54,6 +54,7 @@ macro_rules! impl_buffered_source {
             &mut self,
             buf: &'b mut Vec<u8>,
             position: &mut u64,
+            trim_text_end: bool,
         ) -> ReadTextResult<'b, &'b mut Vec<u8>> {
             let mut read = 0;
             let start = buf.len();
@@ -83,6 +84,9 @@ macro_rules! impl_buffered_source {
                         read += i as u64;
 
                         *position += read;
+                        if trim_text_end && buf[start..].iter().all(|&b| is_whitespace(b)) {
+                            return ReadTextResult::Markup(buf);
+                        }
                         return match std::str::from_utf8(&buf[start..]) {
                             Ok(s) => ReadTextResult::UpToMarkup(s),
                             Err(e) => ReadTextResult::Err(e.into()),

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -325,7 +325,11 @@ macro_rules! read_event_impl {
                         $reader.skip_whitespace(&mut $self.state.offset) $(.$await)? ?;
                     }
 
-                    match $reader.read_text($buf, &mut $self.state.offset) $(.$await)? {
+                    match $reader.read_text(
+                        $buf,
+                        &mut $self.state.offset,
+                        $self.state.config.trim_text_end,
+                    ) $(.$await)? {
                         ReadTextResult::Markup(buf) => {
                             $self.state.state = ParseState::InsideMarkup;
                             // Pass `buf` to the next next iteration of parsing loop
@@ -340,10 +344,6 @@ macro_rules! read_event_impl {
                         }
                         ReadTextResult::UpToMarkup(bytes) => {
                             $self.state.state = ParseState::InsideMarkup;
-                            // FIXME: Can produce an empty event if:
-                            // - event contains only spaces
-                            // - trim_text_start = false
-                            // - trim_text_end = true
                             Ok(Event::Text($self.state.emit_text(bytes)?))
                         }
                         ReadTextResult::UpToRef(bytes) => {
@@ -493,8 +493,8 @@ macro_rules! read_to_end {
         // it is important that this position indicates beginning of the End event.
         // If between last event and the End event would be only spaces, then we
         // take position before the spaces, but spaces would be skipped without
-        // generating event if `trim_text_start` is set to `true`. To prevent that
-        // we temporary disable start text trimming.
+        // generating an event if text trimming is enabled. To prevent that we
+        // temporarily disable text trimming.
         //
         // We also cannot take position after getting End event, because if
         // `trim_markup_names_in_closing_tags` is set to `true` (which is the default),
@@ -502,8 +502,9 @@ macro_rules! read_to_end {
         // the source and cannot correct the position after the End event.
         // So, we in any case should tweak parser configuration.
         let config = $self.config_mut();
-        let trim = config.trim_text_start;
+        let trim = (config.trim_text_start, config.trim_text_end);
         config.trim_text_start = false;
+        config.trim_text_end = false;
 
         let start = $self.buffer_position();
         let mut depth = 0;
@@ -512,20 +513,26 @@ macro_rules! read_to_end {
             let end = $self.buffer_position();
             match $self.$read_event($buf) $(.$await)? {
                 Err(e) => {
-                    $self.config_mut().trim_text_start = trim;
+                    let config = $self.config_mut();
+                    config.trim_text_start = trim.0;
+                    config.trim_text_end = trim.1;
                     return Err(e);
                 }
 
                 Ok(Event::Start(e)) if e.name() == $end => depth += 1,
                 Ok(Event::End(e)) if e.name() == $end => {
                     if depth == 0 {
-                        $self.config_mut().trim_text_start = trim;
+                        let config = $self.config_mut();
+                        config.trim_text_start = trim.0;
+                        config.trim_text_end = trim.1;
                         break start..end;
                     }
                     depth -= 1;
                 }
                 Ok(Event::Eof) => {
-                    $self.config_mut().trim_text_start = trim;
+                    let config = $self.config_mut();
+                    config.trim_text_start = trim.0;
+                    config.trim_text_end = trim.1;
                     return Err(Error::missed_end($end));
                 }
                 _ => (),
@@ -1069,9 +1076,15 @@ trait XmlSource<'r, B> {
     /// - `buf`: Buffer that could be filled from an input (`Self`) and
     ///   from which [events] could borrow their data
     /// - `position`: Will be increased by amount of bytes consumed
+    /// - `trim_text_end`: Skip a whitespace-only text block before markup
     ///
     /// [events]: crate::events::Event
-    fn read_text(&mut self, buf: B, position: &mut u64) -> ReadTextResult<'r, B>;
+    fn read_text(
+        &mut self,
+        buf: B,
+        position: &mut u64,
+        trim_text_end: bool,
+    ) -> ReadTextResult<'r, B>;
 
     /// Read input until end of general reference (the `;`) is found, start of
     /// another general reference (the `&`) is found or end of input is reached.
@@ -1646,7 +1659,7 @@ mod test {
                     let mut input = b"".as_ref();
                     //                ^= 1
 
-                    match $source(&mut input).read_text(buf, &mut position) $(.$await)? {
+                    match $source(&mut input).read_text(buf, &mut position, false) $(.$await)? {
                         ReadTextResult::UpToEof(bytes) => assert_eq!(bytes, ""),
                         x => panic!("Expected `UpToEof(_)`, but got `{:?}`", x),
                     }
@@ -1660,7 +1673,7 @@ mod test {
                     let mut input = b"<".as_ref();
                     //                 ^= 1
 
-                    match $source(&mut input).read_text(buf, &mut position) $(.$await)? {
+                    match $source(&mut input).read_text(buf, &mut position, false) $(.$await)? {
                         ReadTextResult::Markup(b) => assert_eq!(b, $buf),
                         x => panic!("Expected `Markup(_)`, but got `{:?}`", x),
                     }
@@ -1674,7 +1687,7 @@ mod test {
                     let mut input = b"&".as_ref();
                     //                ^= 1
 
-                    match $source(&mut input).read_text(buf, &mut position) $(.$await)? {
+                    match $source(&mut input).read_text(buf, &mut position, false) $(.$await)? {
                         ReadTextResult::Ref(b) => assert_eq!(b, $buf),
                         x => panic!("Expected `Ref(_)`, but got `{:?}`", x),
                     }
@@ -1688,7 +1701,7 @@ mod test {
                     let mut input = b"a<".as_ref();
                     //                  ^= 2
 
-                    match $source(&mut input).read_text(buf, &mut position) $(.$await)? {
+                    match $source(&mut input).read_text(buf, &mut position, false) $(.$await)? {
                         ReadTextResult::UpToMarkup(bytes) => assert_eq!(bytes, "a"),
                         x => panic!("Expected `UpToMarkup(_)`, but got `{:?}`", x),
                     }
@@ -1702,7 +1715,7 @@ mod test {
                     let mut input = b"a&".as_ref();
                     //                 ^= 2
 
-                    match $source(&mut input).read_text(buf, &mut position) $(.$await)? {
+                    match $source(&mut input).read_text(buf, &mut position, false) $(.$await)? {
                         ReadTextResult::UpToRef(bytes) => assert_eq!(bytes, "a"),
                         x => panic!("Expected `UpToRef(_)`, but got `{:?}`", x),
                     }
@@ -1716,7 +1729,7 @@ mod test {
                     let mut input = b"a".as_ref();
                     //                 ^= 2
 
-                    match $source(&mut input).read_text(buf, &mut position) $(.$await)? {
+                    match $source(&mut input).read_text(buf, &mut position, false) $(.$await)? {
                         ReadTextResult::UpToEof(bytes) => assert_eq!(bytes, "a"),
                         x => panic!("Expected `UpToEof(_)`, but got `{:?}`", x),
                     }

--- a/src/reader/slice_reader.rs
+++ b/src/reader/slice_reader.rs
@@ -268,7 +268,12 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
     }
 
     #[inline]
-    fn read_text(&mut self, _buf: (), position: &mut u64) -> ReadTextResult<'a, ()> {
+    fn read_text(
+        &mut self,
+        _buf: (),
+        position: &mut u64,
+        trim_text_end: bool,
+    ) -> ReadTextResult<'a, ()> {
         // Search for start of markup or an entity or character reference
         match memchr::memchr2(b'<', b'&', self) {
             Some(0) if self[0] == b'<' => ReadTextResult::Markup(()),
@@ -280,6 +285,9 @@ impl<'a> XmlSource<'a, ()> for &'a [u8] {
                 let (bytes, rest) = self.split_at(i);
                 *self = rest;
                 *position += i as u64;
+                if trim_text_end && bytes.iter().all(|&b| is_whitespace(b)) {
+                    return ReadTextResult::Markup(());
+                }
                 match std::str::from_utf8(bytes) {
                     Ok(s) => ReadTextResult::UpToMarkup(s),
                     Err(e) => ReadTextResult::Err(e.into()),

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -820,6 +820,29 @@ mod trim_text_end {
     use pretty_assertions::assert_eq;
 
     #[test]
+    fn skips_whitespace_only_text_before_markup() {
+        let mut reader = Reader::from_str(" <a/>");
+        reader.config_mut().trim_text_end = true;
+
+        assert_eq!(
+            reader.read_event().unwrap(),
+            Event::Empty(BytesStart::new("a"))
+        );
+        assert_eq!(reader.read_event().unwrap(), Event::Eof);
+
+        let mut reader = Reader::from_reader(" <a/>".as_bytes());
+        reader.config_mut().trim_text_end = true;
+        let mut buffer = Vec::new();
+
+        assert_eq!(
+            reader.read_event_into(&mut buffer).unwrap(),
+            Event::Empty(BytesStart::new("a"))
+        );
+        buffer.clear();
+        assert_eq!(reader.read_event_into(&mut buffer).unwrap(), Event::Eof);
+    }
+
+    #[test]
     fn false_() {
         let mut reader = Reader::from_str(XML);
         reader.config_mut().trim_text_end = false;


### PR DESCRIPTION
`Config::trim_text_end` promises not to emit a text event when trimming leaves it empty, but whitespace-only text immediately before markup still produced `Text("")`.

This change lets both slice and buffered readers skip those whitespace-only spans before constructing an event. `read_to_end` temporarily disables both start and end trimming so its byte-range accounting remains unchanged.

Regression coverage exercises both `Reader::from_str` and buffered `Reader::from_reader`.

Verification:
- `cargo fmt --all -- --check`
- `cargo test skips_whitespace_only_text_before_markup --all-features`
- `cargo test --all-features`
- `git diff --check`

Closes #984