### PR TITLE
perf: add #[inline] to Reader::read_event_impl chain (fixes #678)

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -1003,6 +1003,7 @@ impl<R> Reader<R> {
     /// Read text into the given buffer, and return an event that borrows from
     /// either that buffer or from the input itself, based on the type of the
     /// reader.
+    #[inline]
     fn read_event_impl<'i, B>(&mut self, mut buf: B) -> Result<Event<'i>, Error>
     where
         R: XmlSource<'i, B>,
@@ -1012,6 +1013,7 @@ impl<R> Reader<R> {
 
     /// Private function to read until `>` is found. This function expects that
     /// it was called just after encounter a `<` symbol.
+    #[inline]
     fn read_until_close<'i, B>(&mut self, buf: B) -> Result<Event<'i>, Error>
     where
         R: XmlSource<'i, B>,


### PR DESCRIPTION
Fixes #678

Non-cascaded `#[inline]` breaks cross-crate inlining. `read_event_into` (src/reader/mod.rs:411) has `#[inline]` but calls `read_event_impl` (src/reader/mod.rs:1006) and `read_until_close` (src/reader/mod.rs:1013) without it.

Bench on 1.3GB XML (from #678, Xeon, 10 runs):
- master 5.94s
- +#[inline] 5.23s (-12%)
- +#[inline(always)] 4.23s (-28%)
Even with lto=true: 4.62s -> 4.14s (-10%)

This PR adds `#[inline]` (not always) to keep binary size conservative, matching maintainer preference.

Verif:
- `cargo test --lib` pass (hot 8s)
- `cargo bench --bench microbenches -- "read_event" --sample-size 10` shows improvement on sample_rss.xml:194K

Related: #405, #718