### PR TITLE
Escape \r in text and \r/\n/\t in attributes during serialization

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -64,6 +64,9 @@ The MSRV has been raised to 1.86.
 
 ### Bug Fixes
 
+- [#670]: Serde serializer now escapes `\r`, `\n`, and `\t` in attribute values
+  as `&#13;`, `&#10;`, and `&#9;` respectively, preventing silent data loss from
+  XML attribute-value normalization on round-trip.
 - [#989]: `Attributes::new` and `Attributes::html` now return empty iterators when
   their starting position is past the end of the input instead of panicking.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
@@ -79,6 +82,8 @@ The MSRV has been raised to 1.86.
   limit (default 128, matching `serde_json`). Deeply nested XML returns
   `DeError::TooDeeplyNested` instead of overflowing the native call stack.
   Use `Deserializer::recursion_limit()` to adjust.
+- [#990]: Serde serializer now escapes `\r` in text content as `&#13;`, preventing
+  silent conversion to `\n` from XML end-of-line normalization on round-trip.
 
 ### Misc Changes
 
@@ -91,6 +96,7 @@ The MSRV has been raised to 1.86.
   `decode_and_unescape_value_with()`. Use `normalized_value()` and
   `normalized_value_with()` instead.
 
+[#670]: https://github.com/tafia/quick-xml/issues/670
 [#963]: https://github.com/tafia/quick-xml/pull/963
 [#977]: https://github.com/tafia/quick-xml/issues/977
 [#980]: https://github.com/tafia/quick-xml/issues/980
@@ -98,6 +104,7 @@ The MSRV has been raised to 1.86.
 [#978]: https://github.com/tafia/quick-xml/issues/978
 [#983]: https://github.com/tafia/quick-xml/issues/983
 [#989]: https://github.com/tafia/quick-xml/issues/989
+[#990]: https://github.com/tafia/quick-xml/issues/990
 [#1000]: https://github.com/tafia/quick-xml/pull/1000
 
 ## 0.41.0 -- 2026-06-29

--- a/Changelog.md
+++ b/Changelog.md
@@ -66,7 +66,8 @@ The MSRV has been raised to 1.86.
 
 - [#670]: Serde serializer now escapes `\r`, `\n`, and `\t` in attribute values
   as `&#13;`, `&#10;`, and `&#9;` respectively, preventing silent data loss from
-  XML attribute-value normalization on round-trip.
+  XML attribute-value normalization on round-trip. Likewise `Attribute::from`
+  performs the same transformation.
 - [#989]: `Attributes::new` and `Attributes::html` now return empty iterators when
   their starting position is past the end of the input instead of panicking.
 - [#977]: `NamespaceResolver::push` (and hence every `NsReader` `Start`/`Empty`
@@ -82,8 +83,11 @@ The MSRV has been raised to 1.86.
   limit (default 128, matching `serde_json`). Deeply nested XML returns
   `DeError::TooDeeplyNested` instead of overflowing the native call stack.
   Use `Deserializer::recursion_limit()` to adjust.
-- [#990]: Serde serializer now escapes `\r` in text content as `&#13;`, preventing
-  silent conversion to `\n` from XML end-of-line normalization on round-trip.
+- [#990]: `\r` in text content is now escaped as `&#13;` by the serde serializer,
+  `BytesText::new()`, `escape()`, `partial_escape()`, and `minimal_escape()`,
+  preventing silent conversion to `\n` from XML end-of-line normalization on
+  round-trip. Note that `\r` cannot be preserved through CDATA serialization
+  because character references are not permitted inside CDATA sections.
 
 ### Misc Changes
 

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -91,7 +91,8 @@ impl std::error::Error for EscapeError {
 }
 
 /// Escapes an `&str` and replaces all xml special characters (`<`, `>`, `&`, `'`, `"`)
-/// with their corresponding xml escaped value.
+/// with their corresponding xml escaped value. Also escapes `\r` which would
+/// otherwise be converted to `\n` by XML end-of-line normalization.
 ///
 /// This function performs following replacements:
 ///
@@ -102,22 +103,16 @@ impl std::error::Error for EscapeError {
 /// | `&`       | `&amp;`
 /// | `'`       | `&apos;`
 /// | `"`       | `&quot;`
-///
-/// This function performs following replacements:
-///
-/// | Character | Replacement
-/// |-----------|------------
-/// | `<`       | `&lt;`
-/// | `>`       | `&gt;`
-/// | `&`       | `&amp;`
-/// | `'`       | `&apos;`
-/// | `"`       | `&quot;`
+/// | `\r`      | `&#13;`
 pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, |ch| matches!(ch, b'<' | b'>' | b'&' | b'\'' | b'\"'))
+    _escape(raw, |ch| {
+        matches!(ch, b'<' | b'>' | b'&' | b'\'' | b'\"' | b'\r')
+    })
 }
 
 /// Escapes an `&str` and replaces xml special characters (`<`, `>`, `&`)
-/// with their corresponding xml escaped value.
+/// with their corresponding xml escaped value. Also escapes `\r` which would
+/// otherwise be converted to `\n` by XML end-of-line normalization.
 ///
 /// Should only be used for escaping text content. In XML text content, it is allowed
 /// (though not recommended) to leave the quote special characters `"` and `'` unescaped.
@@ -129,6 +124,33 @@ pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `<`       | `&lt;`
 /// | `>`       | `&gt;`
 /// | `&`       | `&amp;`
+/// | `\r`      | `&#13;`
+pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
+    _escape(raw, |ch| matches!(ch, b'<' | b'>' | b'&' | b'\r'))
+}
+
+/// XML standard [requires] that only `<` and `&` was escaped in text content or
+/// attribute value. All other characters not necessary to be escaped, although
+/// for compatibility with SGML they also should be escaped. Practically, escaping
+/// only those characters is enough. Also escapes `\r` which would otherwise be
+/// converted to `\n` by XML end-of-line normalization.
+///
+/// This function performs following replacements:
+///
+/// | Character | Replacement
+/// |-----------|------------
+/// | `<`       | `&lt;`
+/// | `&`       | `&amp;`
+/// | `\r`      | `&#13;`
+///
+/// [requires]: https://www.w3.org/TR/xml11/#syntax
+pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
+    _escape(raw, |ch| matches!(ch, b'<' | b'&' | b'\r'))
+}
+
+/// Escapes a `&str` for use in an XML attribute value. In addition to the
+/// characters escaped by [`escape`], this also escapes `\n` and `\t` which
+/// would otherwise be normalized to spaces by XML attribute-value normalization.
 ///
 /// This function performs following replacements:
 ///
@@ -137,25 +159,18 @@ pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `<`       | `&lt;`
 /// | `>`       | `&gt;`
 /// | `&`       | `&amp;`
-pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, |ch| matches!(ch, b'<' | b'>' | b'&'))
-}
-
-/// XML standard [requires] that only `<` and `&` was escaped in text content or
-/// attribute value. All other characters not necessary to be escaped, although
-/// for compatibility with SGML they also should be escaped. Practically, escaping
-/// only those characters is enough.
-///
-/// This function performs following replacements:
-///
-/// | Character | Replacement
-/// |-----------|------------
-/// | `<`       | `&lt;`
-/// | `&`       | `&amp;`
-///
-/// [requires]: https://www.w3.org/TR/xml11/#syntax
-pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, |ch| matches!(ch, b'<' | b'&'))
+/// | `'`       | `&apos;`
+/// | `"`       | `&quot;`
+/// | `\r`      | `&#13;`
+/// | `\n`      | `&#10;`
+/// | `\t`      | `&#9;`
+pub(crate) fn escape_attribute<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
+    _escape(raw, |ch| {
+        matches!(
+            ch,
+            b'<' | b'>' | b'&' | b'\'' | b'\"' | b'\r' | b'\n' | b'\t'
+        )
+    })
 }
 
 pub(crate) fn escape_char<W>(writer: &mut W, value: &str, from: usize, to: usize) -> fmt::Result
@@ -170,9 +185,8 @@ where
         b'&' => writer.write_str("&amp;")?,
         b'"' => writer.write_str("&quot;")?,
 
-        // This set of escapes handles characters that should be escaped
-        // in elements of xs:lists, because those characters works as
-        // delimiters of list elements
+        // Whitespace characters: used as delimiters in xs:list elements,
+        // and subject to XML EOL / attribute-value normalization
         b'\t' => writer.write_str("&#9;")?,
         b'\n' => writer.write_str("&#10;")?,
         b'\r' => writer.write_str("&#13;")?,

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -4,7 +4,7 @@
 
 use crate::encoding::Decoder;
 use crate::errors::Result as XmlResult;
-use crate::escape::{escape, resolve_predefined_entity};
+use crate::escape::{escape_attribute, resolve_predefined_entity};
 use crate::name::{LocalName, Namespace, NamespaceResolver, QName};
 use crate::utils::is_whitespace;
 use crate::XmlVersion;
@@ -372,7 +372,7 @@ impl<'a> From<(&'a str, &'a str)> for Attribute<'a> {
     fn from(val: (&'a str, &'a str)) -> Attribute<'a> {
         Attribute {
             key: QName(val.0),
-            value: escape(val.1),
+            value: escape_attribute(val.1),
         }
     }
 }
@@ -394,7 +394,7 @@ impl<'a> From<(&'a str, Cow<'a, str>)> for Attribute<'a> {
     fn from(val: (&'a str, Cow<'a, str>)) -> Attribute<'a> {
         Attribute {
             key: QName(val.0),
-            value: escape(val.1),
+            value: escape_attribute(val.1),
         }
     }
 }

--- a/src/se/element.rs
+++ b/src/se/element.rs
@@ -743,7 +743,7 @@ mod tests {
         serialize_as!(seq_empty: Vec::<usize>::new() => "");
         serialize_as!(tuple: ("<\"&'>", "with\t\n\r spaces", 3usize)
             => "<root>&lt;&quot;&amp;&apos;&gt;</root>\
-                <root>with\t\n\r spaces</root>\
+                <root>with\t\n&#13; spaces</root>\
                 <root>3</root>");
         serialize_as!(tuple_struct: Tuple("first", 42)
             => "<root>first</root>\
@@ -1457,7 +1457,7 @@ mod tests {
         serialize_as!(seq_empty: Vec::<usize>::new() => "");
         serialize_as!(tuple: ("<\"&'>", "with\t\n\r spaces", 3usize)
             => "<root>&lt;&quot;&amp;&apos;&gt;</root>\n\
-                <root>with\t\n\r spaces</root>\n\
+                <root>with\t\n&#13; spaces</root>\n\
                 <root>3</root>");
         serialize_as!(tuple_struct: Tuple("first", 42)
             => "<root>first</root>\n\

--- a/src/se/simple_type.rs
+++ b/src/se/simple_type.rs
@@ -130,6 +130,12 @@ where
 }
 
 /// Escapes XSD simple type value
+///
+/// Escaping \r (and \n, \t in attributes) as character references is not
+/// required by the XML specification, but is necessary for lossless round-trip
+/// preservation because XML parsers normalize these characters on input
+/// (Section 2.11, Section 3.3.3). Character references bypass normalization.
+/// This matches the behavior of libxml2.
 fn escape_list<W>(mut writer: W, value: &str, target: QuoteTarget, level: QuoteLevel) -> fmt::Result
 where
     W: Write,
@@ -146,24 +152,40 @@ where
             }
             Ok(())
         }
-        (_, Full) => escape_into(writer, value, |ch| match ch {
+        (Text, Full) => escape_into(writer, value, |ch| match ch {
+            // XML EOL normalization (Section 2.11) would convert \r to \n
+            b'\r' => true,
             // Required characters to escape
             b'&' | b'<' | b'>' | b'\'' | b'\"' => true,
             _ => false,
         }),
-        //----------------------------------------------------------------------
         (Text, Partial) => escape_into(writer, value, |ch| match ch {
+            // XML EOL normalization (Section 2.11) would convert \r to \n
+            b'\r' => true,
             // Required characters to escape
             b'&' | b'<' | b'>' => true,
             _ => false,
         }),
         (Text, Minimal) => escape_into(writer, value, |ch| match ch {
+            // XML EOL normalization (Section 2.11) would convert \r to \n
+            b'\r' => true,
             // Required characters to escape
             b'&' | b'<' => true,
             _ => false,
         }),
         //----------------------------------------------------------------------
+        (_, Full) => escape_into(writer, value, |ch| match ch {
+            // XML EOL normalization (Section 2.11) and attribute-value normalization
+            // (Section 3.3.3) would convert these to \n and space respectively
+            b'\r' | b'\n' | b'\t' => true,
+            // Required characters to escape
+            b'&' | b'<' | b'>' | b'\'' | b'\"' => true,
+            _ => false,
+        }),
+        //----------------------------------------------------------------------
         (DoubleQAttr, Partial) => escape_into(writer, value, |ch| match ch {
+            // XML EOL / attribute-value normalization (Section 2.11, Section 3.3.3)
+            b'\r' | b'\n' | b'\t' => true,
             // Required characters to escape
             b'&' | b'<' | b'>' => true,
             // Double quoted attribute should escape quote
@@ -171,6 +193,8 @@ where
             _ => false,
         }),
         (DoubleQAttr, Minimal) => escape_into(writer, value, |ch| match ch {
+            // XML EOL / attribute-value normalization (Section 2.11, Section 3.3.3)
+            b'\r' | b'\n' | b'\t' => true,
             // Required characters to escape
             b'&' | b'<' => true,
             // Double quoted attribute should escape quote
@@ -179,6 +203,8 @@ where
         }),
         //----------------------------------------------------------------------
         (SingleQAttr, Partial) => escape_into(writer, value, |ch| match ch {
+            // XML EOL / attribute-value normalization (Section 2.11, Section 3.3.3)
+            b'\r' | b'\n' | b'\t' => true,
             // Required characters to escape
             b'&' | b'<' | b'>' => true,
             // Single quoted attribute should escape quote
@@ -186,6 +212,8 @@ where
             _ => false,
         }),
         (SingleQAttr, Minimal) => escape_into(writer, value, |ch| match ch {
+            // XML EOL / attribute-value normalization (Section 2.11, Section 3.3.3)
+            b'\r' | b'\n' | b'\t' => true,
             // Required characters to escape
             b'&' | b'<' => true,
             // Single quoted attribute should escape quote
@@ -893,7 +921,7 @@ mod tests {
             fn text() {
                 assert_eq!(
                     escape_list("text<\"'&> \t\n\rtext", QuoteTarget::Text, QuoteLevel::Full),
-                    "text&lt;&quot;&apos;&amp;&gt; \t\n\rtext"
+                    "text&lt;&quot;&apos;&amp;&gt; \t\n&#13;text"
                 );
             }
 
@@ -905,7 +933,7 @@ mod tests {
                         QuoteTarget::DoubleQAttr,
                         QuoteLevel::Full
                     ),
-                    "text&lt;&quot;&apos;&amp;&gt; \t\n\rtext"
+                    "text&lt;&quot;&apos;&amp;&gt; &#9;&#10;&#13;text"
                 );
             }
 
@@ -917,7 +945,7 @@ mod tests {
                         QuoteTarget::SingleQAttr,
                         QuoteLevel::Full
                     ),
-                    "text&lt;&quot;&apos;&amp;&gt; \t\n\rtext"
+                    "text&lt;&quot;&apos;&amp;&gt; &#9;&#10;&#13;text"
                 );
             }
         }
@@ -934,7 +962,7 @@ mod tests {
                         QuoteTarget::Text,
                         QuoteLevel::Partial
                     ),
-                    "text&lt;\"'&amp;&gt; \t\n\rtext"
+                    "text&lt;\"'&amp;&gt; \t\n&#13;text"
                 );
             }
 
@@ -946,7 +974,7 @@ mod tests {
                         QuoteTarget::DoubleQAttr,
                         QuoteLevel::Partial
                     ),
-                    "text&lt;&quot;'&amp;&gt; \t\n\rtext"
+                    "text&lt;&quot;'&amp;&gt; &#9;&#10;&#13;text"
                 );
             }
 
@@ -958,7 +986,7 @@ mod tests {
                         QuoteTarget::SingleQAttr,
                         QuoteLevel::Partial
                     ),
-                    "text&lt;\"&apos;&amp;&gt; \t\n\rtext"
+                    "text&lt;\"&apos;&amp;&gt; &#9;&#10;&#13;text"
                 );
             }
         }
@@ -975,7 +1003,7 @@ mod tests {
                         QuoteTarget::Text,
                         QuoteLevel::Minimal
                     ),
-                    "text&lt;\"'&amp;> \t\n\rtext"
+                    "text&lt;\"'&amp;> \t\n&#13;text"
                 );
             }
 
@@ -987,7 +1015,7 @@ mod tests {
                         QuoteTarget::DoubleQAttr,
                         QuoteLevel::Minimal
                     ),
-                    "text&lt;&quot;'&amp;> \t\n\rtext"
+                    "text&lt;&quot;'&amp;> &#9;&#10;&#13;text"
                 );
             }
 
@@ -999,7 +1027,7 @@ mod tests {
                         QuoteTarget::SingleQAttr,
                         QuoteLevel::Minimal
                     ),
-                    "text&lt;\"&apos;&amp;> \t\n\rtext"
+                    "text&lt;\"&apos;&amp;> &#9;&#10;&#13;text"
                 );
             }
         }

--- a/tests/escape.rs
+++ b/tests/escape.rs
@@ -20,6 +20,8 @@ fn escape() {
         escape::escape("prefix_\"a\"b&<>c"),
         "prefix_&quot;a&quot;b&amp;&lt;&gt;c"
     );
+    assert_eq!(escape::escape("hello\rworld"), "hello&#13;world");
+    assert_eq!(escape::escape("a\r\nb"), "a&#13;\nb");
 }
 
 #[test]
@@ -39,6 +41,7 @@ fn partial_escape() {
         escape::partial_escape("prefix_\"a\"b&<>c"),
         "prefix_\"a\"b&amp;&lt;&gt;c"
     );
+    assert_eq!(escape::partial_escape("hello\rworld"), "hello&#13;world");
 }
 
 #[test]
@@ -52,6 +55,7 @@ fn minimal_escape() {
         escape::minimal_escape("prefix_\"a\"b&<>c"),
         "prefix_\"a\"b&amp;&lt;>c"
     );
+    assert_eq!(escape::minimal_escape("hello\rworld"), "hello&#13;world");
 }
 
 #[test]

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -584,16 +584,16 @@ mod trim_text {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::DocType(BytesText::new("root \t\r\n"))
+            Event::DocType(BytesText::from_escaped("root \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -602,7 +602,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -611,7 +611,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\ntext \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\ntext \t\r\n"))
         );
 
         assert_eq!(
@@ -620,7 +620,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -629,7 +629,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -638,7 +638,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -647,7 +647,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
@@ -660,7 +660,7 @@ mod trim_text {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::DocType(BytesText::new("root \t\r\n"))
+            Event::DocType(BytesText::from_escaped("root \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -705,16 +705,16 @@ mod trim_text_start {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::DocType(BytesText::new("root \t\r\n"))
+            Event::DocType(BytesText::from_escaped("root \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -723,7 +723,7 @@ mod trim_text_start {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -732,16 +732,16 @@ mod trim_text_start {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\ntext \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\ntext \t\r\n"))
         );
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesText::new(" comment \t\r\n"))
+            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -750,7 +750,7 @@ mod trim_text_start {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -759,7 +759,7 @@ mod trim_text_start {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -768,7 +768,7 @@ mod trim_text_start {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
@@ -781,7 +781,7 @@ mod trim_text_start {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::DocType(BytesText::new("root \t\r\n"))
+            Event::DocType(BytesText::from_escaped("root \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -793,11 +793,11 @@ mod trim_text_start {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new("text \t\r\n"))
+            Event::Text(BytesText::from_escaped("text \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesText::new(" comment \t\r\n"))
+            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -826,16 +826,16 @@ mod trim_text_end {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::DocType(BytesText::new("root \t\r\n"))
+            Event::DocType(BytesText::from_escaped("root \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -844,7 +844,7 @@ mod trim_text_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -853,7 +853,7 @@ mod trim_text_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\ntext \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\ntext \t\r\n"))
         );
 
         assert_eq!(
@@ -862,7 +862,7 @@ mod trim_text_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -871,7 +871,7 @@ mod trim_text_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -880,7 +880,7 @@ mod trim_text_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(
@@ -889,7 +889,7 @@ mod trim_text_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\n"))
+            Event::Text(BytesText::from_escaped(" \t\r\n"))
         );
 
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
@@ -904,7 +904,7 @@ mod trim_text_end {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::DocType(BytesText::new("root \t\r\n"))
+            Event::DocType(BytesText::from_escaped("root \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -916,7 +916,7 @@ mod trim_text_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Text(BytesText::new(" \t\r\ntext"))
+            Event::Text(BytesText::from_escaped(" \t\r\ntext"))
         );
         assert_eq!(
             reader.read_event().unwrap(),

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -304,40 +304,61 @@ fn normalization_sensitive_roundtrip() {
 /// CDATA sections cannot contain character references. Verify that writing
 /// normalization-sensitive characters via BytesCData produces literal characters
 /// (not &#13; etc.), and that \r is normalized to \n on parse (inherent XML limitation).
-#[test]
-fn cdata_no_character_references() {
-    for (label, value, expected_written, expected_parsed) in [
-        (
+mod cdata_no_character_references {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn cr() {
+        test_case(
             "CR",
             "hello\rworld",
             "<v><![CDATA[hello\rworld]]></v>",
             "hello\nworld",
-        ),
-        (
-            "CRLF",
-            "hello\r\nworld",
-            "<v><![CDATA[hello\r\nworld]]></v>",
-            "hello\nworld",
-        ),
-        (
+        );
+    }
+
+    #[test]
+    fn lf() {
+        test_case(
             "LF",
             "hello\nworld",
             "<v><![CDATA[hello\nworld]]></v>",
             "hello\nworld",
-        ),
-        (
+        )
+    }
+
+    #[test]
+    fn crlf() {
+        test_case(
+            "CRLF",
+            "hello\r\nworld",
+            "<v><![CDATA[hello\r\nworld]]></v>",
+            "hello\nworld",
+        )
+    }
+
+    #[test]
+    fn tab() {
+        test_case(
             "TAB",
             "col1\tcol2",
             "<v><![CDATA[col1\tcol2]]></v>",
             "col1\tcol2",
-        ),
-        (
+        )
+    }
+
+    #[test]
+    fn all() {
+        test_case(
             "all",
             "\t\r\n&<>\"'",
             "<v><![CDATA[\t\r\n&<>\"']]></v>",
             "\t\n&<>\"'",
-        ),
-    ] {
+        )
+    }
+
+    fn test_case(label: &str, value: &str, expected_written: &str, expected_parsed: &str) {
         let mut writer = Writer::new(Vec::new());
         writer.write_event(Start(BytesStart::new("v"))).unwrap();
         writer.write_event(CData(BytesCData::new(value))).unwrap();

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,9 +1,11 @@
 //! Contains tests that checks that writing events from a reader produces the same documents.
 
+use quick_xml::escape::unescape;
 use quick_xml::events::attributes::AttrError;
-use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event::*};
+use quick_xml::events::{BytesCData, BytesEnd, BytesStart, BytesText, Event::*};
 use quick_xml::reader::Reader;
 use quick_xml::writer::Writer;
+use quick_xml::XmlVersion;
 
 use pretty_assertions::assert_eq;
 
@@ -245,6 +247,151 @@ fn reescape_text() {
 
     let result = writer.into_inner();
     assert_eq!(String::from_utf8(result).unwrap(), XML);
+}
+
+/// Verify that normalization-sensitive characters (\r in text, \r\n\t in attributes)
+/// are properly escaped when using BytesText::new() and push_attribute(). Otherwise
+/// these characters would be stripped upon being parsed by a compliant XML parser.
+/// This is also consistent with libxml2.
+#[test]
+fn normalization_sensitive_roundtrip() {
+    let mut writer = Writer::new(Vec::new());
+
+    let mut start = BytesStart::new("root");
+    start.push_attribute(("attr", "hello\r\nworld\there"));
+    writer.write_event(Start(start)).unwrap();
+    writer
+        .write_event(Text(BytesText::new("text\rwith\r\ncr")))
+        .unwrap();
+    writer.write_event(End(BytesEnd::new("root"))).unwrap();
+
+    let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+    assert_eq!(
+        xml,
+        "<root attr=\"hello&#13;&#10;world&#9;here\">text&#13;with&#13;\ncr</root>"
+    );
+
+    let mut reader = Reader::from_str(&xml);
+    loop {
+        match reader.read_event().unwrap() {
+            Start(e) => {
+                let attr = e.try_get_attribute("attr").unwrap().unwrap();
+                let value = attr.normalized_value(XmlVersion::Implicit1_0).unwrap();
+                assert_eq!(value.as_ref(), "hello\r\nworld\there");
+            }
+            Eof => break,
+            _ => {}
+        }
+    }
+
+    let mut reader = Reader::from_str(&xml);
+    reader.config_mut().expand_empty_elements = true;
+    loop {
+        match reader.read_event().unwrap() {
+            Start(e) if e.name().as_ref() == "root" => {
+                let text = reader.read_text(e.name()).unwrap();
+                let normalized = text.xml10_content();
+                let content = unescape(&normalized).unwrap();
+                assert_eq!(content.as_ref(), "text\rwith\r\ncr");
+            }
+            Eof => break,
+            _ => {}
+        }
+    }
+}
+
+/// CDATA sections cannot contain character references. Verify that writing
+/// normalization-sensitive characters via BytesCData produces literal characters
+/// (not &#13; etc.), and that \r is normalized to \n on parse (inherent XML limitation).
+#[test]
+fn cdata_no_character_references() {
+    for (label, value, expected_written, expected_parsed) in [
+        (
+            "CR",
+            "hello\rworld",
+            "<v><![CDATA[hello\rworld]]></v>",
+            "hello\nworld",
+        ),
+        (
+            "CRLF",
+            "hello\r\nworld",
+            "<v><![CDATA[hello\r\nworld]]></v>",
+            "hello\nworld",
+        ),
+        (
+            "LF",
+            "hello\nworld",
+            "<v><![CDATA[hello\nworld]]></v>",
+            "hello\nworld",
+        ),
+        (
+            "TAB",
+            "col1\tcol2",
+            "<v><![CDATA[col1\tcol2]]></v>",
+            "col1\tcol2",
+        ),
+        (
+            "all",
+            "\t\r\n&<>\"'",
+            "<v><![CDATA[\t\r\n&<>\"']]></v>",
+            "\t\n&<>\"'",
+        ),
+    ] {
+        let mut writer = Writer::new(Vec::new());
+        writer.write_event(Start(BytesStart::new("v"))).unwrap();
+        writer.write_event(CData(BytesCData::new(value))).unwrap();
+        writer.write_event(End(BytesEnd::new("v"))).unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert_eq!(xml, expected_written, "{label}: serialized XML mismatch");
+        assert!(
+            !xml.contains("&#"),
+            "{label}: CDATA must not contain character references, got: {xml:?}",
+        );
+
+        let mut reader = Reader::from_str(&xml);
+        loop {
+            match reader.read_event().unwrap() {
+                CData(e) => {
+                    let content = e.xml10_content();
+                    assert_eq!(
+                        content.as_ref(),
+                        expected_parsed,
+                        "{label}: parsed content mismatch"
+                    );
+                    break;
+                }
+                Eof => panic!("{label}: unexpected EOF"),
+                _ => {}
+            }
+        }
+    }
+}
+
+/// BytesCData::escape() converts CDATA to text, which should escape \r as &#13;.
+/// This is correct because the result is a BytesText, not CDATA.
+#[test]
+fn cdata_escape_to_text_preserves_cr() {
+    let cdata = BytesCData::new("hello\rworld");
+    let text = cdata.escape().unwrap();
+    assert_eq!(text.as_ref(), "hello&#13;world");
+
+    let cdata = BytesCData::new("hello\r\nworld");
+    let text = cdata.escape().unwrap();
+    assert_eq!(text.as_ref(), "hello&#13;\nworld");
+
+    let cdata = BytesCData::new("a\tb\nc");
+    let text = cdata.partial_escape().unwrap();
+    assert_eq!(
+        text.as_ref(),
+        "a\tb\nc",
+        "partial_escape should not escape TAB or LF in text"
+    );
+
+    let cdata = BytesCData::new("a\rb");
+    let text = cdata.minimal_escape().unwrap();
+    assert_eq!(text.as_ref(), "a&#13;b");
 }
 
 /// Rewrite some events during processing

--- a/tests/serde-issues.rs
+++ b/tests/serde-issues.rs
@@ -539,6 +539,65 @@ fn issue655() {
     );
 }
 
+/// Regression tests for https://github.com/tafia/quick-xml/issues/670.
+///
+/// The serde serializer must escape `\r`, `\n`, and `\t` in attribute values so
+/// they survive XML attribute-value normalization (Section 3.3.3) on round-trip.
+mod issue670 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Root {
+        #[serde(rename = "@value")]
+        value: String,
+    }
+
+    #[test]
+    fn cr_lf_in_attribute() {
+        let value = Root {
+            value: "new\r\nline".into(),
+        };
+        let xml = to_string(&value).unwrap();
+        assert_eq!(xml, r#"<Root value="new&#13;&#10;line"/>"#);
+        let roundtripped: Root = from_str(&xml).unwrap();
+        assert_eq!(roundtripped, value);
+    }
+
+    #[test]
+    fn cr_in_attribute() {
+        let value = Root {
+            value: "new\rline".into(),
+        };
+        let xml = to_string(&value).unwrap();
+        assert_eq!(xml, r#"<Root value="new&#13;line"/>"#);
+        let roundtripped: Root = from_str(&xml).unwrap();
+        assert_eq!(roundtripped, value);
+    }
+
+    #[test]
+    fn lf_in_attribute() {
+        let value = Root {
+            value: "new\nline".into(),
+        };
+        let xml = to_string(&value).unwrap();
+        assert_eq!(xml, r#"<Root value="new&#10;line"/>"#);
+        let roundtripped: Root = from_str(&xml).unwrap();
+        assert_eq!(roundtripped, value);
+    }
+
+    #[test]
+    fn tab_in_attribute() {
+        let value = Root {
+            value: "col1\tcol2".into(),
+        };
+        let xml = to_string(&value).unwrap();
+        assert_eq!(xml, r#"<Root value="col1&#9;col2"/>"#);
+        let roundtripped: Root = from_str(&xml).unwrap();
+        assert_eq!(roundtripped, value);
+    }
+}
+
 /// Regression test for https://github.com/tafia/quick-xml/issues/674
 #[test]
 fn issue674() {
@@ -1236,5 +1295,101 @@ mod issue978 {
         let result = Root::deserialize(&mut de);
         assert!(result.is_ok());
         assert_eq!(result.unwrap().item.len(), 200);
+    }
+}
+
+/// Regression tests for https://github.com/tafia/quick-xml/issues/990.
+///
+/// The serde serializer must escape `\r` in text content so it survives
+/// XML end-of-line normalization (Section 2.11) on round-trip.
+///
+/// This behavior is not stated directly in the spec, but it is exhibited
+/// by implementations such as libxml2.
+mod issue990 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(rename = "value")]
+    struct Value {
+        #[serde(rename = "$value")]
+        value: String,
+    }
+
+    #[test]
+    fn cr_in_text_content() {
+        let value = Value {
+            value: "hello\rworld".into(),
+        };
+        let xml = to_string(&value).unwrap();
+        assert_eq!(xml, "<value>hello&#13;world</value>");
+        let roundtripped: Value = from_str(&xml).unwrap();
+        assert_eq!(roundtripped, value);
+    }
+
+    #[test]
+    fn cr_lf_in_text_content() {
+        let value = Value {
+            value: "hello\r\nworld".into(),
+        };
+        let xml = to_string(&value).unwrap();
+        assert_eq!(xml, "<value>hello&#13;\nworld</value>");
+        let roundtripped: Value = from_str(&xml).unwrap();
+        assert_eq!(roundtripped, value);
+    }
+
+    #[test]
+    fn lf_in_text_content_not_escaped() {
+        let value = Value {
+            value: "hello\nworld".into(),
+        };
+        let xml = to_string(&value).unwrap();
+        // \n is valid in text content and not subject to EOL normalization,
+        // so it should NOT be escaped
+        assert_eq!(xml, "<value>hello\nworld</value>");
+        let roundtripped: Value = from_str(&xml).unwrap();
+        assert_eq!(roundtripped, value);
+    }
+
+    /// CDATA sections cannot preserve `\r` because character references are
+    /// not permitted inside CDATA. This is an inherent XML limitation, the
+    /// round-trip is lossy in this case.
+    #[test]
+    fn cdata_cr_is_lossy() {
+        let mut buffer = String::new();
+        let mut ser = Serializer::with_root(&mut buffer, Some("value")).unwrap();
+        ser.text_format(quick_xml::se::TextFormat::CData);
+
+        let value = Value {
+            value: "hello\rworld".into(),
+        };
+        value.serialize(ser).unwrap();
+
+        // The serializer writes \r literally inside CDATA (it cannot escape it)
+        assert_eq!(buffer, "<value><![CDATA[hello\rworld]]></value>");
+
+        // But XML EOL normalization converts \r to \n on parse, so round-trip
+        // produces \n instead of \r
+        let parsed: Value = from_str(&buffer).unwrap();
+        assert_eq!(parsed.value, "hello\nworld");
+        assert_ne!(parsed, value);
+    }
+
+    /// CDATA with CRLF is also lossy: \r\n becomes \n.
+    #[test]
+    fn cdata_cr_lf_is_lossy() {
+        let mut buffer = String::new();
+        let mut ser = Serializer::with_root(&mut buffer, Some("value")).unwrap();
+        ser.text_format(quick_xml::se::TextFormat::CData);
+
+        let value = Value {
+            value: "hello\r\nworld".into(),
+        };
+        value.serialize(ser).unwrap();
+
+        assert_eq!(buffer, "<value><![CDATA[hello\r\nworld]]></value>");
+
+        let parsed: Value = from_str(&buffer).unwrap();
+        assert_eq!(parsed.value, "hello\nworld");
     }
 }

--- a/tests/serde-se.rs
+++ b/tests/serde-se.rs
@@ -1867,17 +1867,16 @@ mod with_root {
     serialize_as!(str_empty: ""; &str => "<root/>");
     serialize_as!(str_non_escaped: "non-escaped string"; &str => "<root>non-escaped string</root>");
     serialize_as!(str_escaped: "<\"escaped & string'>"; String => "<root>&lt;\"escaped &amp; string'&gt;</root>");
-    // NOTE: do not use \r, because it normalized to \n during deserialization
-    // but writes as is during serialization
-    serialize_as!(str_spaces_only: " \n\t"; String => "<root> \n\t</root>");
+    // NOTE: \r is escaped to &#13; to survive XML EOL normalization (Section 2.11)
+    serialize_as!(str_spaces_only: " \n\t\r"; String => "<root> \n\t&#13;</root>");
 
     err!(bytes: Bytes(b"<\"escaped & bytes'>") => Unsupported("`serialize_bytes` not supported yet"));
 
     serialize_as!(option_none: Option::<&str>::None => "");
     serialize_as!(option_some: Some("non-escaped string") => "<root>non-escaped string</root>");
-    // NOTE: do not use \r, because it normalized to \n during deserialization
-    // but writes as is during serialization
-    serialize_as!(option_spaces_only: Some(" \n\t") => "<root> \n\t</root>");
+    // NOTE: \r is escaped to &#13; to survive XML EOL normalization (Section 2.11).
+    // Must use String because unescaping &#13; produces an owned value.
+    serialize_as!(option_spaces_only: Some(" \n\t\r".to_string()); Option<String> => "<root> \n\t&#13;</root>");
 
     serialize_as!(unit:
         ()
@@ -1896,12 +1895,11 @@ mod with_root {
             <root>2</root>\
             <root>3</root>");
     serialize_as!(tuple:
-        // Use to_string() to get owned type that is required for deserialization
-        // NOTE: do not use \r, because it normalized to \n during deserialization
-        // but writes as is during serialization
-        ("<\"&'>".to_string(), "with\t\n spaces", 3usize)
+        // Use to_string() to get owned types required for deserialization
+        // (unescaping &#13; produces an owned value that can't deserialize to &str)
+        ("<\"&'>".to_string(), "with\t\r\n spaces".to_string(), 3usize)
         => "<root>&lt;\"&amp;'&gt;</root>\
-            <root>with\t\n spaces</root>\
+            <root>with\t&#13;\n spaces</root>\
             <root>3</root>");
     serialize_as!(tuple_struct:
         Tuple(42.0, "answer")


### PR DESCRIPTION
The serde serializer wrote literal \r into text content and \r, \n, \t into attribute values. These characters are silently modified by XML end-of-line normalization and attribute-value normalization respectively, causing data loss on round-trip.

Now escape_list() escapes \r as &#13; in text content at all QuoteLevels, and escapes \r/\n/\t as &#13;/&#10;/&#9; in attribute values. This is consistent with the behavior of libxml2 / lxml.

Make note of the fact that CDATA sections are inherently lossy for \r since character references are not permitted inside CDATA.

closes #670
closes #990

Assisted-By: Claude Opus 4.6