### PR TITLE
Document pretty-printing with Serializer::indent

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -79,6 +79,7 @@ The MSRV has been raised to 1.86.
 
 ### Misc Changes
 
+- [#859]: Added an example showing how to pretty-print serialized XML.
 - [#983]: Adopted an AI use and contribution policy for new upstream contributions.
 - [#963]: MSRV bumped to 1.86 (April 2025)
 - [#963]: Deprecated `Attribute` methods that take a `Decoder` parameter, since
@@ -90,6 +91,7 @@ The MSRV has been raised to 1.86.
 [#963]: https://github.com/tafia/quick-xml/pull/963
 [#977]: https://github.com/tafia/quick-xml/issues/977
 [#980]: https://github.com/tafia/quick-xml/issues/980
+[#859]: https://github.com/tafia/quick-xml/issues/859
 [#978]: https://github.com/tafia/quick-xml/issues/978
 [#983]: https://github.com/tafia/quick-xml/issues/983
 [#989]: https://github.com/tafia/quick-xml/issues/989

--- a/src/se/mod.rs
+++ b/src/se/mod.rs
@@ -789,7 +789,33 @@ impl<'w, 'r, W: Write> Serializer<'w, 'r, W> {
         self
     }
 
-    /// Configure indent for a serializer
+    /// Configure indent for a serializer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pretty_assertions::assert_eq;
+    /// use quick_xml::se::Serializer;
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// struct Response {
+    ///     message: &'static str,
+    /// }
+    ///
+    /// let mut output = String::new();
+    /// let mut serializer = Serializer::with_root(&mut output, Some("response")).unwrap();
+    /// serializer.indent(' ', 4);
+    ///
+    /// Response { message: "Success" }
+    ///     .serialize(serializer)
+    ///     .unwrap();
+    ///
+    /// assert_eq!(
+    ///     output,
+    ///     "<response>\n    <message>Success</message>\n</response>"
+    /// );
+    /// ```
     pub fn indent(&mut self, indent_char: char, indent_size: usize) -> &mut Self {
         self.ser.indent = Indent::Owned(Indentation::new(indent_char as u8, indent_size));
         self


### PR DESCRIPTION
## Summary

Closes #859.

Add a runnable `Serializer::indent` example that shows how to pretty-print a serializable struct with a root element. The example is covered by rustdoc, and the change is recorded under the unreleased changelog.

## Verification

- `cargo fmt --check`
- `cargo test --doc --all-features`
- `cargo test --all-features`
