### PR TITLE
perf: SIMD accelerate escape routines with memchr (fixes #405)

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -154,7 +154,7 @@ impl std::error::Error for EscapeError {
 /// | `"`       | `&quot;`
 /// | `\r`      | `&#13;`
 pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, find_escape6)
+    _escape(raw.into(), find_escape6)
 }
 
 /// Escapes an `&str` and replaces xml special characters (`<`, `>`, `&`)
@@ -173,7 +173,7 @@ pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `&`       | `&amp;`
 /// | `\r`      | `&#13;`
 pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, find_escape4)
+    _escape(raw.into(), find_escape4)
 }
 
 /// XML standard [requires] that only `<` and `&` was escaped in text content or
@@ -192,7 +192,7 @@ pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 ///
 /// [requires]: https://www.w3.org/TR/xml11/#syntax
 pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, find_escape3)
+    _escape(raw.into(), find_escape3)
 }
 
 /// Escapes a `&str` for use in an XML attribute value. In addition to the
@@ -212,7 +212,7 @@ pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `\n`      | `&#10;`
 /// | `\t`      | `&#9;`
 pub(crate) fn escape_attribute<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, find_escape8)
+    _escape(raw.into(), find_escape8)
 }
 
 pub(crate) fn escape_char<W>(writer: &mut W, value: &str, from: usize, to: usize) -> fmt::Result
@@ -239,8 +239,10 @@ where
 }
 
 /// Escapes an `&str` using SIMD search `find` to locate next char needing escape.
-fn _escape<'a>(raw: impl Into<Cow<'a, str>>, find: fn(&[u8]) -> Option<usize>) -> Cow<'a, str> {
-    let raw = raw.into();
+fn _escape<'a, F>(raw: Cow<'a, str>, find: F) -> Cow<'a, str>
+where
+    F: Fn(&[u8]) -> Option<usize>,
+{
     let bytes = raw.as_bytes();
     let mut escaped = None;
     let mut pos = 0;

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -104,6 +104,7 @@ impl std::error::Error for EscapeError {
 /// | `'`       | `&apos;`
 /// | `"`       | `&quot;`
 /// | `\r`      | `&#13;`
+#[allow(missing_docs)]
 #[inline]
 fn find_escape6(bytes: &[u8]) -> Option<usize> {
     let a = memchr3(b'<', b'>', b'&', bytes);
@@ -115,6 +116,7 @@ fn find_escape6(bytes: &[u8]) -> Option<usize> {
         (None, None) => None,
     }
 }
+#[allow(missing_docs)]
 #[inline]
 fn find_escape4(bytes: &[u8]) -> Option<usize> {
     let a = memchr3(b'<', b'>', b'&', bytes);
@@ -126,10 +128,12 @@ fn find_escape4(bytes: &[u8]) -> Option<usize> {
         (None, None) => None,
     }
 }
+#[allow(missing_docs)]
 #[inline]
 fn find_escape3(bytes: &[u8]) -> Option<usize> {
     memchr3(b'<', b'&', b'\r', bytes)
 }
+#[allow(missing_docs)]
 #[inline]
 fn find_escape8(bytes: &[u8]) -> Option<usize> {
     let a = memchr3(b'<', b'>', b'&', bytes);
@@ -264,6 +268,7 @@ fn _escape<'a, F: Fn(u8) -> bool>(raw: impl Into<Cow<'a, str>>, escape_chars: F)
     }
 }
 
+#[allow(missing_docs)]
 fn _escape_with<'a>(raw: impl Into<Cow<'a, str>>, find: fn(&[u8]) -> Option<usize>) -> Cow<'a, str> {
     let raw = raw.into();
     let bytes = raw.as_bytes();

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,6 +1,6 @@
 //! Manage xml character escapes
 
-use memchr::{memchr, memchr2_iter, memchr3};
+use memchr::{memchr, memchr2, memchr2_iter, memchr3};
 use std::borrow::Cow;
 use std::fmt::{self, Write};
 use std::num::ParseIntError;
@@ -104,10 +104,53 @@ impl std::error::Error for EscapeError {
 /// | `'`       | `&apos;`
 /// | `"`       | `&quot;`
 /// | `\r`      | `&#13;`
+#[inline]
+fn find_escape6(bytes: &[u8]) -> Option<usize> {
+    let a = memchr3(b'<', b'>', b'&', bytes);
+    let b = memchr3(b'\'', b'"', b'\r', bytes);
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    }
+}
+#[inline]
+fn find_escape4(bytes: &[u8]) -> Option<usize> {
+    let a = memchr3(b'<', b'>', b'&', bytes);
+    let b = memchr(b'\r', bytes);
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    }
+}
+#[inline]
+fn find_escape3(bytes: &[u8]) -> Option<usize> {
+    memchr3(b'<', b'&', b'\r', bytes)
+}
+#[inline]
+fn find_escape8(bytes: &[u8]) -> Option<usize> {
+    let a = memchr3(b'<', b'>', b'&', bytes);
+    let b = memchr3(b'\'', b'"', b'\r', bytes);
+    let c = memchr2(b'\n', b'\t', bytes);
+    let ab = match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    };
+    match (ab, c) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    }
+}
+
 pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, |ch| {
-        matches!(ch, b'<' | b'>' | b'&' | b'\'' | b'\"' | b'\r')
-    })
+    _escape_with(raw, find_escape6)
 }
 
 /// Escapes an `&str` and replaces xml special characters (`<`, `>`, `&`)
@@ -126,7 +169,7 @@ pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `&`       | `&amp;`
 /// | `\r`      | `&#13;`
 pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, |ch| matches!(ch, b'<' | b'>' | b'&' | b'\r'))
+    _escape_with(raw, find_escape4)
 }
 
 /// XML standard [requires] that only `<` and `&` was escaped in text content or
@@ -145,7 +188,7 @@ pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 ///
 /// [requires]: https://www.w3.org/TR/xml11/#syntax
 pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, |ch| matches!(ch, b'<' | b'&' | b'\r'))
+    _escape_with(raw, find_escape3)
 }
 
 /// Escapes a `&str` for use in an XML attribute value. In addition to the
@@ -165,12 +208,7 @@ pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `\n`      | `&#10;`
 /// | `\t`      | `&#9;`
 pub(crate) fn escape_attribute<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape(raw, |ch| {
-        matches!(
-            ch,
-            b'<' | b'>' | b'&' | b'\'' | b'\"' | b'\r' | b'\n' | b'\t'
-        )
-    })
+    _escape_with(raw, find_escape8)
 }
 
 pub(crate) fn escape_char<W>(writer: &mut W, value: &str, from: usize, to: usize) -> fmt::Result
@@ -215,6 +253,32 @@ fn _escape<'a, F: Fn(u8) -> bool>(raw: impl Into<Cow<'a, str>>, escape_chars: F)
         pos = new_pos + 1;
     }
 
+    if let Some(mut escaped) = escaped {
+        if let Some(raw) = raw.get(pos..) {
+            // SAFETY: It should fail only on OOM
+            escaped.write_str(raw).unwrap();
+        }
+        Cow::Owned(escaped)
+    } else {
+        raw
+    }
+}
+
+fn _escape_with<'a>(raw: impl Into<Cow<'a, str>>, find: fn(&[u8]) -> Option<usize>) -> Cow<'a, str> {
+    let raw = raw.into();
+    let bytes = raw.as_bytes();
+    let mut escaped = None;
+    let mut pos = 0;
+    while let Some(i) = find(&bytes[pos..]) {
+        if escaped.is_none() {
+            escaped = Some(String::with_capacity(raw.len()));
+        }
+        let escaped = escaped.as_mut().expect("initialized");
+        let new_pos = pos + i;
+        // SAFETY: It should fail only on OOM
+        escape_char(escaped, &raw, pos, new_pos).unwrap();
+        pos = new_pos + 1;
+    }
     if let Some(mut escaped) = escaped {
         if let Some(raw) = raw.get(pos..) {
             // SAFETY: It should fail only on OOM

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -2,6 +2,55 @@
 
 use memchr::{memchr, memchr2, memchr2_iter, memchr3};
 use std::borrow::Cow;
+
+/// Finds first `<`, `>`, `&`, `'`, `"`, or `\r` using SIMD `memchr3`.
+#[inline]
+fn find_escape6(bytes: &[u8]) -> Option<usize> {
+    let a = memchr3(b'<', b'>', b'&', bytes);
+    let b = memchr3(b'\'', b'"', b'\r', bytes);
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    }
+}
+/// Finds first `<`, `>`, `&`, or `\r` using SIMD `memchr`.
+#[inline]
+fn find_escape4(bytes: &[u8]) -> Option<usize> {
+    let a = memchr3(b'<', b'>', b'&', bytes);
+    let b = memchr(b'\r', bytes);
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    }
+}
+/// Finds first `<`, `&`, or `\r` using SIMD `memchr3`.
+#[inline]
+fn find_escape3(bytes: &[u8]) -> Option<usize> {
+    memchr3(b'<', b'&', b'\r', bytes)
+}
+/// Finds first `<`, `>`, `&`, `'`, `"`, `\r`, `\n`, or `\t` using SIMD `memchr`.
+#[inline]
+fn find_escape8(bytes: &[u8]) -> Option<usize> {
+    let a = memchr3(b'<', b'>', b'&', bytes);
+    let b = memchr3(b'\'', b'"', b'\r', bytes);
+    let c = memchr2(b'\n', b'\t', bytes);
+    let ab = match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    };
+    match (ab, c) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    }
+}
 use std::fmt::{self, Write};
 use std::num::ParseIntError;
 use std::ops::Range;
@@ -104,57 +153,8 @@ impl std::error::Error for EscapeError {
 /// | `'`       | `&apos;`
 /// | `"`       | `&quot;`
 /// | `\r`      | `&#13;`
-#[allow(missing_docs)]
-#[inline]
-fn find_escape6(bytes: &[u8]) -> Option<usize> {
-    let a = memchr3(b'<', b'>', b'&', bytes);
-    let b = memchr3(b'\'', b'"', b'\r', bytes);
-    match (a, b) {
-        (Some(x), Some(y)) => Some(x.min(y)),
-        (Some(x), None) => Some(x),
-        (None, Some(y)) => Some(y),
-        (None, None) => None,
-    }
-}
-#[allow(missing_docs)]
-#[inline]
-fn find_escape4(bytes: &[u8]) -> Option<usize> {
-    let a = memchr3(b'<', b'>', b'&', bytes);
-    let b = memchr(b'\r', bytes);
-    match (a, b) {
-        (Some(x), Some(y)) => Some(x.min(y)),
-        (Some(x), None) => Some(x),
-        (None, Some(y)) => Some(y),
-        (None, None) => None,
-    }
-}
-#[allow(missing_docs)]
-#[inline]
-fn find_escape3(bytes: &[u8]) -> Option<usize> {
-    memchr3(b'<', b'&', b'\r', bytes)
-}
-#[allow(missing_docs)]
-#[inline]
-fn find_escape8(bytes: &[u8]) -> Option<usize> {
-    let a = memchr3(b'<', b'>', b'&', bytes);
-    let b = memchr3(b'\'', b'"', b'\r', bytes);
-    let c = memchr2(b'\n', b'\t', bytes);
-    let ab = match (a, b) {
-        (Some(x), Some(y)) => Some(x.min(y)),
-        (Some(x), None) => Some(x),
-        (None, Some(y)) => Some(y),
-        (None, None) => None,
-    };
-    match (ab, c) {
-        (Some(x), Some(y)) => Some(x.min(y)),
-        (Some(x), None) => Some(x),
-        (None, Some(y)) => Some(y),
-        (None, None) => None,
-    }
-}
-
 pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape_with(raw, find_escape6)
+    _escape(raw, find_escape6)
 }
 
 /// Escapes an `&str` and replaces xml special characters (`<`, `>`, `&`)
@@ -173,7 +173,7 @@ pub fn escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `&`       | `&amp;`
 /// | `\r`      | `&#13;`
 pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape_with(raw, find_escape4)
+    _escape(raw, find_escape4)
 }
 
 /// XML standard [requires] that only `<` and `&` was escaped in text content or
@@ -192,7 +192,7 @@ pub fn partial_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 ///
 /// [requires]: https://www.w3.org/TR/xml11/#syntax
 pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape_with(raw, find_escape3)
+    _escape(raw, find_escape3)
 }
 
 /// Escapes a `&str` for use in an XML attribute value. In addition to the
@@ -212,7 +212,7 @@ pub fn minimal_escape<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
 /// | `\n`      | `&#10;`
 /// | `\t`      | `&#9;`
 pub(crate) fn escape_attribute<'a>(raw: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-    _escape_with(raw, find_escape8)
+    _escape(raw, find_escape8)
 }
 
 pub(crate) fn escape_char<W>(writer: &mut W, value: &str, from: usize, to: usize) -> fmt::Result
@@ -238,38 +238,8 @@ where
     Ok(())
 }
 
-/// Escapes an `&str` and replaces a subset of xml special characters (`<`, `>`,
-/// `&`, `'`, `"`) with their corresponding xml escaped value.
-fn _escape<'a, F: Fn(u8) -> bool>(raw: impl Into<Cow<'a, str>>, escape_chars: F) -> Cow<'a, str> {
-    let raw = raw.into();
-    let bytes = raw.as_bytes();
-    let mut escaped = None;
-    let mut iter = bytes.iter();
-    let mut pos = 0;
-    while let Some(i) = iter.position(|&b| escape_chars(b)) {
-        if escaped.is_none() {
-            escaped = Some(String::with_capacity(raw.len()));
-        }
-        let escaped = escaped.as_mut().expect("initialized");
-        let new_pos = pos + i;
-        // SAFETY: It should fail only on OOM
-        escape_char(escaped, &raw, pos, new_pos).unwrap();
-        pos = new_pos + 1;
-    }
-
-    if let Some(mut escaped) = escaped {
-        if let Some(raw) = raw.get(pos..) {
-            // SAFETY: It should fail only on OOM
-            escaped.write_str(raw).unwrap();
-        }
-        Cow::Owned(escaped)
-    } else {
-        raw
-    }
-}
-
-#[allow(missing_docs)]
-fn _escape_with<'a>(raw: impl Into<Cow<'a, str>>, find: fn(&[u8]) -> Option<usize>) -> Cow<'a, str> {
+/// Escapes an `&str` using SIMD search `find` to locate next char needing escape.
+fn _escape<'a>(raw: impl Into<Cow<'a, str>>, find: fn(&[u8]) -> Option<usize>) -> Cow<'a, str> {
     let raw = raw.into();
     let bytes = raw.as_bytes();
     let mut escaped = None;


### PR DESCRIPTION
Fixes #405

Replace scalar `iter.position(|&b| matches!(b, <>&'"\r))` in `_escape` with SIMD `memchr` (SSE2/AVX2 runtime dispatch via `memchr` crate).

- `escape" 6 chars (<>&'"\r): 2x memchr3
- `partial_escape" 4 chars (<>&\r): memchr3 + memchr
- `minimal_escape" 3 chars (<&\r): memchr3
- `escape_attribute" 8 chars (<>&'"\r\n\t): 2x memchr3 + memchr2

Previously `_escape` used generic closure `iter.position()` scalar per byte.
Now `_escape_with(find: fn(&[u8])->Option<usize>)` dispatches to SIMD search.

Bench `cargo bench --bench microbenches -- escape_text` (needs \#404 coverage, now available):
- `escape_text/no_chars_to_escape_long" and `escaped_chars_long" expected 2-5% win on AVX2, larger on short strings (avoid closure overhead)
- Matches suggestion in #405 to use `jetscii` (handles 16) but uses existing `memchr` dep to avoid new dep; can switch to jetscii later if gains shown in #718.

Verif: `cargo test --lib` pass, `cargo bench --bench microbenches escape_text --sample-size 10`

Related: #718 memchr vs stringzilla 6.2x reverse throughput with SIMD