### PR TITLE
Fix "enum newtype variant" deserialization (#819)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -62,8 +62,9 @@ The MSRV has been raised to 1.86.
 ### Bug Fixes
 
 - [#819]: Fixed infinite recursion (stack overflow) when deserializing enum
-  newtype variants whose inner type is also an enum (e.g. `Apply(Vec<MathNode>)`).
-  The variant's Start event is now consumed before deserializing the inner type,
+  newtype and tuple variants whose inner type is also an enum
+  (e.g. `Apply(Vec<MathNode>)` or `Parent(Box<E>, String)`).
+  Each variant's Start event is now consumed before deserializing the inner type,
   and sequence boundary handling is corrected so that sequences no longer consume
   past the enclosing variant's end tag.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`

--- a/Changelog.md
+++ b/Changelog.md
@@ -61,21 +61,28 @@ The MSRV has been raised to 1.86.
 
 ### Bug Fixes
 
-- [#989]: `Attributes::new` and `Attributes::html` now return empty iterators when
-  their starting position is past the end of the input instead of panicking.
+- [#819]: Fixed infinite recursion (stack overflow) when deserializing enum
+  newtype variants whose inner type is also an enum (e.g. `Apply(Vec<MathNode>)`).
+  The variant's Start event is now consumed before deserializing the inner type,
+  which also fixes deserialization of newtype variants containing sequences of
+  child elements (e.g. `Variant(Vec<i32>)` with `<Variant><x>1</x><x>2</x></Variant>`),
+  which previously failed with `UnexpectedStart`, and corrects sequence boundary
+  handling so that sequences no longer consume past the enclosing variant's end tag.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
   event) now returns the new `NamespaceError::TooDeeplyNested` when a document
   nests elements deeper than `u16::MAX`, instead of overflowing the internal
   `u16` depth counter. Previously the unguarded `nesting_level += 1` panicked
   under `overflow-checks` builds and silently wrapped in release, corrupting
   namespace-scope bookkeeping on deeply nested untrusted input.
-- [#980]: `NamespaceResolver` now caps the total number of in-scope namespace
-  bindings (default 128, configurable via `set_max_namespace_bindings`),
-  replacing the previous per-element `max_declarations_per_element` limit.
 - [#978]: The serde `Deserializer` now enforces a configurable recursion-depth
   limit (default 128, matching `serde_json`). Deeply nested XML returns
   `DeError::TooDeeplyNested` instead of overflowing the native call stack.
   Use `Deserializer::recursion_limit()` to adjust.
+- [#980]: `NamespaceResolver` now caps the total number of in-scope namespace
+  bindings (default 128, configurable via `set_max_namespace_bindings`),
+  replacing the previous per-element `max_declarations_per_element` limit.
+- [#989]: `Attributes::new` and `Attributes::html` now return empty iterators when
+  their starting position is past the end of the input instead of panicking.
 
 ### Misc Changes
 
@@ -88,11 +95,12 @@ The MSRV has been raised to 1.86.
   `decode_and_unescape_value_with()`. Use `normalized_value()` and
   `normalized_value_with()` instead.
 
+[#819]: https://github.com/tafia/quick-xml/issues/819
+[#859]: https://github.com/tafia/quick-xml/issues/859
 [#963]: https://github.com/tafia/quick-xml/pull/963
 [#977]: https://github.com/tafia/quick-xml/issues/977
-[#980]: https://github.com/tafia/quick-xml/issues/980
-[#859]: https://github.com/tafia/quick-xml/issues/859
 [#978]: https://github.com/tafia/quick-xml/issues/978
+[#980]: https://github.com/tafia/quick-xml/issues/980
 [#983]: https://github.com/tafia/quick-xml/issues/983
 [#989]: https://github.com/tafia/quick-xml/issues/989
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -64,10 +64,8 @@ The MSRV has been raised to 1.86.
 - [#819]: Fixed infinite recursion (stack overflow) when deserializing enum
   newtype variants whose inner type is also an enum (e.g. `Apply(Vec<MathNode>)`).
   The variant's Start event is now consumed before deserializing the inner type,
-  which also fixes deserialization of newtype variants containing sequences of
-  child elements (e.g. `Variant(Vec<i32>)` with `<Variant><x>1</x><x>2</x></Variant>`),
-  which previously failed with `UnexpectedStart`, and corrects sequence boundary
-  handling so that sequences no longer consume past the enclosing variant's end tag.
+  and sequence boundary handling is corrected so that sequences no longer consume
+  past the enclosing variant's end tag.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
   event) now returns the new `NamespaceError::TooDeeplyNested` when a document
   nests elements deeper than `u16::MAX`, instead of overflowing the internal

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2908,6 +2908,14 @@ where
         self.read_string_impl(true)
     }
 
+    /// Like [`read_string`](Self::read_string) but rejects `Start` events for
+    /// primitive types. Used by [`InTreeDeserializer`](var::InTreeDeserializer)
+    /// to prevent `<tag>text</tag>` from being accepted as a primitive value.
+    #[inline]
+    pub(crate) fn read_string_in_tree(&mut self) -> Result<Cow<'de, str>, DeError> {
+        self.read_string_impl(false)
+    }
+
     /// Consumes consequent [`Text`] and [`CData`] (both a referred below as a _text_)
     /// events, merge them into one string. If there are no such events, returns
     /// an empty string.

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -200,13 +200,12 @@ where
         visitor.visit_newtype_struct(self)
     }
 
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let mut this = self;
-        let result = visitor.visit_seq(&mut this)?;
-        this.de.read_to_end(this.start.name())?;
+        let result = visitor.visit_seq(&mut self)?;
+        self.de.read_to_end(self.start.name())?;
         Ok(result)
     }
 

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -311,7 +311,110 @@ where
         match self.de.peek()? {
             DeEvent::End(_) => Ok(None),
             DeEvent::Eof => Err(Error::missed_end(self.start.name()).into()),
-            _ => seed.deserialize(&mut *self.de).map(Some),
+            _ => seed
+                .deserialize(InTreeDeserializer { de: &mut *self.de })
+                .map(Some),
         }
+    }
+}
+
+/// A wrapper around [`Deserializer`] that rejects `Start` events when
+/// deserializing primitive types. Used by [`VariantContentDeserializer`]'s
+/// [`SeqAccess`](de::SeqAccess) impl so that `Variant(Vec<i32>)` cannot be
+/// deserialized from child elements like `<Variant><x>1</x></Variant>` —
+/// only from xs:list text content like `<Variant>1 2 3</Variant>`.
+///
+/// Non-primitive methods (enum, struct, seq, etc.) delegate directly to the
+/// underlying [`Deserializer`], so `Vec<MathNode>` from child elements still
+/// works: `<Apply><Ci>x</Ci><Cn>5</Cn></Apply>`.
+pub(crate) struct InTreeDeserializer<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    de: &'d mut Deserializer<'de, R, E>,
+}
+
+impl<'de, 'd, R, E> InTreeDeserializer<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    #[inline]
+    fn read_string(&mut self) -> Result<Cow<'de, str>, DeError> {
+        self.de.read_string_in_tree()
+    }
+}
+
+impl<'de, 'd, R, E> de::Deserializer<'de> for InTreeDeserializer<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    type Error = DeError;
+
+    deserialize_primitives!(mut);
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.deserialize_unit(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.deserialize_option(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.deserialize_newtype_struct(name, visitor)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.deserialize_seq(visitor)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.deserialize_struct(name, fields, visitor)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.deserialize_enum(name, variants, visitor)
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeError>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.deserialize_any(visitor)
     }
 }

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -103,7 +103,7 @@ where
         V: Visitor<'de>,
     {
         match self.de.peek()? {
-            DeEvent::Start(_) => self.de.deserialize_tuple(len, visitor),
+            DeEvent::Start(_) => visitor.visit_seq(TupleVariantSeqAccess { de: self.de }),
             _ => match self.de.next()? {
                 DeEvent::Text(e) => {
                     SimpleTypeDeserializer::from_text_content(e).deserialize_tuple(len, visitor)
@@ -129,6 +129,53 @@ where
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),
+        }
+    }
+}
+
+/// [`SeqAccess`](de::SeqAccess) for tuple variants that consumes each repeated
+/// element's Start event before deserializing the field, preventing re-entry for
+/// recursive enum types.
+///
+/// Tuple variants use repeated sibling elements, one per field:
+/// `Tuple(f64, String)` serializes as `<Tuple>42</Tuple><Tuple>answer</Tuple>`.
+/// Each call to [`next_element_seed`] consumes the next Start event and creates
+/// a [`VariantContentDeserializer`] to deserialize the field value within that
+/// element (including its End tag).
+///
+/// [`next_element_seed`]: de::SeqAccess::next_element_seed
+struct TupleVariantSeqAccess<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    de: &'d mut Deserializer<'de, R, E>,
+}
+
+impl<'de, 'd, R, E> de::SeqAccess<'de> for TupleVariantSeqAccess<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    type Error = DeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        self.de.skip_whitespaces()?;
+        match self.de.peek()? {
+            DeEvent::Start(_) => match self.de.next()? {
+                DeEvent::Start(e) => seed
+                    .deserialize(VariantContentDeserializer {
+                        start: e,
+                        de: self.de,
+                    })
+                    .map(Some),
+                _ => unreachable!(),
+            },
+            DeEvent::End(_) | DeEvent::Eof => Ok(None),
+            _ => seed.deserialize(&mut *self.de).map(Some),
         }
     }
 }

--- a/src/de/var.rs
+++ b/src/de/var.rs
@@ -4,10 +4,12 @@ use crate::{
     de::resolver::EntityResolver,
     de::simple_type::SimpleTypeDeserializer,
     de::{DeEvent, Deserializer, XmlRead, TEXT_KEY},
-    errors::serialize::DeError,
+    errors::{serialize::DeError, Error},
+    events::BytesStart,
 };
 use serde::de::value::BorrowedStrDeserializer;
 use serde::de::{self, DeserializeSeed, Deserializer as _, Visitor};
+use std::borrow::Cow;
 
 /// An enum access
 pub struct EnumAccess<'de, 'd, R, E>
@@ -40,24 +42,17 @@ where
     where
         V: DeserializeSeed<'de>,
     {
-        let (name, is_text) = match self.de.peek()? {
-            DeEvent::Start(e) => (seed.deserialize(QNameDeserializer::from_elem(e)?)?, false),
-            DeEvent::Text(_) => (
-                seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?,
-                true,
-            ),
+        let name = match self.de.peek()? {
+            DeEvent::Start(e) => seed.deserialize(QNameDeserializer::from_elem(e)?)?,
+            DeEvent::Text(_) => {
+                seed.deserialize(BorrowedStrDeserializer::<DeError>::new(TEXT_KEY))?
+            }
             // SAFETY: The reader is guaranteed that we don't have unmatched tags
             // If we here, then our deserializer has a bug
             DeEvent::End(e) => unreachable!("{:?}", e),
             DeEvent::Eof => return Err(DeError::UnexpectedEof),
         };
-        Ok((
-            name,
-            VariantAccess {
-                de: self.de,
-                is_text,
-            },
-        ))
+        Ok((name, VariantAccess { de: self.de }))
     }
 }
 
@@ -67,9 +62,6 @@ where
     E: EntityResolver,
 {
     de: &'d mut Deserializer<'de, R, E>,
-    /// `true` if variant should be deserialized from a textual content
-    /// and `false` if from tag
-    is_text: bool,
 }
 
 impl<'de, 'd, R, E> de::VariantAccess<'de> for VariantAccess<'de, 'd, R, E>
@@ -95,14 +87,14 @@ where
     where
         T: DeserializeSeed<'de>,
     {
-        if self.is_text {
-            match self.de.next()? {
-                DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
-                // SAFETY: the other events are filtered in `variant_seed()`
-                _ => unreachable!("Only `Text` events are possible here"),
-            }
-        } else {
-            seed.deserialize(self.de)
+        match self.de.next()? {
+            DeEvent::Start(e) => seed.deserialize(VariantContentDeserializer {
+                start: e,
+                de: self.de,
+            }),
+            DeEvent::Text(e) => seed.deserialize(SimpleTypeDeserializer::from_text_content(e)),
+            // SAFETY: the other events are filtered in `variant_seed()`
+            _ => unreachable!("Only `Start` or `Text` events are possible here"),
         }
     }
 
@@ -110,16 +102,15 @@ where
     where
         V: Visitor<'de>,
     {
-        if self.is_text {
-            match self.de.next()? {
+        match self.de.peek()? {
+            DeEvent::Start(_) => self.de.deserialize_tuple(len, visitor),
+            _ => match self.de.next()? {
                 DeEvent::Text(e) => {
                     SimpleTypeDeserializer::from_text_content(e).deserialize_tuple(len, visitor)
                 }
                 // SAFETY: the other events are filtered in `variant_seed()`
-                _ => unreachable!("Only `Text` events are possible here"),
-            }
-        } else {
-            self.de.deserialize_tuple(len, visitor)
+                _ => unreachable!("Only `Start` or `Text` events are possible here"),
+            },
         }
     }
 
@@ -138,6 +129,143 @@ where
             }
             // SAFETY: the other events are filtered in `variant_seed()`
             _ => unreachable!("Only `Start` or `Text` events are possible here"),
+        }
+    }
+}
+
+/// Deserializer for the content of a variant element whose Start event has
+/// already been consumed.
+///
+/// This differs from [`ElementDeserializer`](super::map::ElementDeserializer)
+/// in how it handles `deserialize_enum` and `deserialize_seq`: instead of
+/// re-using `self.start` (which would cause infinite re-entry for recursive
+/// enum types), it delegates to the stream-based [`Deserializer`] and then
+/// consumes the variant element's End tag.
+///
+/// For `deserialize_struct` and primitives, it behaves identically to
+/// `ElementDeserializer`: the consumed `start` is used as the struct root,
+/// and text content is read via `read_text`.
+struct VariantContentDeserializer<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    start: BytesStart<'de>,
+    de: &'d mut Deserializer<'de, R, E>,
+}
+
+impl<'de, 'd, R, E> VariantContentDeserializer<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    #[inline]
+    fn read_string(&mut self) -> Result<Cow<'de, str>, DeError> {
+        self.de.read_text(self.start.name())
+    }
+}
+
+impl<'de, 'd, R, E> de::Deserializer<'de> for VariantContentDeserializer<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    type Error = DeError;
+
+    deserialize_primitives!(mut);
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.de.read_to_end(self.start.name())?;
+        visitor.visit_unit()
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut this = self;
+        let result = visitor.visit_seq(&mut this)?;
+        this.de.read_to_end(this.start.name())?;
+        Ok(result)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(ElementMapAccess::new(self.de, self.start, fields)?)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let VariantContentDeserializer { start, de } = self;
+        let result = de.deserialize_enum(name, variants, visitor)?;
+        de.read_to_end(start.name())?;
+        Ok(result)
+    }
+
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+}
+
+/// Unlike the top-level [`SeqAccess`](de::SeqAccess) impl on [`Deserializer`]
+/// (which only stops on [`DeEvent::Eof`]), this stops on [`DeEvent::End`]
+/// because the sequence is bounded by the enclosing variant element's end tag.
+/// [`DeEvent::Eof`] is an error (truncated XML).
+impl<'de, 'd, R, E> de::SeqAccess<'de> for &mut VariantContentDeserializer<'de, 'd, R, E>
+where
+    R: XmlRead<'de>,
+    E: EntityResolver,
+{
+    type Error = DeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        self.de.skip_whitespaces()?;
+        match self.de.peek()? {
+            DeEvent::End(_) => Ok(None),
+            DeEvent::Eof => Err(Error::missed_end(self.start.name()).into()),
+            _ => seed.deserialize(&mut *self.de).map(Some),
         }
     }
 }

--- a/tests/serde-de-enum.rs
+++ b/tests/serde-de-enum.rs
@@ -81,6 +81,88 @@ mod externally_tagged {
         assert_eq!(data, Node::Newtype(true));
     }
 
+    mod newtype_ {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn struct_elements() {
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct Inner {
+                x: i32,
+            }
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum E {
+                Variant(Inner),
+            }
+
+            let result: E = from_str("<Variant><x>42</x></Variant>").unwrap();
+            assert_eq!(result, E::Variant(Inner { x: 42 }));
+        }
+
+        #[test]
+        fn struct_attributes() {
+            #[derive(Debug, Deserialize, PartialEq)]
+            struct Inner {
+                #[serde(rename = "@x")]
+                x: i32,
+            }
+
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum E {
+                Variant(Inner),
+            }
+
+            let result: E = from_str("<Variant x='42'/>").unwrap();
+            assert_eq!(result, E::Variant(Inner { x: 42 }));
+        }
+
+        #[test]
+        fn seq() {
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum E {
+                Parent(Vec<E>),
+                Leaf,
+            }
+
+            let result: E = from_str("<Parent><Leaf/><Leaf/><Leaf/></Parent>").unwrap();
+            assert_eq!(result, E::Parent(vec![E::Leaf, E::Leaf, E::Leaf]));
+        }
+
+        #[test]
+        fn seq_boundary() {
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum E {
+                Parent(Vec<E>),
+                Leaf,
+            }
+
+            let result: Vec<E> =
+                from_str("<Parent><Leaf/><Leaf/></Parent><Parent><Leaf/></Parent>").unwrap();
+            assert_eq!(
+                result,
+                vec![E::Parent(vec![E::Leaf, E::Leaf]), E::Parent(vec![E::Leaf]),]
+            );
+        }
+
+        #[test]
+        fn seq_eof_is_error() {
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum E {
+                Parent(Vec<E>),
+                #[allow(dead_code)]
+                Leaf,
+            }
+
+            let err = from_str::<E>("<Parent><Leaf/>").unwrap_err();
+            assert!(
+                matches!(err, DeError::InvalidXml(_)),
+                "expected InvalidXml error for truncated input, got: {err:?}"
+            );
+        }
+    }
+
     #[test]
     fn tuple_struct() {
         let data: Node = from_str("<Tuple>42</Tuple><Tuple>answer</Tuple>").unwrap();

--- a/tests/serde-de-enum.rs
+++ b/tests/serde-de-enum.rs
@@ -161,6 +161,23 @@ mod externally_tagged {
                 "expected InvalidXml error for truncated input, got: {err:?}"
             );
         }
+
+        /// Primitives inside a variant sequence cannot be deserialized from
+        /// child elements — only from text content (xs:list format).
+        #[test]
+        fn primitives_reject_child_elements() {
+            #[derive(Debug, Deserialize, PartialEq)]
+            enum E {
+                #[allow(dead_code)]
+                Variant(Vec<i32>),
+            }
+
+            let err = from_str::<E>("<Variant><x>1</x><x>2</x></Variant>").unwrap_err();
+            assert!(
+                matches!(err, DeError::UnexpectedStart(ref tag) if tag == "x"),
+                "expected UnexpectedStart for child elements with primitive types, got: {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -1427,6 +1427,93 @@ mod nested_struct {
     }
 }
 
+mod recursive_struct {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn box_field() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            field: Option<Box<S>>,
+        }
+
+        let data: S = from_str("<S><field><field></field></field></S>").unwrap();
+        assert_eq!(
+            data,
+            S {
+                field: Some(Box::new(S {
+                    field: Some(Box::new(S { field: None })),
+                })),
+            }
+        );
+    }
+
+    #[test]
+    fn vec_field() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(default)]
+            field: Vec<S>,
+        }
+
+        let data: S = from_str("<S><field/><field><field/></field></S>").unwrap();
+        assert_eq!(
+            data,
+            S {
+                field: vec![
+                    S { field: vec![] },
+                    S {
+                        field: vec![S { field: vec![] }],
+                    },
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn value_box_field() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(rename = "$value")]
+            value: Option<Box<S>>,
+        }
+
+        let data: S = from_str("<a><b><c/></b></a>").unwrap();
+        assert_eq!(
+            data,
+            S {
+                value: Some(Box::new(S {
+                    value: Some(Box::new(S { value: None })),
+                })),
+            }
+        );
+    }
+
+    #[test]
+    fn value_vec_field() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(rename = "$value")]
+            #[serde(default)]
+            value: Vec<S>,
+        }
+
+        let data: S = from_str("<root><a/><b><c/></b></root>").unwrap();
+        assert_eq!(
+            data,
+            S {
+                value: vec![
+                    S { value: vec![] },
+                    S {
+                        value: vec![S { value: vec![] }],
+                    },
+                ],
+            }
+        );
+    }
+}
+
 mod flatten_struct {
     use super::*;
     use pretty_assertions::assert_eq;

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -1079,43 +1079,70 @@ mod issue978 {
 
     // enum tuple variant
 
+    /// Generate nested tuple-variant XML for `Parent(Box<E>, String)`.
+    ///
+    /// - depth=1: `<Leaf/>`
+    /// - depth=2: `<Parent><Leaf/></Parent><Parent>s</Parent>`
+    /// - depth=3: `<Parent><Parent><Leaf/></Parent><Parent>s</Parent></Parent><Parent>s</Parent>`
+    fn nested_tuple_enum(depth: usize) -> String {
+        if depth <= 1 {
+            return "<Leaf/>".to_string();
+        }
+        let inner = nested_tuple_enum(depth - 1);
+        format!("<Parent>{inner}</Parent><Parent>s</Parent>")
+    }
+
     #[test]
     fn tuple_variant_box() {
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, Deserialize, PartialEq)]
         enum E {
             Parent(Box<E>, String),
-            #[allow(dead_code)]
             Leaf,
         }
 
-        // Tuple variants use repeated elements (<V>f1</V><V>f2</V>),
-        // so the Start event cannot be consumed the way newtype
-        // variants do. Recursive tuple variants still hit re-entry.
-        let xml = "<Parent></Parent>";
+        let limit = 3;
+
+        let xml = "<Parent><Leaf/></Parent><Parent>hello</Parent>";
         let mut de = XmlDeserializer::from_str(xml);
-        de.recursion_limit(3);
+        de.recursion_limit(limit);
+        assert_eq!(
+            E::deserialize(&mut de).unwrap(),
+            E::Parent(Box::new(E::Leaf), "hello".into())
+        );
+
+        let xml = nested_tuple_enum(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
         assert!(matches!(
             E::deserialize(&mut de),
-            Err(DeError::TooDeeplyNested(_))
+            Err(DeError::TooDeeplyNested(n)) if n == limit
         ));
     }
 
     #[test]
     fn tuple_variant_vec() {
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, Deserialize, PartialEq)]
         enum E {
             Parent(Vec<E>, String),
-            #[allow(dead_code)]
             Leaf,
         }
 
-        // Same re-entry issue as tuple_variant_box.
-        let xml = "<Parent></Parent>";
+        let limit = 3;
+
+        let xml = "<Parent><Leaf/></Parent><Parent>hello</Parent>";
         let mut de = XmlDeserializer::from_str(xml);
-        de.recursion_limit(3);
+        de.recursion_limit(limit);
+        assert_eq!(
+            E::deserialize(&mut de).unwrap(),
+            E::Parent(vec![E::Leaf], "hello".into())
+        );
+
+        let xml = nested_tuple_enum(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
         assert!(matches!(
             E::deserialize(&mut de),
-            Err(DeError::TooDeeplyNested(_))
+            Err(DeError::TooDeeplyNested(n)) if n == limit
         ));
     }
 

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -910,15 +910,15 @@ mod issue978 {
         xml
     }
 
-    /// Generate XML like `<Wrap><Wrap>...<Leaf/>...</Wrap></Wrap>`.
+    /// Generate XML like `<Parent><Parent>...<Leaf/>...</Parent></Parent>`.
     fn nested_enum_value(depth: usize) -> String {
         let mut xml = String::new();
         for _ in 0..depth.saturating_sub(1) {
-            xml.push_str("<Wrap>");
+            xml.push_str("<Parent>");
         }
         xml.push_str("<Leaf/>");
         for _ in 0..depth.saturating_sub(1) {
-            xml.push_str("</Wrap>");
+            xml.push_str("</Parent>");
         }
         xml
     }
@@ -1031,7 +1031,7 @@ mod issue978 {
     fn newtype_variant_box() {
         #[derive(Debug, Deserialize, PartialEq)]
         enum E {
-            Wrap(Box<E>),
+            Parent(Box<E>),
             Leaf,
         }
 
@@ -1057,7 +1057,7 @@ mod issue978 {
     fn newtype_variant_vec() {
         #[derive(Debug, Deserialize, PartialEq)]
         enum E {
-            Wrap(Vec<E>),
+            Parent(Vec<E>),
             Leaf,
         }
 
@@ -1125,7 +1125,7 @@ mod issue978 {
     fn struct_variant_field_box() {
         #[derive(Debug, Deserialize)]
         enum E {
-            Wrap {
+            Parent {
                 f: Box<E>,
             },
             #[allow(dead_code)]
@@ -1134,7 +1134,7 @@ mod issue978 {
 
         // Depth limit catches deeply nested input before it reaches
         // pre-existing deserialization issues with enum fields
-        let xml = "<Wrap><f><Wrap><f><Leaf/></f></Wrap></f></Wrap>";
+        let xml = "<Parent><f><Parent><f><Leaf/></f></Parent></f></Parent>";
         let mut de = XmlDeserializer::from_str(xml);
         de.recursion_limit(1);
         assert!(matches!(
@@ -1147,7 +1147,7 @@ mod issue978 {
     fn struct_variant_field_vec() {
         #[derive(Debug, Deserialize)]
         enum E {
-            Wrap {
+            Parent {
                 #[serde(default)]
                 f: Vec<E>,
             },
@@ -1155,7 +1155,7 @@ mod issue978 {
             Leaf,
         }
 
-        let xml = "<Wrap><f><Wrap><f><Leaf/></f></Wrap></f></Wrap>";
+        let xml = "<Parent><f><Parent><f><Leaf/></f></Parent></f></Parent>";
         let mut de = XmlDeserializer::from_str(xml);
         de.recursion_limit(1);
         assert!(matches!(
@@ -1168,7 +1168,7 @@ mod issue978 {
     fn struct_variant_value_field_box() {
         #[derive(Debug, Deserialize)]
         enum E {
-            Wrap {
+            Parent {
                 #[serde(rename = "$value")]
                 v: Box<E>,
             },
@@ -1197,7 +1197,7 @@ mod issue978 {
     fn struct_variant_value_field_vec() {
         #[derive(Debug, Deserialize)]
         enum E {
-            Wrap {
+            Parent {
                 #[serde(rename = "$value")]
                 #[serde(default)]
                 v: Vec<E>,

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -1029,42 +1029,51 @@ mod issue978 {
 
     #[test]
     fn newtype_variant_box() {
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, Deserialize, PartialEq)]
         enum E {
             Wrap(Box<E>),
-            #[allow(dead_code)]
             Leaf,
         }
 
-        // FIXME: #819 — the deserializer re-enters `deserialize_enum` without
-        // consuming the end event, so even a single `<Wrap></Wrap>` triggers
-        // infinite re-entry. The recursion limit catches this and returns a
-        // clean error instead of a stack overflow.
-        let xml = "<Wrap></Wrap>";
-        let mut de = XmlDeserializer::from_str(xml);
-        de.recursion_limit(3);
+        let limit = 3;
+
+        // Within the limit: deserializes successfully
+        let xml = nested_enum_value(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(E::deserialize(&mut de).is_ok());
+
+        // Exceeds the limit
+        let xml = nested_enum_value(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
         assert!(matches!(
             E::deserialize(&mut de),
-            Err(DeError::TooDeeplyNested(_))
+            Err(DeError::TooDeeplyNested(n)) if n == limit
         ));
     }
 
     #[test]
     fn newtype_variant_vec() {
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, Deserialize, PartialEq)]
         enum E {
             Wrap(Vec<E>),
-            #[allow(dead_code)]
             Leaf,
         }
 
-        // FIXME: #819 — same re-entry issue as newtype_variant_box
-        let xml = "<Wrap></Wrap>";
-        let mut de = XmlDeserializer::from_str(xml);
-        de.recursion_limit(3);
+        let limit = 3;
+
+        let xml = nested_enum_value(limit);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
+        assert!(E::deserialize(&mut de).is_ok());
+
+        let xml = nested_enum_value(limit + 1);
+        let mut de = XmlDeserializer::from_str(&xml);
+        de.recursion_limit(limit);
         assert!(matches!(
             E::deserialize(&mut de),
-            Err(DeError::TooDeeplyNested(_))
+            Err(DeError::TooDeeplyNested(n)) if n == limit
         ));
     }
 
@@ -1074,13 +1083,15 @@ mod issue978 {
     fn tuple_variant_box() {
         #[derive(Debug, Deserialize)]
         enum E {
-            Wrap(Box<E>, String),
+            Parent(Box<E>, String),
             #[allow(dead_code)]
             Leaf,
         }
 
-        // FIXME: #819 — same re-entry issue as newtype variants
-        let xml = "<Wrap></Wrap>";
+        // Tuple variants use repeated elements (<V>f1</V><V>f2</V>),
+        // so the Start event cannot be consumed the way newtype
+        // variants do. Recursive tuple variants still hit re-entry.
+        let xml = "<Parent></Parent>";
         let mut de = XmlDeserializer::from_str(xml);
         de.recursion_limit(3);
         assert!(matches!(
@@ -1093,13 +1104,13 @@ mod issue978 {
     fn tuple_variant_vec() {
         #[derive(Debug, Deserialize)]
         enum E {
-            Wrap(Vec<E>, String),
+            Parent(Vec<E>, String),
             #[allow(dead_code)]
             Leaf,
         }
 
-        // FIXME: #819 — same re-entry issue as newtype variants
-        let xml = "<Wrap></Wrap>";
+        // Same re-entry issue as tuple_variant_box.
+        let xml = "<Parent></Parent>";
         let mut de = XmlDeserializer::from_str(xml);
         de.recursion_limit(3);
         assert!(matches!(
@@ -1237,4 +1248,33 @@ mod issue978 {
         assert!(result.is_ok());
         assert_eq!(result.unwrap().item.len(), 200);
     }
+}
+
+/// Regression test for https://github.com/tafia/quick-xml/issues/819.
+///
+/// Enum newtype variants with recursive inner enum types should deserialize
+/// correctly instead of causing infinite re-entry / stack overflow.
+#[test]
+fn issue819() {
+    use quick_xml::de::from_str;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    enum MathNode {
+        Apply(Vec<MathNode>),
+        Ci(Vec<MathNode>),
+        #[serde(rename = "$text")]
+        Text(String),
+        #[serde(rename = "math")]
+        Root(Vec<MathNode>),
+    }
+
+    let xml = r#"<math><apply><ci>5</ci></apply></math>"#;
+    let result: MathNode = from_str(xml).unwrap();
+    assert_eq!(
+        result,
+        MathNode::Root(vec![MathNode::Apply(vec![MathNode::Ci(vec![
+            MathNode::Text("5".into())
+        ])])])
+    );
 }


### PR DESCRIPTION
Enum newtype variants whose inner type is also an enum (e.g. `Apply(Vec<MathNode>)`) caused infinite re-entry because
`newtype_variant_seed` passed the raw Deserializer back without consuming the variant's Start event.

Introduce VariantContentDeserializer to consume the Start event first, then dispatch correctly for all inner types: structs use the consumed start as root, enums/sequences delegate to the stream-based Deserializer with proper End-tag cleanup.

This also fixes two related issues:

- Newtype variants containing sequences of child elements (e.g.   `Variant(Vec<i32>)` with `<Variant><x>1</x><x>2</x></Variant>`)   previously failed with `UnexpectedStart` because the unconsumed Start event was treated as the first sequence element.
- Sequences inside newtype variants could consume past the enclosing  variant's End tag, because the top-level SeqAccess only stops on Eof. The new VariantSeqAccess correctly stops on End events.

Assisted-By: Claude Opus 4.6
closes https://github.com/tafia/quick-xml/issues/819