### PR TITLE
Rename `DeError::UnexpectedStart` to `DeError::MixedContent` to clarify its conditions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -58,6 +58,9 @@ The MSRV has been raised to 1.86.
   and `NamespaceResolver::set_max_declarations_per_element` has been renamed to
   `NamespaceResolver::set_max_namespace_bindings`, and the semantic behavior has
   changed slightly. The default maximum has also been reduced from 256 to 128.
+- [#1000]: `DeError::UnexpectedStart` renamed to `DeError::MixedContent`. That error
+  is emitted when you try to deserialize boolean, number or string `field` from
+  something like `<field>text <tag/> another text</field>`.
 
 ### Bug Fixes
 
@@ -95,6 +98,7 @@ The MSRV has been raised to 1.86.
 [#978]: https://github.com/tafia/quick-xml/issues/978
 [#983]: https://github.com/tafia/quick-xml/issues/983
 [#989]: https://github.com/tafia/quick-xml/issues/989
+[#1000]: https://github.com/tafia/quick-xml/pull/1000
 
 ## 0.41.0 -- 2026-06-29
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2928,7 +2928,7 @@ where
     ///
     /// |Event             |XML                        |Handling
     /// |------------------|---------------------------|----------------------------------------
-    /// |[`DeEvent::Start`]|`<tag>...</tag>`           |if `allow_start == true`, result determined by the second table, otherwise emits [`UnexpectedStart("tag")`](DeError::UnexpectedStart)
+    /// |[`DeEvent::Start`]|`<tag>...</tag>`           |if `allow_start == true`, result determined by the second table, otherwise emits [`MixedContent("tag")`](DeError::MixedContent)
     /// |[`DeEvent::End`]  |`</any-tag>`               |This is impossible situation, the method will panic if it happens
     /// |[`DeEvent::Text`] |`text content` or `<![CDATA[cdata content]]>` (probably mixed)|Returns event content unchanged
     /// |[`DeEvent::Eof`]  |                           |Emits [`UnexpectedEof`](DeError::UnexpectedEof)
@@ -2937,7 +2937,7 @@ where
     ///
     /// |Event             |XML                        |Handling
     /// |------------------|---------------------------|----------------------------------------------------------------------------------
-    /// |[`DeEvent::Start`]|`<any-tag>...</any-tag>`   |Emits [`UnexpectedStart("any-tag")`](DeError::UnexpectedStart)
+    /// |[`DeEvent::Start`]|`<any-tag>...</any-tag>`   |Emits [`MixedContent("any-tag")`](DeError::MixedContent)
     /// |[`DeEvent::End`]  |`</tag>`                   |Returns an empty slice. The reader guarantee that tag will match the open one
     /// |[`DeEvent::Text`] |`text content` or `<![CDATA[cdata content]]>` (probably mixed)|Returns event content unchanged, expects the `</tag>` after that
     /// |[`DeEvent::Eof`]  |                           |Emits [`InvalidXml(IllFormed(MissingEndTag))`](DeError::InvalidXml)
@@ -2952,7 +2952,7 @@ where
             // Reached by trivial::{...}::{field, field_nested, field_tag_after, field_tag_before, nested, tag_after, tag_before, wrapped}
             DeEvent::Start(e) if allow_start => self.read_text(e.name()),
             // TODO: not reached by any tests
-            DeEvent::Start(e) => Err(DeError::UnexpectedStart(e.name().as_ref().to_owned())),
+            DeEvent::Start(e) => Err(DeError::MixedContent(e.name().as_ref().to_owned())),
             // SAFETY: The reader is guaranteed that we don't have unmatched tags
             // If we here, then our deserializer has a bug
             DeEvent::End(e) => unreachable!("{:?}", e),
@@ -2975,7 +2975,7 @@ where
                 // SAFETY: Cannot be two consequent Text events, they would be merged into one
                 DeEvent::Text(_) => unreachable!(),
                 // Reached by trivial::{...}::{field_tag_after, tag_after}
-                DeEvent::Start(e) => Err(DeError::UnexpectedStart(e.name().as_ref().to_owned())),
+                DeEvent::Start(e) => Err(DeError::MixedContent(e.name().as_ref().to_owned())),
                 // Reached by struct_::non_closed::elements_child
                 DeEvent::Eof => Err(Error::missed_end(name).into()),
             },
@@ -2985,7 +2985,7 @@ where
             // Reached by {...}::xs_list::empty
             DeEvent::End(_) => Ok("".into()),
             // Reached by trivial::{...}::{field_nested, field_tag_before, nested, tag_before}
-            DeEvent::Start(s) => Err(DeError::UnexpectedStart(s.name().as_ref().to_owned())),
+            DeEvent::Start(s) => Err(DeError::MixedContent(s.name().as_ref().to_owned())),
             // Reached by struct_::non_closed::elements_child
             DeEvent::Eof => Err(Error::missed_end(name).into()),
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -338,7 +338,7 @@ pub mod serialize {
         /// Deserializer encounter a start tag with a specified name when it is
         /// not expecting. This happens when you try to deserialize a primitive
         /// value (numbers, strings, booleans) from an XML element.
-        UnexpectedStart(String),
+        MixedContent(String),
         /// The [`Reader`] produced [`Event::Eof`] when it is not expecting,
         /// for example, after producing [`Event::Start`] but before corresponding
         /// [`Event::End`].
@@ -366,7 +366,7 @@ pub mod serialize {
                 Self::Custom(s) => f.write_str(s),
                 Self::InvalidXml(e) => e.fmt(f),
                 Self::KeyNotRead => f.write_str("invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`"),
-                Self::UnexpectedStart(e) => write!(f, "unexpected `Event::Start({})", e),
+                Self::MixedContent(e) => write!(f, "cannot deserialize primitive type from mixed content, found unexpected tag <{}>", e),
                 Self::UnexpectedEof => f.write_str("unexpected `Event::Eof`"),
                 Self::TooDeeplyNested(limit) => write!(f, "XML is too deeply nested, recursion limit of {} exceeded", limit),
                 #[cfg(feature = "overlapped-lists")]

--- a/tests/serde-de.rs
+++ b/tests/serde-de.rs
@@ -331,9 +331,9 @@ mod trivial {
                 fn nested() {
                     match from_str::<$type>(&format!("<root><nested>{}</nested></root>", $value)) {
                         // Expected unexpected start element `<nested>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "nested"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "nested"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("nested"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("nested"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -343,9 +343,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<nested>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "nested"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "nested"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("nested"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("nested"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -356,9 +356,9 @@ mod trivial {
                 fn tag_after() {
                     match from_str::<$type>(&format!("<root>{}<something-else/></root>", $value)) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -368,9 +368,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -381,9 +381,9 @@ mod trivial {
                 fn tag_before() {
                     match from_str::<$type>(&format!("<root><something-else/>{}</root>", $value)) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -393,9 +393,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -420,9 +420,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<nested>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "nested"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "nested"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("nested"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("nested"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -432,9 +432,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<nested>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "nested"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "nested"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("nested"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("nested"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -447,9 +447,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -459,9 +459,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -474,9 +474,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }
@@ -486,9 +486,9 @@ mod trivial {
                         $value
                     )) {
                         // Expected unexpected start element `<something-else>`
-                        Err(DeError::UnexpectedStart(tag)) => assert_eq!(tag, "something-else"),
+                        Err(DeError::MixedContent(tag)) => assert_eq!(tag, "something-else"),
                         x => panic!(
-                            r#"Expected `Err(UnexpectedStart("something-else"))`, but got `{:?}`"#,
+                            r#"Expected `Err(MixedContent("something-else"))`, but got `{:?}`"#,
                             x
                         ),
                     }


### PR DESCRIPTION
Give more clear name to the `UnexpectedStart` error. It occurs only if you try to deserialize something that contains text and tags into a primitive type:
```xml
<field>some text <tag/> another text</field>
```
In XML terminology, this is called "mixed content". XML Schema even has a special setting `mixed ="true"` in the types allowing this.

Currently we do not allow to capture mixed content into a string (#257) and should never allow that without explicit request. Such request should be the `RawValue` type (similar to the `serde_json::value::RawValue`). To save the catched data into a string we may ensure that it would be possible to use something like:
```rust
struct Tag {
  // Capture any content from the <value> tag, including nested XML
  #[serde(with = "RawValue")]
  value: String,
}
```