### PR TITLE
Remove implementation of traits that can confuse users because of lack well-defining meaning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -113,7 +113,7 @@ The MSRV has been raised to 1.86.
 - [#1002]: Added `Deserializer::resolver` and `Deserializer::resolver_mut` methods
   to get a namespace resolver used by this deserializer, because it no longer uses
   an `NsReader` internally.
-- [#1005]: Implement `Hash`, `PartialOrd`, and `Ord` across all `Bytes*` types.
+- [#1005]: Implement `Hash`, `PartialOrd`, and `Ord` for `BytesText` and `BytesCData` types.
 
 [#269]: https://github.com/tafia/quick-xml/issues/269
 [#331]: https://github.com/tafia/quick-xml/issues/331

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -95,7 +95,7 @@ use attributes::{AttrError, Attribute, Attributes};
 /// [`local_name`]: Self::local_name
 /// [`attributes`]: Self::attributes
 /// [`.into_owned()`]: Self::into_owned
-#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesStart<'i> {
     /// content of the element
     pub(crate) buf: Cow<'i, str>,
@@ -399,7 +399,7 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesStart<'i> {
 /// [`name`]: Self::name
 /// [`local_name`]: Self::local_name
 /// [`.into_owned()`]: Self::into_owned
-#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesEnd<'i> {
     name: Cow<'i, str>,
 }
@@ -1043,7 +1043,7 @@ impl FusedIterator for CDataIterator<'_> {}
 ///
 /// [PI]: https://www.w3.org/TR/xml11/#sec-pi
 /// [`.into_owned()`]: Self::into_owned
-#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesPI<'i> {
     content: BytesStart<'i>,
 }
@@ -1228,7 +1228,7 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesPI<'i> {
 /// using [`.into_owned()`].
 ///
 /// [`.into_owned()`]: Self::into_owned
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BytesDecl<'i> {
     content: BytesStart<'i>,
 }
@@ -1586,7 +1586,7 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesDecl<'i> {
 /// using [`.into_owned()`].
 ///
 /// [`.into_owned()`]: Self::into_owned
-#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesRef<'i> {
     content: Cow<'i, str>,
 }
@@ -1777,7 +1777,7 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesRef<'i> {
 ///
 /// [`Reader::read_event_into`]: crate::reader::Reader::read_event_into
 /// [`.into_owned()`]: Self::into_owned
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Event<'i> {
     /// Start tag (with attributes) `<tag attr="value">`.


### PR DESCRIPTION
As [discussed](https://github.com/tafia/quick-xml/pull/1005#pullrequestreview-5000009292) in #1005