### PR TITLE
Fix indented writer misaligning End tags after Comment + Text 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -64,6 +64,10 @@ The MSRV has been raised to 1.86.
 
 ### Bug Fixes
 
+- [#276]: Fixed `Writer::new_with_indent` producing misaligned closing tags
+  when an element contained a non-text child (e.g. a comment) followed by a
+  text node. The `</tag>` was appended directly after the text instead of
+  starting on a new line at the correct indentation level.
 - [#670]: Serde serializer now escapes `\r`, `\n`, and `\t` in attribute values
   as `&#13;`, `&#10;`, and `&#9;` respectively, preventing silent data loss from
   XML attribute-value normalization on round-trip. Likewise `Attribute::from`
@@ -110,6 +114,7 @@ The MSRV has been raised to 1.86.
   to get a namespace resolver used by this deserializer, because it no longer uses
   an `NsReader` internally.
 
+[#276]: https://github.com/tafia/quick-xml/issues/276
 [#670]: https://github.com/tafia/quick-xml/issues/670
 [#859]: https://github.com/tafia/quick-xml/issues/859
 [#953]: https://github.com/tafia/quick-xml/issues/953

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -260,10 +260,12 @@ impl<W: Write> Writer<W> {
     /// Writes the given event to the underlying writer.
     pub fn write_event<'a, E: Into<Event<'a>>>(&mut self, event: E) -> io::Result<()> {
         let mut next_should_line_break = true;
+        let mut mark_non_text = false;
         let result = match event.into() {
             Event::Start(e) => {
                 let result = self.write_wrapped("<", &e, ">");
                 if let Some(i) = self.indent.as_mut() {
+                    i.mark_non_text_content();
                     i.grow();
                 }
                 result
@@ -271,36 +273,60 @@ impl<W: Write> Writer<W> {
             Event::End(e) => {
                 if let Some(i) = self.indent.as_mut() {
                     i.shrink();
+                    if i.last_non_text_level > i.current_indent_len {
+                        i.should_line_break = true;
+                    }
                 }
                 self.write_wrapped("</", &e, ">")
             }
-            Event::Empty(e) => self.write_wrapped(
-                "<",
-                &e,
-                if self.config.add_space_before_slash_in_empty_elements {
-                    " />"
-                } else {
-                    "/>"
-                },
-            ),
+            Event::Empty(e) => {
+                mark_non_text = true;
+                self.write_wrapped(
+                    "<",
+                    &e,
+                    if self.config.add_space_before_slash_in_empty_elements {
+                        " />"
+                    } else {
+                        "/>"
+                    },
+                )
+            }
             Event::Text(e) => {
                 next_should_line_break = false;
                 self.write(e.as_bytes())
             }
-            Event::Comment(e) => self.write_wrapped("<!--", &e, "-->"),
+            Event::Comment(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<!--", &e, "-->")
+            }
             Event::CData(e) => {
                 next_should_line_break = false;
                 self.write(b"<![CDATA[")?;
                 self.write(e.as_bytes())?;
                 self.write(b"]]>")
             }
-            Event::Decl(e) => self.write_wrapped("<?", &e, "?>"),
-            Event::PI(e) => self.write_wrapped("<?", &e, "?>"),
-            Event::DocType(e) => self.write_wrapped("<!DOCTYPE ", &e, ">"),
-            Event::GeneralRef(e) => self.write_wrapped("&", &e, ";"),
+            Event::Decl(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<?", &e, "?>")
+            }
+            Event::PI(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<?", &e, "?>")
+            }
+            Event::DocType(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<!DOCTYPE ", &e, ">")
+            }
+            Event::GeneralRef(e) => {
+                mark_non_text = true;
+                self.write_wrapped("&", &e, ";")
+            }
             Event::Eof => Ok(()),
         };
         if let Some(i) = self.indent.as_mut() {
+            if mark_non_text {
+                i.mark_non_text_content();
+            }
             i.should_line_break = next_should_line_break;
         }
         result
@@ -679,6 +705,10 @@ pub(crate) struct Indentation {
     indents: String,
     /// The current amount of indentation
     current_indent_len: usize,
+    /// Indent level at which the most recent non-text event was written.
+    /// Used by End to force a line break when a non-text child (Comment,
+    /// Empty, child Start, etc.) preceded a Text event in the same element.
+    last_non_text_level: usize,
 }
 
 impl Indentation {
@@ -690,6 +720,7 @@ impl Indentation {
             indent_size,
             indents: std::iter::repeat(indent_char).take(128).collect(),
             current_indent_len: 0,
+            last_non_text_level: 0,
         }
     }
 
@@ -720,5 +751,9 @@ impl Indentation {
         while self.indents.len() < new_len {
             self.indents.push(self.indent_char);
         }
+    }
+
+    fn mark_non_text_content(&mut self) {
+        self.last_non_text_level = self.current_indent_len;
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -260,12 +260,12 @@ impl<W: Write> Writer<W> {
     /// Writes the given event to the underlying writer.
     pub fn write_event<'a, E: Into<Event<'a>>>(&mut self, event: E) -> io::Result<()> {
         let mut next_should_line_break = true;
-        let mut should_mark_non_text = true;
+        let mut mark_non_text = false;
         let result = match event.into() {
             Event::Start(e) => {
-                should_mark_non_text = false;
                 let result = self.write_wrapped("<", &e, ">");
                 if let Some(i) = self.indent.as_mut() {
+                    i.mark_non_text_content();
                     i.grow();
                 }
                 result
@@ -279,36 +279,52 @@ impl<W: Write> Writer<W> {
                 }
                 self.write_wrapped("</", &e, ">")
             }
-            Event::Empty(e) => self.write_wrapped(
-                "<",
-                &e,
-                if self.config.add_space_before_slash_in_empty_elements {
-                    " />"
-                } else {
-                    "/>"
-                },
-            ),
+            Event::Empty(e) => {
+                mark_non_text = true;
+                self.write_wrapped(
+                    "<",
+                    &e,
+                    if self.config.add_space_before_slash_in_empty_elements {
+                        " />"
+                    } else {
+                        "/>"
+                    },
+                )
+            }
             Event::Text(e) => {
                 next_should_line_break = false;
-                should_mark_non_text = false;
                 self.write(e.as_bytes())
             }
-            Event::Comment(e) => self.write_wrapped("<!--", &e, "-->"),
+            Event::Comment(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<!--", &e, "-->")
+            }
             Event::CData(e) => {
                 next_should_line_break = false;
-                should_mark_non_text = false;
                 self.write(b"<![CDATA[")?;
                 self.write(e.as_bytes())?;
                 self.write(b"]]>")
             }
-            Event::Decl(e) => self.write_wrapped("<?", &e, "?>"),
-            Event::PI(e) => self.write_wrapped("<?", &e, "?>"),
-            Event::DocType(e) => self.write_wrapped("<!DOCTYPE ", &e, ">"),
-            Event::GeneralRef(e) => self.write_wrapped("&", &e, ";"),
+            Event::Decl(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<?", &e, "?>")
+            }
+            Event::PI(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<?", &e, "?>")
+            }
+            Event::DocType(e) => {
+                mark_non_text = true;
+                self.write_wrapped("<!DOCTYPE ", &e, ">")
+            }
+            Event::GeneralRef(e) => {
+                mark_non_text = true;
+                self.write_wrapped("&", &e, ";")
+            }
             Event::Eof => Ok(()),
         };
         if let Some(i) = self.indent.as_mut() {
-            if should_mark_non_text {
+            if mark_non_text {
                 i.mark_non_text_content();
             }
             i.should_line_break = next_should_line_break;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -260,12 +260,12 @@ impl<W: Write> Writer<W> {
     /// Writes the given event to the underlying writer.
     pub fn write_event<'a, E: Into<Event<'a>>>(&mut self, event: E) -> io::Result<()> {
         let mut next_should_line_break = true;
-        let mut mark_non_text = false;
+        let mut should_mark_non_text = true;
         let result = match event.into() {
             Event::Start(e) => {
+                should_mark_non_text = false;
                 let result = self.write_wrapped("<", &e, ">");
                 if let Some(i) = self.indent.as_mut() {
-                    i.mark_non_text_content();
                     i.grow();
                 }
                 result
@@ -279,52 +279,36 @@ impl<W: Write> Writer<W> {
                 }
                 self.write_wrapped("</", &e, ">")
             }
-            Event::Empty(e) => {
-                mark_non_text = true;
-                self.write_wrapped(
-                    "<",
-                    &e,
-                    if self.config.add_space_before_slash_in_empty_elements {
-                        " />"
-                    } else {
-                        "/>"
-                    },
-                )
-            }
+            Event::Empty(e) => self.write_wrapped(
+                "<",
+                &e,
+                if self.config.add_space_before_slash_in_empty_elements {
+                    " />"
+                } else {
+                    "/>"
+                },
+            ),
             Event::Text(e) => {
                 next_should_line_break = false;
+                should_mark_non_text = false;
                 self.write(e.as_bytes())
             }
-            Event::Comment(e) => {
-                mark_non_text = true;
-                self.write_wrapped("<!--", &e, "-->")
-            }
+            Event::Comment(e) => self.write_wrapped("<!--", &e, "-->"),
             Event::CData(e) => {
                 next_should_line_break = false;
+                should_mark_non_text = false;
                 self.write(b"<![CDATA[")?;
                 self.write(e.as_bytes())?;
                 self.write(b"]]>")
             }
-            Event::Decl(e) => {
-                mark_non_text = true;
-                self.write_wrapped("<?", &e, "?>")
-            }
-            Event::PI(e) => {
-                mark_non_text = true;
-                self.write_wrapped("<?", &e, "?>")
-            }
-            Event::DocType(e) => {
-                mark_non_text = true;
-                self.write_wrapped("<!DOCTYPE ", &e, ">")
-            }
-            Event::GeneralRef(e) => {
-                mark_non_text = true;
-                self.write_wrapped("&", &e, ";")
-            }
+            Event::Decl(e) => self.write_wrapped("<?", &e, "?>"),
+            Event::PI(e) => self.write_wrapped("<?", &e, "?>"),
+            Event::DocType(e) => self.write_wrapped("<!DOCTYPE ", &e, ">"),
+            Event::GeneralRef(e) => self.write_wrapped("&", &e, ";"),
             Event::Eof => Ok(()),
         };
         if let Some(i) = self.indent.as_mut() {
-            if mark_non_text {
+            if should_mark_non_text {
                 i.mark_non_text_content();
             }
             i.should_line_break = next_should_line_break;

--- a/src/writer/async_tokio.rs
+++ b/src/writer/async_tokio.rs
@@ -11,12 +11,12 @@ impl<W: AsyncWrite + Unpin> Writer<W> {
     /// Writes the given event to the underlying writer. Async version of [`Writer::write_event`].
     pub async fn write_event_async<'a, E: Into<Event<'a>>>(&mut self, event: E) -> Result<()> {
         let mut next_should_line_break = true;
-        let mut mark_non_text = false;
+        let mut should_mark_non_text = true;
         let result = match event.into() {
             Event::Start(e) => {
+                should_mark_non_text = false;
                 let result = self.write_wrapped_async("<", &e, ">").await;
                 if let Some(i) = self.indent.as_mut() {
-                    i.mark_non_text_content();
                     i.grow();
                 }
                 result
@@ -30,44 +30,28 @@ impl<W: AsyncWrite + Unpin> Writer<W> {
                 }
                 self.write_wrapped_async("</", &e, ">").await
             }
-            Event::Empty(e) => {
-                mark_non_text = true;
-                self.write_wrapped_async("<", &e, "/>").await
-            }
+            Event::Empty(e) => self.write_wrapped_async("<", &e, "/>").await,
             Event::Text(e) => {
                 next_should_line_break = false;
+                should_mark_non_text = false;
                 self.write_async(e.as_bytes()).await
             }
-            Event::Comment(e) => {
-                mark_non_text = true;
-                self.write_wrapped_async("<!--", &e, "-->").await
-            }
+            Event::Comment(e) => self.write_wrapped_async("<!--", &e, "-->").await,
             Event::CData(e) => {
                 next_should_line_break = false;
+                should_mark_non_text = false;
                 self.write_async(b"<![CDATA[").await?;
                 self.write_async(e.as_bytes()).await?;
                 self.write_async(b"]]>").await
             }
-            Event::Decl(e) => {
-                mark_non_text = true;
-                self.write_wrapped_async("<?", &e, "?>").await
-            }
-            Event::PI(e) => {
-                mark_non_text = true;
-                self.write_wrapped_async("<?", &e, "?>").await
-            }
-            Event::DocType(e) => {
-                mark_non_text = true;
-                self.write_wrapped_async("<!DOCTYPE ", &e, ">").await
-            }
-            Event::GeneralRef(e) => {
-                mark_non_text = true;
-                self.write_wrapped_async("&", &e, ";").await
-            }
+            Event::Decl(e) => self.write_wrapped_async("<?", &e, "?>").await,
+            Event::PI(e) => self.write_wrapped_async("<?", &e, "?>").await,
+            Event::DocType(e) => self.write_wrapped_async("<!DOCTYPE ", &e, ">").await,
+            Event::GeneralRef(e) => self.write_wrapped_async("&", &e, ";").await,
             Event::Eof => Ok(()),
         };
         if let Some(i) = self.indent.as_mut() {
-            if mark_non_text {
+            if should_mark_non_text {
                 i.mark_non_text_content();
             }
             i.should_line_break = next_should_line_break;

--- a/src/writer/async_tokio.rs
+++ b/src/writer/async_tokio.rs
@@ -11,10 +11,12 @@ impl<W: AsyncWrite + Unpin> Writer<W> {
     /// Writes the given event to the underlying writer. Async version of [`Writer::write_event`].
     pub async fn write_event_async<'a, E: Into<Event<'a>>>(&mut self, event: E) -> Result<()> {
         let mut next_should_line_break = true;
+        let mut mark_non_text = false;
         let result = match event.into() {
             Event::Start(e) => {
                 let result = self.write_wrapped_async("<", &e, ">").await;
                 if let Some(i) = self.indent.as_mut() {
+                    i.mark_non_text_content();
                     i.grow();
                 }
                 result
@@ -22,28 +24,52 @@ impl<W: AsyncWrite + Unpin> Writer<W> {
             Event::End(e) => {
                 if let Some(i) = self.indent.as_mut() {
                     i.shrink();
+                    if i.last_non_text_level > i.current_indent_len {
+                        i.should_line_break = true;
+                    }
                 }
                 self.write_wrapped_async("</", &e, ">").await
             }
-            Event::Empty(e) => self.write_wrapped_async("<", &e, "/>").await,
+            Event::Empty(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<", &e, "/>").await
+            }
             Event::Text(e) => {
                 next_should_line_break = false;
                 self.write_async(e.as_bytes()).await
             }
-            Event::Comment(e) => self.write_wrapped_async("<!--", &e, "-->").await,
+            Event::Comment(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<!--", &e, "-->").await
+            }
             Event::CData(e) => {
                 next_should_line_break = false;
                 self.write_async(b"<![CDATA[").await?;
                 self.write_async(e.as_bytes()).await?;
                 self.write_async(b"]]>").await
             }
-            Event::Decl(e) => self.write_wrapped_async("<?", &e, "?>").await,
-            Event::PI(e) => self.write_wrapped_async("<?", &e, "?>").await,
-            Event::DocType(e) => self.write_wrapped_async("<!DOCTYPE ", &e, ">").await,
-            Event::GeneralRef(e) => self.write_wrapped_async("&", &e, ";").await,
+            Event::Decl(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<?", &e, "?>").await
+            }
+            Event::PI(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<?", &e, "?>").await
+            }
+            Event::DocType(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<!DOCTYPE ", &e, ">").await
+            }
+            Event::GeneralRef(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("&", &e, ";").await
+            }
             Event::Eof => Ok(()),
         };
         if let Some(i) = self.indent.as_mut() {
+            if mark_non_text {
+                i.mark_non_text_content();
+            }
             i.should_line_break = next_should_line_break;
         }
         result

--- a/src/writer/async_tokio.rs
+++ b/src/writer/async_tokio.rs
@@ -11,12 +11,12 @@ impl<W: AsyncWrite + Unpin> Writer<W> {
     /// Writes the given event to the underlying writer. Async version of [`Writer::write_event`].
     pub async fn write_event_async<'a, E: Into<Event<'a>>>(&mut self, event: E) -> Result<()> {
         let mut next_should_line_break = true;
-        let mut should_mark_non_text = true;
+        let mut mark_non_text = false;
         let result = match event.into() {
             Event::Start(e) => {
-                should_mark_non_text = false;
                 let result = self.write_wrapped_async("<", &e, ">").await;
                 if let Some(i) = self.indent.as_mut() {
+                    i.mark_non_text_content();
                     i.grow();
                 }
                 result
@@ -30,28 +30,44 @@ impl<W: AsyncWrite + Unpin> Writer<W> {
                 }
                 self.write_wrapped_async("</", &e, ">").await
             }
-            Event::Empty(e) => self.write_wrapped_async("<", &e, "/>").await,
+            Event::Empty(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<", &e, "/>").await
+            }
             Event::Text(e) => {
                 next_should_line_break = false;
-                should_mark_non_text = false;
                 self.write_async(e.as_bytes()).await
             }
-            Event::Comment(e) => self.write_wrapped_async("<!--", &e, "-->").await,
+            Event::Comment(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<!--", &e, "-->").await
+            }
             Event::CData(e) => {
                 next_should_line_break = false;
-                should_mark_non_text = false;
                 self.write_async(b"<![CDATA[").await?;
                 self.write_async(e.as_bytes()).await?;
                 self.write_async(b"]]>").await
             }
-            Event::Decl(e) => self.write_wrapped_async("<?", &e, "?>").await,
-            Event::PI(e) => self.write_wrapped_async("<?", &e, "?>").await,
-            Event::DocType(e) => self.write_wrapped_async("<!DOCTYPE ", &e, ">").await,
-            Event::GeneralRef(e) => self.write_wrapped_async("&", &e, ";").await,
+            Event::Decl(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<?", &e, "?>").await
+            }
+            Event::PI(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<?", &e, "?>").await
+            }
+            Event::DocType(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("<!DOCTYPE ", &e, ">").await
+            }
+            Event::GeneralRef(e) => {
+                mark_non_text = true;
+                self.write_wrapped_async("&", &e, ";").await
+            }
             Event::Eof => Ok(()),
         };
         if let Some(i) = self.indent.as_mut() {
-            if should_mark_non_text {
+            if mark_non_text {
                 i.mark_non_text_content();
             }
             i.should_line_break = next_should_line_break;

--- a/tests/writer-indentation.rs
+++ b/tests/writer-indentation.rs
@@ -1,4 +1,4 @@
-use quick_xml::events::{BytesStart, BytesText, Event};
+use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::writer::Writer;
 
 use pretty_assertions::assert_eq;
@@ -549,4 +549,31 @@ mod in_attributes_multi {
             \n/>"
         );
     }
+}
+
+// Regression test for https://github.com/tafia/quick-xml/issues/276
+// Elements containing both a comment and a text node should not produce
+// misaligned closing tags.
+#[test]
+fn issue_276_comment_then_text_indent() {
+    let mut buffer = Vec::new();
+    let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
+
+    writer
+        .write_event(Event::Start(BytesStart::new("tag2")))
+        .unwrap();
+    writer
+        .write_event(Event::Comment(BytesText::new("Test comment")))
+        .unwrap();
+    writer
+        .write_event(Event::Text(BytesText::new("Test")))
+        .unwrap();
+    writer
+        .write_event(Event::End(BytesEnd::new("tag2")))
+        .unwrap();
+
+    let output = std::str::from_utf8(&buffer).unwrap();
+    // The closing </tag2> must start on a new line at the same indentation
+    // level as <tag2>, not immediately after the text node.
+    assert_eq!(output, "<tag2>\n    <!--Test comment-->Test\n</tag2>");
 }


### PR DESCRIPTION
When an element contained a non-text child (e.g. Comment) followed by a
Text event, the closing End tag lost its line break because Text
unconditionally cleared should_line_break. Track the indent level of the
most recent non-text event and force a line break for the End tag when
that level is deeper than the current level after shrink.

closes https://github.com/tafia/quick-xml/issues/276