### PR TITLE
Use dedicated type for Comment event

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,8 +25,11 @@
 
 ### Misc Changes
 
+- [#1009]: Split of `BytesComment` from `BytesText`.
+
 [#1005]: https://github.com/tafia/quick-xml/pull/1005
 [#1007]: https://github.com/tafia/quick-xml/pull/1007
+[#1009]: https://github.com/tafia/quick-xml/pull/1009
 
 
 ## 0.42.0 -- 2026-08-22

--- a/fuzz/fuzz_targets/fuzz_chunked_reader.rs
+++ b/fuzz/fuzz_targets/fuzz_chunked_reader.rs
@@ -25,11 +25,12 @@ fuzz_target!(|data: &[u8]| {
     // is not legal, and any capacity `>= data.len()` degenerates to the
     // Cursor case already covered by `fuzz_target_1`, so a small range is
     // both sufficient and the most efficient use of fuzz budget.
-    let Some((&cap_byte, xml)) = data.split_first() else { return };
+    let Some((&cap_byte, xml)) = data.split_first() else {
+        return;
+    };
     let capacity = (cap_byte as usize).max(1);
 
-    let mut reader =
-        Reader::from_reader(BufReader::with_capacity(capacity, Cursor::new(xml)));
+    let mut reader = Reader::from_reader(BufReader::with_capacity(capacity, Cursor::new(xml)));
     let mut buf = Vec::new();
     loop {
         // Touch the event payload enough to exercise the borrowed-data

--- a/fuzz/fuzz_targets/fuzz_chunked_reader.rs
+++ b/fuzz/fuzz_targets/fuzz_chunked_reader.rs
@@ -50,7 +50,10 @@ fuzz_target!(|data: &[u8]| {
                     }
                 }
             }
-            Ok(Event::Text(ref e)) | Ok(Event::Comment(ref e)) | Ok(Event::DocType(ref e)) => {
+            Ok(Event::Text(ref e)) | Ok(Event::DocType(ref e)) => {
+                let _ = black_box(e);
+            }
+            Ok(Event::Comment(ref e)) => {
                 let _ = black_box(e);
             }
             Ok(Event::CData(e)) => {

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -2,7 +2,7 @@
 use libfuzzer_sys::fuzz_target;
 use std::hint::black_box;
 
-use quick_xml::{events::Event, reader::Reader, writer::Writer, XmlVersion};
+use quick_xml::{XmlVersion, events::Event, reader::Reader, writer::Writer};
 use std::io::Cursor;
 
 macro_rules! debug_format {

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -42,7 +42,10 @@ where
                     }
                 }
             }
-            Ok(Event::Text(ref e)) | Ok(Event::Comment(ref e)) | Ok(Event::DocType(ref e)) => {
+            Ok(Event::Text(ref e)) | Ok(Event::DocType(ref e)) => {
+                debug_format!(e);
+            }
+            Ok(Event::Comment(ref e)) => {
                 debug_format!(e);
             }
             Ok(Event::CData(e)) => {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -80,6 +80,8 @@ use attributes::{AttrError, Attribute, Attributes};
 /// assert_eq!(reader.read_event().unwrap(), Event::Empty(event.borrow()));
 /// assert_eq!(reader.read_event().unwrap(), Event::Start(event.borrow()));
 /// // deref coercion of &BytesStart to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
 /// assert_eq!(event.as_ref(), content);
 /// ```
 ///
@@ -385,6 +387,8 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesStart<'i> {
 /// assert_eq!(reader.read_event().unwrap(), Event::End(event.borrow()));
 /// assert_eq!(event.name().as_ref(), content);
 /// // deref coercion of &BytesEnd to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
 /// assert_eq!(event.as_ref(), content);
 /// ```
 ///
@@ -520,6 +524,8 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesEnd<'i> {
 /// assert_eq!(reader.read_event().unwrap(), Event::Text(event.borrow()));
 /// assert_eq!(reader.read_event().unwrap(), Event::Comment(event.borrow()));
 /// // deref coercion of &BytesText to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
 /// assert_eq!(event.as_ref(), content);
 /// ```
 ///
@@ -743,6 +749,8 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesText<'i> {
 ///
 /// assert_eq!(reader.read_event().unwrap(), Event::CData(event.borrow()));
 /// // deref coercion of &BytesCData to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
 /// assert_eq!(event.as_ref(), content);
 /// ```
 ///
@@ -1030,6 +1038,8 @@ impl FusedIterator for CDataIterator<'_> {}
 ///
 /// assert_eq!(reader.read_event().unwrap(), Event::PI(event.borrow()));
 /// // deref coercion of &BytesPI to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
 /// assert_eq!(event.as_ref(), content);
 /// ```
 ///
@@ -1216,6 +1226,8 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesPI<'i> {
 ///
 /// assert_eq!(reader.read_event().unwrap(), Event::Decl(event.borrow()));
 /// // deref coercion of &BytesDecl to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
 /// assert_eq!(event.as_ref(), content);
 /// ```
 ///
@@ -1574,6 +1586,8 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesDecl<'i> {
 ///
 /// assert_eq!(reader.read_event().unwrap(), Event::GeneralRef(event.borrow()));
 /// // deref coercion of &BytesRef to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
 /// assert_eq!(event.as_ref(), content);
 /// ```
 ///

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -500,11 +500,9 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesEnd<'i> {
 /// Data from various events (most notably, `Event::Text`).
 ///
 /// This event implements `Deref<Target = str>`. The `deref()` implementation
-/// returns the content of this event. In case of comment this is everything
-/// between `<!--` and `-->` and the text of comment may not contain `-->` inside
-/// (if [`Config::check_comments`] is set to `true`).
-/// In case of DTD this is everything between `<!DOCTYPE` + spaces and closing `>`
-/// (i.e. in case of DTD the first character is never space):
+/// returns the content of this event. In case of DTD this is everything between
+/// `<!DOCTYPE` + spaces and closing `>` (i.e. in case of DTD the first character
+/// is never space):
 ///
 /// ```
 /// # use quick_xml::events::{BytesText, Event};
@@ -513,16 +511,14 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesEnd<'i> {
 /// // Remember, that \ at the end of string literal strips
 /// // all space characters to the first non-space character
 /// let mut reader = Reader::from_str("\
-///     <!DOCTYPE comment or text >\
-///     comment or text \
-///     <!--comment or text -->"
+///     <!DOCTYPE  text >\
+///     text "
 /// );
-/// let content = "comment or text ";
+/// let content = "text ";
 /// let event = BytesText::new(content);
 ///
 /// assert_eq!(reader.read_event().unwrap(), Event::DocType(event.borrow()));
 /// assert_eq!(reader.read_event().unwrap(), Event::Text(event.borrow()));
-/// assert_eq!(reader.read_event().unwrap(), Event::Comment(event.borrow()));
 /// // deref coercion of &BytesText to &str
 /// assert_eq!(&event as &str, content);
 /// // AsRef<str> for &T
@@ -537,7 +533,6 @@ impl<'i> arbitrary::Arbitrary<'i> for BytesEnd<'i> {
 /// If such event need to outlive the single parsing loop iteration, take ownership of the data
 /// using [`.into_owned()`].
 ///
-/// [`Config::check_comments`]: crate::reader::Config::check_comments
 /// [`.into_owned()`]: Self::into_owned
 #[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct BytesText<'i> {
@@ -1018,6 +1013,41 @@ impl<'a> Iterator for CDataIterator<'a> {
 }
 
 impl FusedIterator for CDataIterator<'_> {}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// A data between `<!--` and `-->` of an XML comment.
+///
+/// This event implements `Deref<Target = str>`. The `deref()` implementation
+/// returns the content of this event. This is everything between `<!--` and `-->`
+/// and the text of comment may not contain `--` inside (when [`Config::check_comments`] is set to `true`).
+///
+/// ```
+/// # use quick_xml::events::{BytesComment, Event};
+/// # use quick_xml::reader::Reader;
+/// # use pretty_assertions::assert_eq;
+/// let mut reader = Reader::from_str("<!--comment -- -->");
+/// let content = "comment -- ";
+/// let event = BytesComment::new(content);
+///
+/// assert_eq!(reader.read_event().unwrap(), Event::Comment(event.borrow()));
+/// // deref coercion of &BytesComment to &str
+/// assert_eq!(&event as &str, content);
+/// // AsRef<str> for &T
+/// assert_eq!(event.as_ref(), content);
+/// ```
+///
+/// # Lifetime
+///
+/// `'i` (stands of "input") is a lifetime of the original buffer from which event was parsed.
+/// In particular, when reader was created from a string, this is lifetime of the string.
+/// If event come from a buffered reader, this is lifetime of the user-provided buffer.
+/// If such event need to outlive the single parsing loop iteration, take ownership of the data
+/// using [`.into_owned()`].
+///
+/// [`Config::check_comments`]: crate::reader::Config::check_comments
+/// [`.into_owned()`]: Self::into_owned
+pub type BytesComment<'i> = BytesText<'i>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1805,7 +1835,7 @@ pub enum Event<'i> {
     /// Unescaped character data stored in `<![CDATA[...]]>`.
     CData(BytesCData<'i>),
     /// Comment `<!-- ... -->`.
-    Comment(BytesText<'i>),
+    Comment(BytesComment<'i>),
     /// XML declaration `<?xml ...?>`.
     Decl(BytesDecl<'i>),
     /// Processing instruction `<?...?>`.

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1028,7 +1028,7 @@ impl FusedIterator for CDataIterator<'_> {}
 /// # use pretty_assertions::assert_eq;
 /// let mut reader = Reader::from_str("<!--comment -- -->");
 /// let content = "comment -- ";
-/// let event = BytesComment::new(content);
+/// let event = BytesComment::new(content).unwrap();
 ///
 /// assert_eq!(reader.read_event().unwrap(), Event::Comment(event.borrow()));
 /// // deref coercion of &BytesComment to &str
@@ -1047,7 +1047,145 @@ impl FusedIterator for CDataIterator<'_> {}
 ///
 /// [`Config::check_comments`]: crate::reader::Config::check_comments
 /// [`.into_owned()`]: Self::into_owned
-pub type BytesComment<'i> = BytesText<'i>;
+#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct BytesComment<'i> {
+    content: BytesText<'i>,
+}
+
+impl<'i> BytesComment<'i> {
+    /// Creates a new `BytesComment` from a string as it appeared in the XML source.
+    #[inline]
+    pub(crate) const fn wrap(content: &'i str) -> Self {
+        Self {
+            content: BytesText::wrap(content),
+        }
+    }
+
+    /// Creates a new comment from a string. Returns error if `content` contains the `-->` sequence,
+    /// with the position of `-->`.
+    ///
+    /// ```
+    /// # use quick_xml::events::BytesComment;
+    /// #
+    /// assert!(BytesComment::new("--").is_ok());
+    /// assert!(matches!(BytesComment::new("illegal -->"), Err(8)));
+    /// ```
+    #[inline]
+    pub fn new(content: &'i str) -> Result<Self, usize> {
+        match content.find("-->") {
+            Some(p) => Err(p),
+            None => Ok(Self::wrap(content)),
+        }
+    }
+
+    /// Ensures that all data is owned to extend the object's lifetime if necessary.
+    #[inline]
+    pub fn into_owned(self) -> BytesComment<'static> {
+        BytesComment {
+            content: self.content.into_owned(),
+        }
+    }
+
+    /// Extracts the inner `Cow` from the `BytesComment` event container.
+    #[inline]
+    pub fn into_inner(self) -> Cow<'i, str> {
+        self.content.into_inner()
+    }
+
+    /// Converts the event into a borrowed event.
+    #[inline]
+    pub fn borrow(&self) -> BytesComment<'_> {
+        BytesComment {
+            content: self.content.borrow(),
+        }
+    }
+
+    /// Returns the content of the XML 1.0 or HTML event with EOL normalization applied.
+    ///
+    /// This will allocate if EOL normalization is required.
+    ///
+    /// Note, that this method should be used only if event represents XML 1.0 or HTML content,
+    /// because rules for normalizing EOLs for [XML 1.0] / [HTML] and [XML 1.1] differs.
+    ///
+    /// This method also can be used to get HTML content, because rules the same.
+    ///
+    /// [XML 1.0]: https://www.w3.org/TR/xml/#sec-line-ends
+    /// [XML 1.1]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    #[inline]
+    pub fn xml10_content(&self) -> Cow<'i, str> {
+        self.content.xml10_content()
+    }
+
+    /// Returns the content of the XML 1.1 event with EOL normalization applied.
+    ///
+    /// This will allocate if EOL normalization is required.
+    ///
+    /// Note, that this method should be used only if event represents XML 1.1 content,
+    /// because rules for normalizing EOLs for [XML 1.0], [XML 1.1] and [HTML] differs.
+    ///
+    /// To get HTML content use [`xml10_content()`](Self::xml10_content).
+    ///
+    /// [XML 1.0]: https://www.w3.org/TR/xml/#sec-line-ends
+    /// [XML 1.1]: https://www.w3.org/TR/xml11/#sec-line-ends
+    /// [HTML]: https://html.spec.whatwg.org/#normalize-newlines
+    #[inline]
+    pub fn xml11_content(&self) -> Cow<'i, str> {
+        self.content.xml11_content()
+    }
+
+    /// Returns the content of the XML event with EOL normalization applied
+    /// according to the specified version.
+    ///
+    /// This will allocate if EOL normalization is required.
+    #[inline]
+    pub fn xml_content(&self, version: XmlVersion) -> Cow<'i, str> {
+        self.content.xml_content(version)
+    }
+
+    /// Alias for [`xml10_content()`](Self::xml10_content).
+    #[inline]
+    pub fn html_content(&self) -> Cow<'i, str> {
+        self.content.html_content()
+    }
+}
+
+impl<'i> Debug for BytesComment<'i> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "BytesComment {{ content: ")?;
+        write_cow_string(f, &self.content.content)?;
+        write!(f, " }}")
+    }
+}
+
+impl<'i> Deref for BytesComment<'i> {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.content
+    }
+}
+
+impl AsRef<str> for BytesComment<'_> {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'i> arbitrary::Arbitrary<'i> for BytesComment<'i> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'i>) -> arbitrary::Result<Self> {
+        let s = <&str>::arbitrary(u)?;
+        if !s.chars().all(char::is_alphanumeric) {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+        Self::new(s).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <&str as arbitrary::Arbitrary>::size_hint(depth)
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -2086,7 +2086,7 @@ mod test {
 
             /// Ensures, that no empty `Text` events are generated
             mod $read_event {
-                use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event};
+                use crate::events::{BytesCData, BytesComment, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event};
                 use crate::reader::Reader;
                 use pretty_assertions::assert_eq;
 
@@ -2212,7 +2212,7 @@ mod test {
 
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Comment(BytesText::from_escaped(""))
+                        Event::Comment(BytesComment::from_escaped(""))
                     );
                 }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -2212,7 +2212,7 @@ mod test {
 
                     assert_eq!(
                         reader.$read_event($buf) $(.$await)? .unwrap(),
-                        Event::Comment(BytesComment::from_escaped(""))
+                        Event::Comment(BytesComment::new("").unwrap())
                     );
                 }
 

--- a/src/reader/state.rs
+++ b/src/reader/state.rs
@@ -5,7 +5,9 @@ use std::fmt::Debug;
 use encoding_rs::UTF_8;
 
 use crate::errors::{Error, IllFormedError, Result};
-use crate::events::{BytesCData, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event};
+use crate::events::{
+    BytesCData, BytesComment, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event,
+};
 use crate::parser::{Parser, PiParser};
 #[cfg(feature = "encoding")]
 use crate::reader::EncodingRef;
@@ -136,7 +138,7 @@ impl ReaderState {
                         haystack = &haystack[p + 1..];
                     }
                 }
-                Ok(Event::Comment(BytesText::wrap(
+                Ok(Event::Comment(BytesComment::wrap(
                     // Cut of `<!--` and `-->` from start and end
                     &buf[4..len - 3],
                 )))

--- a/src/writer/async_tokio.rs
+++ b/src/writer/async_tokio.rs
@@ -345,7 +345,7 @@ mod tests {
 
     test!(
         comment,
-        Event::Comment(BytesText::new("this is a comment")),
+        Event::Comment(BytesComment::new("this is a comment")),
         r#"<!--this is a comment-->"#
     );
 

--- a/src/writer/async_tokio.rs
+++ b/src/writer/async_tokio.rs
@@ -345,7 +345,7 @@ mod tests {
 
     test!(
         comment,
-        Event::Comment(BytesComment::new("this is a comment")),
+        Event::Comment(BytesComment::new("this is a comment").unwrap()),
         r#"<!--this is a comment-->"#
     );
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -120,7 +120,7 @@ macro_rules! small_buffers_tests {
 
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                    Event::Comment(BytesComment::new("comment"))
+                    Event::Comment(BytesComment::new("comment").unwrap())
                 );
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -139,7 +139,7 @@ macro_rules! small_buffers_tests {
 
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                    Event::Comment(BytesComment::new("comment"))
+                    Event::Comment(BytesComment::new("comment").unwrap())
                 );
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -10,7 +10,7 @@ macro_rules! small_buffers_tests {
         $(, $async:ident, $await:ident)?
     ) => {
         mod small_buffers {
-            use quick_xml::events::{BytesCData, BytesDecl, BytesPI, BytesStart, BytesText, Event};
+            use quick_xml::events::{BytesCData, BytesComment, BytesDecl, BytesPI, BytesStart, Event};
             use quick_xml::reader::Reader;
             use pretty_assertions::assert_eq;
 
@@ -120,7 +120,7 @@ macro_rules! small_buffers_tests {
 
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                    Event::Comment(BytesText::new("comment"))
+                    Event::Comment(BytesComment::new("comment"))
                 );
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),
@@ -139,7 +139,7 @@ macro_rules! small_buffers_tests {
 
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),
-                    Event::Comment(BytesText::new("comment"))
+                    Event::Comment(BytesComment::new("comment"))
                 );
                 assert_eq!(
                     reader.$read_event(&mut buf) $(.$await)? .unwrap(),

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -279,7 +279,7 @@ mod issue604 {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Event::Comment(BytesComment::from_escaped(">"))
+            Event::Comment(BytesComment::new(">").unwrap())
         );
         assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
     }
@@ -297,7 +297,7 @@ mod issue604 {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Event::Comment(BytesComment::from_escaped("->"))
+            Event::Comment(BytesComment::new("->").unwrap())
         );
         assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
     }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -7,7 +7,7 @@ use std::iter;
 use std::sync::mpsc;
 
 use quick_xml::errors::{Error, IllFormedError, SyntaxError};
-use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::events::{BytesComment, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::name::{Namespace, QName, ResolveResult};
 use quick_xml::reader::{NsReader, Reader};
 use quick_xml::utils::Bytes;
@@ -279,7 +279,7 @@ mod issue604 {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Event::Comment(BytesText::from_escaped(">"))
+            Event::Comment(BytesComment::from_escaped(">"))
         );
         assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
     }
@@ -297,7 +297,7 @@ mod issue604 {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Event::Comment(BytesText::from_escaped("->"))
+            Event::Comment(BytesComment::from_escaped("->"))
         );
         assert_eq!(reader.read_event_into(&mut buf).unwrap(), Event::Eof);
     }

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -139,7 +139,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(""))
+                Event::Comment(BytesComment::new("").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -155,7 +155,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(" comment "))
+                Event::Comment(BytesComment::new(" comment ").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -171,7 +171,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(" comment -- "))
+                Event::Comment(BytesComment::new(" comment -- ").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -187,7 +187,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(" comment -"))
+                Event::Comment(BytesComment::new(" comment -").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -203,7 +203,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(">"))
+                Event::Comment(BytesComment::new(">").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -219,7 +219,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped("->"))
+                Event::Comment(BytesComment::new("->").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -249,7 +249,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(""))
+                Event::Comment(BytesComment::new("").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -265,7 +265,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(" comment "))
+                Event::Comment(BytesComment::new(" comment ").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -319,7 +319,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(">"))
+                Event::Comment(BytesComment::new(">").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -335,7 +335,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped("->"))
+                Event::Comment(BytesComment::new("->").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -626,7 +626,7 @@ mod trim_text {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::new(" comment \t\r\n").unwrap())
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -698,7 +698,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::new(" comment \t\r\n").unwrap())
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -744,7 +744,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::new(" comment \t\r\n").unwrap())
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -791,7 +791,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::new(" comment \t\r\n").unwrap())
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -871,7 +871,7 @@ mod trim_text {
             );
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesComment::from_escaped(" comment "))
+                Event::Comment(BytesComment::new(" comment ").unwrap())
             );
             assert_eq!(
                 reader.read_event().unwrap(),

--- a/tests/reader-config.rs
+++ b/tests/reader-config.rs
@@ -6,7 +6,9 @@
 //! Please keep tests sorted (exceptions are allowed if options are tightly related).
 
 use quick_xml::errors::{Error, IllFormedError};
-use quick_xml::events::{BytesCData, BytesEnd, BytesPI, BytesRef, BytesStart, BytesText, Event};
+use quick_xml::events::{
+    BytesCData, BytesComment, BytesEnd, BytesPI, BytesRef, BytesStart, BytesText, Event,
+};
 use quick_xml::reader::Reader;
 
 mod allow_dangling_amp {
@@ -137,7 +139,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(""))
+                Event::Comment(BytesComment::from_escaped(""))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -153,7 +155,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(" comment "))
+                Event::Comment(BytesComment::from_escaped(" comment "))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -169,7 +171,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(" comment -- "))
+                Event::Comment(BytesComment::from_escaped(" comment -- "))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -185,7 +187,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(" comment -"))
+                Event::Comment(BytesComment::from_escaped(" comment -"))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -201,7 +203,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(">"))
+                Event::Comment(BytesComment::from_escaped(">"))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -217,7 +219,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped("->"))
+                Event::Comment(BytesComment::from_escaped("->"))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -247,7 +249,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(""))
+                Event::Comment(BytesComment::from_escaped(""))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -263,7 +265,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(" comment "))
+                Event::Comment(BytesComment::from_escaped(" comment "))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -317,7 +319,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(">"))
+                Event::Comment(BytesComment::from_escaped(">"))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -333,7 +335,7 @@ mod check_comments {
 
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped("->"))
+                Event::Comment(BytesComment::from_escaped("->"))
             );
             assert_eq!(
                 reader.read_event().unwrap(),
@@ -624,7 +626,7 @@ mod trim_text {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -696,7 +698,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -742,7 +744,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -789,7 +791,7 @@ mod trim_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesText::from_escaped(" comment \t\r\n"))
+            Event::Comment(BytesComment::from_escaped(" comment \t\r\n"))
         );
         assert_eq!(
             reader.read_event().unwrap(),
@@ -869,7 +871,7 @@ mod trim_text {
             );
             assert_eq!(
                 reader.read_event().unwrap(),
-                Event::Comment(BytesText::from_escaped(" comment "))
+                Event::Comment(BytesComment::from_escaped(" comment "))
             );
             assert_eq!(
                 reader.read_event().unwrap(),

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -100,8 +100,8 @@ mod syntax {
         syntax_err!(unclosed09(".<!--->") => SyntaxError::UnclosedComment);
         syntax_err!(unclosed10(".<!---c") => SyntaxError::UnclosedComment);
 
-        event_ok!(normal1("<!---->")     => 7: Event::Comment(BytesComment::new("")));
-        event_ok!(normal2("<!---->rest") => 7: Event::Comment(BytesComment::new("")));
+        event_ok!(normal1("<!---->")     => 7: Event::Comment(BytesComment::new("").unwrap()));
+        event_ok!(normal2("<!---->rest") => 7: Event::Comment(BytesComment::new("").unwrap()));
     }
 
     /// https://www.w3.org/TR/xml11/#NT-CDSect
@@ -645,7 +645,7 @@ mod ill_formed {
         found: "end".to_string(),
     });
 
-    event_ok!(double_hyphen_in_comment1("<!---->") => 7: Event::Comment(BytesComment::new("")));
+    event_ok!(double_hyphen_in_comment1("<!---->") => 7: Event::Comment(BytesComment::new("").unwrap()));
     err!(double_hyphen_in_comment2("<!----->") => 4: IllFormedError::DoubleHyphenInComment);
     //                                  ^= 4
     err!(double_hyphen_in_comment3("<!-- --->") => 5: IllFormedError::DoubleHyphenInComment);

--- a/tests/reader-errors.rs
+++ b/tests/reader-errors.rs
@@ -1,7 +1,9 @@
 //! Contains tests that produces errors during parsing XML.
 
 use quick_xml::errors::{Error, SyntaxError};
-use quick_xml::events::{BytesCData, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event};
+use quick_xml::events::{
+    BytesCData, BytesComment, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event,
+};
 use quick_xml::reader::{NsReader, Reader};
 
 // For event_ok and syntax_err macros
@@ -98,8 +100,8 @@ mod syntax {
         syntax_err!(unclosed09(".<!--->") => SyntaxError::UnclosedComment);
         syntax_err!(unclosed10(".<!---c") => SyntaxError::UnclosedComment);
 
-        event_ok!(normal1("<!---->")     => 7: Event::Comment(BytesText::new("")));
-        event_ok!(normal2("<!---->rest") => 7: Event::Comment(BytesText::new("")));
+        event_ok!(normal1("<!---->")     => 7: Event::Comment(BytesComment::new("")));
+        event_ok!(normal2("<!---->rest") => 7: Event::Comment(BytesComment::new("")));
     }
 
     /// https://www.w3.org/TR/xml11/#NT-CDSect
@@ -643,7 +645,7 @@ mod ill_formed {
         found: "end".to_string(),
     });
 
-    event_ok!(double_hyphen_in_comment1("<!---->") => 7: Event::Comment(BytesText::new("")));
+    event_ok!(double_hyphen_in_comment1("<!---->") => 7: Event::Comment(BytesComment::new("")));
     err!(double_hyphen_in_comment2("<!----->") => 4: IllFormedError::DoubleHyphenInComment);
     //                                  ^= 4
     err!(double_hyphen_in_comment3("<!-- --->") => 5: IllFormedError::DoubleHyphenInComment);

--- a/tests/reader-namespaces.rs
+++ b/tests/reader-namespaces.rs
@@ -2,7 +2,7 @@ use pretty_assertions::assert_eq;
 use quick_xml::events::Event::*;
 use quick_xml::events::attributes::Attribute;
 use quick_xml::events::{
-    BytesCData, BytesDecl, BytesEnd, BytesPI, BytesRef, BytesStart, BytesText,
+    BytesCData, BytesComment, BytesDecl, BytesEnd, BytesPI, BytesRef, BytesStart, BytesText,
 };
 use quick_xml::name::ResolveResult::*;
 use quick_xml::name::{Namespace, PrefixDeclaration, QName};
@@ -609,7 +609,7 @@ mod read_to_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesText::new("comment"))
+            Comment(BytesComment::new("comment"))
         );
         assert_eq!(
             reader.read_to_end(QName("root")).unwrap(),
@@ -953,7 +953,7 @@ mod read_to_end_into {
         );
         assert_eq!(
             reader.read_event_into(buf).unwrap(),
-            Comment(BytesText::new("comment"))
+            Comment(BytesComment::new("comment"))
         );
         assert_eq!(
             reader.read_to_end_into(QName("root"), buf).unwrap(),
@@ -1299,7 +1299,7 @@ mod read_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesText::new("comment"))
+            Comment(BytesComment::new("comment"))
         );
         assert_eq!(
             reader.read_text(QName("root")).unwrap(),
@@ -1646,7 +1646,7 @@ mod read_text_into {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Comment(BytesText::new("comment"))
+            Comment(BytesComment::new("comment"))
         );
         assert_eq!(
             reader.read_text_into(QName("root"), &mut buf).unwrap(),

--- a/tests/reader-namespaces.rs
+++ b/tests/reader-namespaces.rs
@@ -609,7 +609,7 @@ mod read_to_end {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesComment::new("comment"))
+            Comment(BytesComment::new("comment").unwrap())
         );
         assert_eq!(
             reader.read_to_end(QName("root")).unwrap(),
@@ -953,7 +953,7 @@ mod read_to_end_into {
         );
         assert_eq!(
             reader.read_event_into(buf).unwrap(),
-            Comment(BytesComment::new("comment"))
+            Comment(BytesComment::new("comment").unwrap())
         );
         assert_eq!(
             reader.read_to_end_into(QName("root"), buf).unwrap(),
@@ -1299,7 +1299,7 @@ mod read_text {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesComment::new("comment"))
+            Comment(BytesComment::new("comment").unwrap())
         );
         assert_eq!(
             reader.read_text(QName("root")).unwrap(),
@@ -1646,7 +1646,7 @@ mod read_text_into {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Comment(BytesComment::new("comment"))
+            Comment(BytesComment::new("comment").unwrap())
         );
         assert_eq!(
             reader.read_text_into(QName("root"), &mut buf).unwrap(),

--- a/tests/reader-read-text.rs
+++ b/tests/reader-read-text.rs
@@ -116,7 +116,7 @@ mod borrowed {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesComment::new("comment"))
+            Event::Comment(BytesComment::new("comment").unwrap())
         );
         assert_eq!(
             reader.read_text(QName("root")).unwrap(),
@@ -433,7 +433,7 @@ mod buffered {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Event::Comment(BytesComment::new("comment"))
+            Event::Comment(BytesComment::new("comment").unwrap())
         );
         assert_eq!(
             reader.read_text_into(QName("root"), &mut buf).unwrap(),

--- a/tests/reader-read-text.rs
+++ b/tests/reader-read-text.rs
@@ -1,4 +1,6 @@
-use quick_xml::events::{BytesCData, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event};
+use quick_xml::events::{
+    BytesCData, BytesComment, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event,
+};
 use quick_xml::name::QName;
 use quick_xml::reader::Reader;
 
@@ -114,7 +116,7 @@ mod borrowed {
         );
         assert_eq!(
             reader.read_event().unwrap(),
-            Event::Comment(BytesText::new("comment"))
+            Event::Comment(BytesComment::new("comment"))
         );
         assert_eq!(
             reader.read_text(QName("root")).unwrap(),
@@ -431,7 +433,7 @@ mod buffered {
         );
         assert_eq!(
             reader.read_event_into(&mut buf).unwrap(),
-            Event::Comment(BytesText::new("comment"))
+            Event::Comment(BytesComment::new("comment"))
         );
         assert_eq!(
             reader.read_text_into(QName("root"), &mut buf).unwrap(),

--- a/tests/reader-references.rs
+++ b/tests/reader-references.rs
@@ -63,7 +63,7 @@ mod character_reference {
 
                 assert_eq!(
                     reader.read_event().unwrap(),
-                    Comment(BytesComment::from_escaped(&format!("&{i};"))),
+                    Comment(BytesComment::new(&format!("&{i};")).unwrap()),
                     "Character reference {i}=0x{i:x}: {input}"
                 );
             }
@@ -205,7 +205,7 @@ mod character_reference {
 
                 assert_eq!(
                     reader.read_event().unwrap(),
-                    Comment(BytesComment::from_escaped(&format!("&#{i:x};"))),
+                    Comment(BytesComment::new(&format!("&#{i:x};")).unwrap()),
                     "Character reference {i}=0x{i:x}: {input}"
                 );
             }
@@ -339,7 +339,7 @@ mod general_entity_reference {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesComment::from_escaped("&entity;")),
+            Comment(BytesComment::new("&entity;").unwrap()),
         );
     }
 
@@ -459,7 +459,7 @@ mod parameter_entity_reference {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesComment::from_escaped("%param;")),
+            Comment(BytesComment::new("%param;").unwrap()),
         );
     }
 

--- a/tests/reader-references.rs
+++ b/tests/reader-references.rs
@@ -1,5 +1,6 @@
+use quick_xml::events::Event::*;
 use quick_xml::events::{
-    BytesCData, BytesDecl, BytesEnd, BytesPI, BytesRef, BytesStart, BytesText, Event::*,
+    BytesCData, BytesComment, BytesDecl, BytesEnd, BytesPI, BytesRef, BytesStart, BytesText,
 };
 use quick_xml::reader::Reader;
 
@@ -62,7 +63,7 @@ mod character_reference {
 
                 assert_eq!(
                     reader.read_event().unwrap(),
-                    Comment(BytesText::from_escaped(&format!("&{i};"))),
+                    Comment(BytesComment::from_escaped(&format!("&{i};"))),
                     "Character reference {i}=0x{i:x}: {input}"
                 );
             }
@@ -204,7 +205,7 @@ mod character_reference {
 
                 assert_eq!(
                     reader.read_event().unwrap(),
-                    Comment(BytesText::from_escaped(&format!("&#{i:x};"))),
+                    Comment(BytesComment::from_escaped(&format!("&#{i:x};"))),
                     "Character reference {i}=0x{i:x}: {input}"
                 );
             }
@@ -338,7 +339,7 @@ mod general_entity_reference {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesText::from_escaped("&entity;")),
+            Comment(BytesComment::from_escaped("&entity;")),
         );
     }
 
@@ -458,7 +459,7 @@ mod parameter_entity_reference {
 
         assert_eq!(
             reader.read_event().unwrap(),
-            Comment(BytesText::from_escaped("%param;")),
+            Comment(BytesComment::from_escaped("%param;")),
         );
     }
 

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -1,4 +1,5 @@
-use quick_xml::events::{BytesCData, BytesEnd, BytesRef, BytesStart, BytesText, Event::*};
+use quick_xml::events::Event::*;
+use quick_xml::events::{BytesCData, BytesComment, BytesEnd, BytesRef, BytesStart, BytesText};
 use quick_xml::name::QName;
 use quick_xml::reader::Reader;
 
@@ -64,7 +65,7 @@ fn test_start_end_comment() {
         r.read_event().unwrap(),
         Empty(BytesStart::from_content("a  ", 1))
     );
-    assert_eq!(r.read_event().unwrap(), Comment(BytesText::new("t")));
+    assert_eq!(r.read_event().unwrap(), Comment(BytesComment::new("t")));
     assert_eq!(r.read_event().unwrap(), End(BytesEnd::new("b")));
 }
 
@@ -81,7 +82,7 @@ fn test_start_txt_end() {
 fn test_comment() {
     let mut r = Reader::from_str("<!--test-->");
 
-    assert_eq!(r.read_event().unwrap(), Comment(BytesText::new("test")));
+    assert_eq!(r.read_event().unwrap(), Comment(BytesComment::new("test")));
 }
 
 #[test]

--- a/tests/reader.rs
+++ b/tests/reader.rs
@@ -65,7 +65,10 @@ fn test_start_end_comment() {
         r.read_event().unwrap(),
         Empty(BytesStart::from_content("a  ", 1))
     );
-    assert_eq!(r.read_event().unwrap(), Comment(BytesComment::new("t")));
+    assert_eq!(
+        r.read_event().unwrap(),
+        Comment(BytesComment::new("t").unwrap())
+    );
     assert_eq!(r.read_event().unwrap(), End(BytesEnd::new("b")));
 }
 
@@ -82,7 +85,10 @@ fn test_start_txt_end() {
 fn test_comment() {
     let mut r = Reader::from_str("<!--test-->");
 
-    assert_eq!(r.read_event().unwrap(), Comment(BytesComment::new("test")));
+    assert_eq!(
+        r.read_event().unwrap(),
+        Comment(BytesComment::new("test").unwrap())
+    );
 }
 
 #[test]

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -195,9 +195,9 @@ fn cdata() {
 fn comment() {
     let mut writer = Writer::new(Vec::new());
     writer
-        .write_event(Comment(BytesComment::from_escaped(
-            "Kerrigan & Raynor: The Z[erg] programming language",
-        )))
+        .write_event(Comment(
+            BytesComment::new("Kerrigan & Raynor: The Z[erg] programming language").unwrap(),
+        ))
         .expect("writing comment should succeed");
 
     let result = writer.into_inner();

--- a/tests/writer.rs
+++ b/tests/writer.rs
@@ -1,5 +1,6 @@
+use quick_xml::events::Event::*;
 use quick_xml::events::{
-    BytesCData, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText, Event::*,
+    BytesCData, BytesComment, BytesDecl, BytesEnd, BytesPI, BytesStart, BytesText,
 };
 use quick_xml::writer::Writer;
 
@@ -194,7 +195,7 @@ fn cdata() {
 fn comment() {
     let mut writer = Writer::new(Vec::new());
     writer
-        .write_event(Comment(BytesText::from_escaped(
+        .write_event(Comment(BytesComment::from_escaped(
             "Kerrigan & Raynor: The Z[erg] programming language",
         )))
         .expect("writing comment should succeed");


### PR DESCRIPTION
The dedicated type provides two improvements:
- it is validated at creation time that comment does not contain `-->` inside
- it may contain comment-specific methods (I plan to add `.validate()` method for Validation API that will check for absence of `--` inside)