### PR TITLE
Add tests for correct trim behavior around special events

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -998,16 +998,15 @@ impl<R> Reader<R> {
 /// Result of an attempt to read XML textual data from the source.
 #[derive(Debug)]
 enum ReadTextResult<'r, B> {
-    /// Start of markup (`<` character) was found in the first byte. `<` was consumed.
+    /// The reader is positioned at `<` (start of markup). `<` was not consumed.
     /// Contains buffer that should be returned back to the next iteration cycle
     /// to satisfy borrow checker requirements.
     Markup(B),
-    /// Start of reference (`&` character) was found in the first byte.
-    /// `&` was not consumed.
+    /// The reader is positioned at `&` (start of a reference). `&` was not consumed.
     /// Contains buffer that should be returned back to the next iteration cycle
     /// to satisfy borrow checker requirements.
     Ref(B),
-    /// Contains text block up to start of markup (`<` character). `<` was consumed.
+    /// Contains text block up to start of markup (`<` character). `<` was not consumed.
     UpToMarkup(&'r str),
     /// Contains text block up to start of reference (`&` character).
     /// `&` was not consumed.

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -159,57 +159,83 @@ pub struct Config {
     /// [`check_end_names`]: Self::check_end_names
     pub trim_markup_names_in_closing_tags: bool,
 
-    /// Whether whitespace before character data should be removed.
+    /// Whether leading whitespace before character data should be removed.
     ///
-    /// When set to `true`, leading whitespace is trimmed in [`Text`] events.
-    /// If after that the event is empty it will not be pushed.
+    /// When set to `true`, whitespace at the start of [`Text`] events is
+    /// stripped. If the event becomes empty after trimming, it is still
+    /// emitted as `Text("")`.
     ///
     /// Default: `false`
     ///
-    /// <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
+    /// <div style="background:rgba(255, 80, 80, 0.20);padding:0.75em;">
     ///
-    /// WARNING: With this option every text events will be trimmed which is
-    /// incorrect behavior when text events delimited by comments, processing
-    /// instructions or CDATA sections. To correctly trim data manually apply
-    /// [`BytesText::inplace_trim_start`] and [`BytesText::inplace_trim_end`]
-    /// only to necessary events.
+    /// **WARNING:** This option has known issues.
+    ///
+    /// - **Incorrect trimming around comments, PIs, and CDATA sections:**
+    ///   Trimming applies to every [`Text`] event regardless of context.
+    ///   In `text <!-- comment --> more`, the leading space of ` more` is
+    ///   content, but this option trims it because the parser treats each
+    ///   text chunk independently without knowledge of the surrounding markup.
+    /// - **Empty events:** Whitespace-only text that is fully trimmed
+    ///   produces an empty `Text("")` event instead of being suppressed
+    ///   ([#984]).
+    ///
+    /// To correctly trim data manually apply [`BytesText::inplace_trim_start`]
+    /// and [`BytesText::inplace_trim_end`] only to necessary events.
     /// </div>
     ///
     /// [`Text`]: crate::events::Event::Text
     /// [`BytesText::inplace_trim_start`]: crate::events::BytesText::inplace_trim_start
     /// [`BytesText::inplace_trim_end`]: crate::events::BytesText::inplace_trim_end
+    /// [#984]: https://github.com/tafia/quick-xml/issues/984
     pub trim_text_start: bool,
 
-    /// Whether whitespace after character data should be removed.
+    /// Whether trailing whitespace after character data should be removed.
     ///
-    /// When set to `true`, trailing whitespace is trimmed in [`Text`] events.
-    /// If after that the event is empty it will not be pushed.
+    /// When set to `true`, trailing whitespace in [`Text`] events is
+    /// stripped. If the event becomes empty after trimming, it is still
+    /// emitted as `Text("")`.
     ///
     /// Default: `false`
     ///
-    /// <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
+    /// <div style="background:rgba(255, 80, 80, 0.20);padding:0.75em;">
     ///
-    /// WARNING: With this option every text events will be trimmed which is
-    /// incorrect behavior when text events delimited by comments, processing
-    /// instructions or CDATA sections. To correctly trim data manually apply
-    /// [`BytesText::inplace_trim_start`] and [`BytesText::inplace_trim_end`]
-    /// only to necessary events.
+    /// **WARNING:** This option has known issues.
+    ///
+    /// - **Incorrect trimming around comments, PIs, and CDATA sections:**
+    ///   Trimming applies to every [`Text`] event regardless of context.
+    ///   In `text <!-- comment --> more`, the trailing space of `text ` is
+    ///   content, but this option trims it because the parser treats each
+    ///   text chunk independently without knowledge of the surrounding markup.
+    /// - **Empty events:** Whitespace-only text that is fully trimmed
+    ///   produces an empty `Text("")` event instead of being suppressed
+    ///   ([#984]).
+    ///
+    /// To correctly trim data manually apply [`BytesText::inplace_trim_start`]
+    /// and [`BytesText::inplace_trim_end`] only to necessary events.
     /// </div>
     ///
     /// [`Text`]: crate::events::Event::Text
     /// [`BytesText::inplace_trim_start`]: crate::events::BytesText::inplace_trim_start
     /// [`BytesText::inplace_trim_end`]: crate::events::BytesText::inplace_trim_end
+    /// [#984]: https://github.com/tafia/quick-xml/issues/984
     pub trim_text_end: bool,
 }
 
 impl Config {
     /// Set both [`trim_text_start`] and [`trim_text_end`] to the same value.
     ///
-    /// <div style="background:rgba(80, 240, 100, 0.20);padding:0.75em;">
+    /// See those options for more details, including known issues.
     ///
-    /// WARNING: With this option every text events will be trimmed which is
-    /// incorrect behavior when text events delimited by comments, processing
-    /// instructions or CDATA sections. To correctly trim data manually apply
+    /// Default: `false`
+    ///
+    /// <div style="background:rgba(255, 80, 80, 0.20);padding:0.75em;">
+    ///
+    /// **WARNING:** This option has known issues.
+    ///
+    /// With this option every text event will be trimmed which is incorrect
+    /// behavior when text events delimited by comments, processing instructions
+    /// or CDATA sections. To correctly trim data manually apply
     /// [`BytesText::inplace_trim_start`] and [`BytesText::inplace_trim_end`]
     /// only to necessary events.
     /// </div>
@@ -218,6 +244,7 @@ impl Config {
     /// [`trim_text_end`]: Self::trim_text_end
     /// [`BytesText::inplace_trim_start`]: crate::events::BytesText::inplace_trim_start
     /// [`BytesText::inplace_trim_end`]: crate::events::BytesText::inplace_trim_end
+    /// [#984]: https://github.com/tafia/quick-xml/issues/984
     #[inline]
     pub fn trim_text(&mut self, trim: bool) {
         self.trim_text_start = trim;

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -661,6 +661,16 @@ mod trim_text {
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
     }
 
+    // NOTE: Documents CURRENT behavior, which is not spec-correct (see
+    // https://github.com/tafia/quick-xml/issues/984 and `mod correctness` below).
+    // Two known divergences from correct XML handling:
+    //  - Whitespace-only text adjacent to comments, CDATA, and PIs is suppressed,
+    //    but that whitespace is text content, not inter-element indentation, so a
+    //    correct parser preserves it.
+    //  - The mixed-content node around `text` is trimmed on both edges; a correct
+    //    parser preserves the whole node and only drops whitespace-only nodes that
+    //    sit between distinct elements. But this is effectively a different feature
+    //    than what currently exists.
     #[test]
     fn trim_text_true() {
         let mut reader = Reader::from_str(XML);
@@ -703,6 +713,11 @@ mod trim_text {
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
     }
 
+    // NOTE: Documents CURRENT (spec-incorrect) behavior, same divergences as
+    // `trim_text_true`: leading whitespace is stripped from the mixed-content
+    // `text` node and from whitespace-only nodes adjacent to comments/CDATA/PIs,
+    // all of which is text content a correct parser preserves. See #984 and
+    // `mod correctness`.
     #[test]
     fn trim_text_start() {
         let mut reader = Reader::from_str(XML);
@@ -745,8 +760,12 @@ mod trim_text {
     }
 
     // TODO: Enable test after rewriting parser
+    // NOTE: The expected values below still do not reflect fully-correct behavior:
+    // the mixed-content node around `text` should be preserved whole, and
+    // whitespace-only text adjacent to comments/CDATA/PIs should be kept rather
+    // than suppressed. See #984 and `mod correctness`.
     #[test]
-    #[ignore = "currently it is hard to fix incorrect behavior, but this will much easy after parser rewrite"]
+    #[ignore = "fails due to https://github.com/tafia/quick-xml/issues/984"]
     fn trim_text_end() {
         let mut reader = Reader::from_str(XML);
         reader.config_mut().trim_text_end = true;
@@ -785,5 +804,219 @@ mod trim_text {
             Event::End(BytesEnd::new("root"))
         );
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
+    }
+
+    // trim_text should only suppress whitespace-only text nodes that represent
+    // inter-element indentation (pretty-printing whitespace between start/end/empty
+    // elements). It must NOT trim whitespace that is adjacent to "invisible" markup
+    // (comments, PIs, CDATA) or entity references, because that whitespace is part
+    // of the text content.
+    //
+    // The fix for https://github.com/tafia/quick-xml/issues/984 should try to fix
+    // these tests also.
+    mod correctness {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        // Whitespace before and after entity references must not be trimmed.
+        // The parser cannot know what a reference expands to as `&amp;` is content,
+        // so ` &amp;` must preserve the leading space.
+        #[test]
+        #[ignore = "broken pending trimming rework / removal"]
+        fn trim_text_preserves_whitespace_around_entity_ref() {
+            let mut reader = Reader::from_str("<root> &amp; </root>");
+            reader.config_mut().trim_text(true);
+
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Start(BytesStart::new("root"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped(" "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::GeneralRef(BytesRef::new("amp"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped(" "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::End(BytesEnd::new("root"))
+            );
+            assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        }
+
+        // Whitespace around comments must not be trimmed from text content. Comments are
+        // "invisible", they don't break text. The logical text content of
+        // `text <!-- comment --> more` is `text  more` with both spaces preserved.
+        #[test]
+        #[ignore = "broken pending trimming rework / removal"]
+        fn trim_text_preserves_whitespace_around_comment() {
+            let mut reader = Reader::from_str("<root>text <!-- comment --> more</root>");
+            reader.config_mut().trim_text(true);
+
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Start(BytesStart::new("root"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped("text "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Comment(BytesText::from_escaped(" comment "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped(" more"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::End(BytesEnd::new("root"))
+            );
+            assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        }
+
+        // Same as comments - whitespace around PIs is text content.
+        #[test]
+        #[ignore = "broken pending trimming rework / removal"]
+        fn trim_text_preserves_whitespace_around_pi() {
+            let mut reader = Reader::from_str("<root>text <?pi target?> more</root>");
+            reader.config_mut().trim_text(true);
+
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Start(BytesStart::new("root"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped("text "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::PI(BytesPI::new("pi target"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped(" more"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::End(BytesEnd::new("root"))
+            );
+            assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        }
+
+        // Same as comments - whitespace around CDATA is text content.
+        #[test]
+        #[ignore = "broken pending trimming rework / removal"]
+        fn trim_text_preserves_whitespace_around_cdata() {
+            let mut reader = Reader::from_str("<root>text <![CDATA[data]]> more</root>");
+            reader.config_mut().trim_text(true);
+
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Start(BytesStart::new("root"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped("text "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::CData(BytesCData::new("data"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped(" more"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::End(BytesEnd::new("root"))
+            );
+            assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        }
+
+        // Whitespace-only text between elements IS indentation and should be trimmed.
+        // Verify trim still works for the intended case.
+        #[test]
+        fn trim_text_removes_inter_element_whitespace() {
+            let mut reader = Reader::from_str("<root>\n  <child/>\n</root>");
+            reader.config_mut().trim_text(true);
+
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Start(BytesStart::new("root"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Empty(BytesStart::new("child"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::End(BytesEnd::new("root"))
+            );
+            assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        }
+
+        // Mixed content: whitespace flanking real text is part of the character
+        // data, not inter-element indentation, so it must be preserved even
+        // directly against the enclosing element's tags. Only whitespace-only
+        // nodes between distinct elements are indentation (see
+        // `trim_text_removes_inter_element_whitespace`).
+        // NOTE: This behavior would effectively encode a different feature from
+        // what currently exists / is possible with `trim_text_start` & `trim_text_end`
+        #[test]
+        #[ignore = "broken pending trimming rework / removal"]
+        fn trim_text_preserves_whitespace_around_text_content() {
+            let mut reader = Reader::from_str("<root> text </root>");
+            reader.config_mut().trim_text(true);
+
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Start(BytesStart::new("root"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped(" text "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::End(BytesEnd::new("root"))
+            );
+            assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        }
+
+        // Whitespace-only content of a leaf element is that element's entire text
+        // content, not indentation between distinct elements, so it is preserved.
+        // NOTE: this is a deliberate content-fidelity choice. The whitespace here
+        // is indistinguishable from pretty-printing, but `<root>`/`</root>` are the
+        // same element's tags (not two distinct elements), so nothing marks it as
+        // ignorable and we keep it. Revisit if the #984 rework decides otherwise.
+        #[test]
+        #[ignore = "broken pending trimming rework / removal"]
+        fn trim_text_preserves_whitespace_only_leaf_content() {
+            let mut reader = Reader::from_str("<root> </root>");
+            reader.config_mut().trim_text(true);
+
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Start(BytesStart::new("root"))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::Text(BytesText::from_escaped(" "))
+            );
+            assert_eq!(
+                reader.read_event().unwrap(),
+                Event::End(BytesEnd::new("root"))
+            );
+            assert_eq!(reader.read_event().unwrap(), Event::Eof);
+        }
     }
 }

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -563,6 +563,12 @@ mod trim_markup_names_in_closing_tags {
     }
 }
 
+// NOTE: These tests currently do NOT apply XML end-of-line normalization (XML 1.0 Section 2.11).
+// Per the spec, `\r\n` must be normalized to `\n` before any other processing, which
+// means every `\r\n` in this constant should become `\n` in the parsed output. That
+// normalization applies universally: text content, element/attribute whitespace, comments,
+// PIs, CDATA, and DOCTYPE. All assertions below that expect `\r\n` in their output are
+// therefore incorrect with respect to a spec-compliant parser.
 const XML: &str = " \t\r\n\
 <!DOCTYPE root \t\r\n> \t\r\n\
 <root \t\r\n> \t\r\n\

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -584,9 +584,11 @@ mod trim_text {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn false_() {
+    fn trim_text_false() {
         let mut reader = Reader::from_str(XML);
         reader.config_mut().trim_text(false);
+        assert_eq!(reader.config().trim_text_start, false);
+        assert_eq!(reader.config().trim_text_end, false);
 
         assert_eq!(
             reader.read_event().unwrap(),
@@ -660,9 +662,11 @@ mod trim_text {
     }
 
     #[test]
-    fn true_() {
+    fn trim_text_true() {
         let mut reader = Reader::from_str(XML);
         reader.config_mut().trim_text(true);
+        assert_eq!(reader.config().trim_text_start, true);
+        assert_eq!(reader.config().trim_text_end, true);
 
         assert_eq!(
             reader.read_event().unwrap(),
@@ -698,92 +702,12 @@ mod trim_text {
         );
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
     }
-}
-
-mod trim_text_start {
-    use super::*;
-    use pretty_assertions::assert_eq;
 
     #[test]
-    fn false_() {
-        let mut reader = Reader::from_str(XML);
-        reader.config_mut().trim_text_start = false;
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::DocType(BytesText::from_escaped("root \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Start(BytesStart::from_content("root \t\r\n", 4))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Empty(BytesStart::from_content("empty \t\r\n", 5))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\ntext \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::CData(BytesCData::new(" \t\r\ncdata \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::PI(BytesPI::new("pi \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::End(BytesEnd::new("root"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(reader.read_event().unwrap(), Event::Eof);
-    }
-
-    #[test]
-    fn true_() {
+    fn trim_text_start() {
         let mut reader = Reader::from_str(XML);
         reader.config_mut().trim_text_start = true;
+        assert_eq!(reader.config().trim_text_end, false);
 
         assert_eq!(
             reader.read_event().unwrap(),
@@ -819,94 +743,14 @@ mod trim_text_start {
         );
         assert_eq!(reader.read_event().unwrap(), Event::Eof);
     }
-}
-
-mod trim_text_end {
-    use super::*;
-    use pretty_assertions::assert_eq;
-
-    #[test]
-    fn false_() {
-        let mut reader = Reader::from_str(XML);
-        reader.config_mut().trim_text_end = false;
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::DocType(BytesText::from_escaped("root \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Start(BytesStart::from_content("root \t\r\n", 4))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Empty(BytesStart::from_content("empty \t\r\n", 5))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\ntext \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::CData(BytesCData::new(" \t\r\ncdata \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::PI(BytesPI::new("pi \t\r\n"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::End(BytesEnd::new("root"))
-        );
-        assert_eq!(
-            reader.read_event().unwrap(),
-            Event::Text(BytesText::from_escaped(" \t\r\n"))
-        );
-
-        assert_eq!(reader.read_event().unwrap(), Event::Eof);
-    }
 
     // TODO: Enable test after rewriting parser
     #[test]
     #[ignore = "currently it is hard to fix incorrect behavior, but this will much easy after parser rewrite"]
-    fn true_() {
+    fn trim_text_end() {
         let mut reader = Reader::from_str(XML);
         reader.config_mut().trim_text_end = true;
+        assert_eq!(reader.config().trim_text_start, false);
 
         assert_eq!(
             reader.read_event().unwrap(),


### PR DESCRIPTION
\+ document a number of existing faults in the code, faulty tests, and incorrect documentation in the parser.