### PR TITLE
Fix out-of-bounds attribute iterator position

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,8 @@ The MSRV has been raised to 1.86.
 
 ### Bug Fixes
 
+- [#989]: Attribute iterators whose start position is beyond the input now
+  terminate instead of panicking.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
   event) now returns the new `NamespaceError::TooDeeplyNested` when a document
   nests elements deeper than `u16::MAX`, instead of overflowing the internal
@@ -85,6 +87,7 @@ The MSRV has been raised to 1.86.
 [#977]: https://github.com/tafia/quick-xml/issues/977
 [#980]: https://github.com/tafia/quick-xml/issues/980
 [#983]: https://github.com/tafia/quick-xml/issues/983
+[#989]: https://github.com/tafia/quick-xml/issues/989
 
 ## 0.41.0 -- 2026-06-29
 

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -946,7 +946,8 @@ impl IterState {
     fn recover(&self, slice: &[u8]) -> Option<usize> {
         match self.state {
             State::Done => None,
-            State::Next(offset) => Some(offset),
+            State::Next(offset) if offset < slice.len() => Some(offset),
+            State::Next(_) => None,
             State::SkipValue(offset) => self.skip_value(slice, offset),
             State::SkipEqValue(offset) => self.skip_eq_value(slice, offset),
         }
@@ -1260,6 +1261,20 @@ impl IterState {
 mod xml {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn next_with_out_of_bounds_position() {
+        let mut iter = Attributes::new("a", 2);
+
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn has_nil_with_out_of_bounds_position() {
+        let mut iter = Attributes::new("a", 2);
+
+        assert!(!iter.has_nil(&NamespaceResolver::default()));
+    }
 
     mod attribute_value_normalization {
         use super::*;


### PR DESCRIPTION
## Summary

  - stop attribute iteration when its start position is outside the input
  - cover direct iteration and `has_nil()` with regression tests

  ## Testing

  - `cargo test out_of_bounds_position`
  - `cargo test --all-features`
  - `cargo fmt -- --check`
  - `git diff --check`

  Closes #989